### PR TITLE
fix: escape reporter API key before sed injection

### DIFF
--- a/install-syswarden.sh
+++ b/install-syswarden.sh
@@ -87,6 +87,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+escape_sed_replacement() {
+    local value="$1"
+    value=${value//\\/\\\\}
+    value=${value//&/\\&}
+    value=${value//|/\\|}
+    printf '%s' "$value"
+}
+
 detect_os_backend() {
     log "INFO" "Detecting Operating System and Firewall Backend..."
 
@@ -3808,8 +3816,10 @@ EOF
         if [[ "$REPORT_F2B" =~ ^[Yy]$ ]]; then PY_F2B="True"; fi
         local PY_FW="False"
         if [[ "$REPORT_FW" =~ ^[Yy]$ ]]; then PY_FW="True"; fi
+        local ESCAPED_API_KEY
+        ESCAPED_API_KEY=$(escape_sed_replacement "$USER_API_KEY")
 
-        sed -i "s/PLACEHOLDER_KEY/$USER_API_KEY/" /usr/local/bin/syswarden_reporter.py
+        sed -i "s|PLACEHOLDER_KEY|$ESCAPED_API_KEY|" /usr/local/bin/syswarden_reporter.py
         sed -i "s/PLACEHOLDER_F2B/$PY_F2B/" /usr/local/bin/syswarden_reporter.py
         sed -i "s/PLACEHOLDER_FW/$PY_FW/" /usr/local/bin/syswarden_reporter.py
 


### PR DESCRIPTION
## Summary
This fixes a bug in `install-syswarden.sh` when injecting the AbuseIPDB API key into `syswarden_reporter.py`.

Before this change, the script used:
`sed -i "s/PLACEHOLDER_KEY/$USER_API_KEY/"`

If the API key contained special characters such as `/`, `&`, `\` or `|`, the replacement could fail or generate an invalid Python file.

## Change
- add a small helper to escape `sed` replacement values safely
- replace the API key placeholder using an escaped value and a safer separator

## Why
`sed` replacement strings treat some characters specially:
- `/` can break the delimiter-based substitution
- `&` expands to the full matched string
- `\` is an escape character
- `|` matters when used as the custom delimiter

Escaping these characters ensures the generated reporter file contains the exact API key value.