### PR TITLE
Update Plumber to v0.3.86 (security fix)

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write   # required to upload SARIF to Code Scanning
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: getplumber/plumber@981540f2cfb3ecb7c0a1aaddc7bb1b77f7451fca # v0.3.82
+      - uses: getplumber/plumber@a697e9c316b058d279861719c73b87093fb5a60f # v0.3.86
         with:
           score-push: true
           threshold: 80


### PR DESCRIPTION
Hi 👋

I'm from the Plumber team. This repo pins the `getplumber/plumber` action in CI, and the version here is affected by a security issue we've just fixed (everything `<= 0.3.85`).

This PR bumps the pinned action to **v0.3.86** (SHA-pinned), which contains the fix.

We're not sharing the details publicly yet, a full advisory will be published soon. In the meantime we'd recommend updating promptly. Happy to answer anything.

Thanks! 🙏
