### PR TITLE
fix: use exact SSH whitelist IP matching

### DIFF
--- a/syswarden-manager.sh
+++ b/syswarden-manager.sh
@@ -94,7 +94,7 @@ check_ip() {
     if grep -q "^${target_ip}$" "$WHITELIST_FILE" 2>/dev/null; then echo -e "${GREEN}PRESENT${NC}"; else echo -e "${YELLOW}Not Found${NC}"; fi
 
     echo -n "[Storage] SSH-Only Bypass  : "
-    if grep -q "^${target_ip}" "$SSH_WHITELIST_FILE" 2>/dev/null; then echo -e "${GREEN}PRESENT${NC}"; else echo -e "${YELLOW}Not Found${NC}"; fi
+    if awk -F':' -v ip="$target_ip" '$1 == ip { found=1; exit } END { exit !found }' "$SSH_WHITELIST_FILE" 2>/dev/null; then echo -e "${GREEN}PRESENT${NC}"; else echo -e "${YELLOW}Not Found${NC}"; fi
 
     echo -n "[Storage] Global Blocklist : "
     if grep -q "^${target_ip}$" "$BLOCKLIST_FILE" 2>/dev/null; then echo -e "${RED}PRESENT${NC}"; else echo -e "${YELLOW}Not Found${NC}"; fi


### PR DESCRIPTION
## Summary
This fixes a false positive in `syswarden-manager.sh` when checking `ssh_whitelist.txt`.

Before this change, the lookup used:
`grep "^${target_ip}"`

That could incorrectly match prefixes, for example:
- searched IP: `1.2.3.4`
- existing entry: `1.2.3.40:22`

With this patch, the check now matches the exact IP field before `:`.

## Change
- replace prefix-based `grep` with exact field matching using `awk`