### PR TITLE
Patch : fix release environment boolean gates for v4.02.11

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -925,6 +925,17 @@ jobs:
           set -euo pipefail
           environment_json="$(gh api \
             "repos/${GITHUB_REPOSITORY}/environments/syswarden-release-production")"
+          required_environment_boolean() {
+            local field="${1:?environment boolean field is required}"
+            jq -er --arg field "${field}" '
+              .deployment_branch_policy[$field] |
+              if type == "boolean" then
+                tostring
+              else
+                error("deployment_branch_policy." + $field + " must be boolean")
+              end
+            ' <<< "${environment_json}"
+          }
           environment_name="$(jq -r '.name // ""' <<< "${environment_json}")"
           reviewer_rule_count="$(jq --arg owner "${GITHUB_REPOSITORY_OWNER}" '[
             .protection_rules[]? |
@@ -942,12 +953,10 @@ jobs:
           ] | length' <<< "${environment_json}")"
           protection_rule_count="$(jq '[.protection_rules[]?] | length' \
             <<< "${environment_json}")"
-          protected_branches="$(jq -r \
-            '.deployment_branch_policy.protected_branches // "missing"' \
-            <<< "${environment_json}")"
-          custom_branch_policies="$(jq -r \
-            '.deployment_branch_policy.custom_branch_policies // "missing"' \
-            <<< "${environment_json}")"
+          protected_branches="$(required_environment_boolean \
+            "protected_branches")"
+          custom_branch_policies="$(required_environment_boolean \
+            "custom_branch_policies")"
           if [[ "${environment_name}" != "syswarden-release-production" || \
                 "${reviewer_rule_count}" != "1" || \
                 "${branch_policy_rule_count}" != "1" || \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -53,6 +53,17 @@ jobs:
           command -v jq >/dev/null
           environment_json="$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/environments/syswarden-release-qualification")"
+          required_environment_boolean() {
+            local field="${1:?environment boolean field is required}"
+            jq -er --arg field "${field}" '
+              .deployment_branch_policy[$field] |
+              if type == "boolean" then
+                tostring
+              else
+                error("deployment_branch_policy." + $field + " must be boolean")
+              end
+            ' <<< "${environment_json}"
+          }
           environment_name="$(jq -r '.name // ""' <<< "${environment_json}")"
           reviewer_rule_count="$(jq '[
             .protection_rules[]? | select(.type == "required_reviewers")
@@ -62,12 +73,10 @@ jobs:
           ] | length' <<< "${environment_json}")"
           protection_rule_count="$(jq '[.protection_rules[]?] | length' \
             <<< "${environment_json}")"
-          protected_branches="$(jq -r \
-            '.deployment_branch_policy.protected_branches // "missing"' \
-            <<< "${environment_json}")"
-          custom_branch_policies="$(jq -r \
-            '.deployment_branch_policy.custom_branch_policies // "missing"' \
-            <<< "${environment_json}")"
+          protected_branches="$(required_environment_boolean \
+            "protected_branches")"
+          custom_branch_policies="$(required_environment_boolean \
+            "custom_branch_policies")"
           if [[ "${environment_name}" != "syswarden-release-qualification" || \
                 "${reviewer_rule_count}" != "0" || \
                 "${branch_policy_rule_count}" != "1" || \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # SysWarden v4
 
-Current source version: **v4.02.10**.
+Current source version: **v4.02.11**.
 
 > **Active Defense and HIDS/HIPS/WAAP Out-of-Band Orchestration for Critical Linux Infrastructure**
 
@@ -60,18 +60,11 @@ access and a tested host snapshot or rollback path.
 - `syswarden web-tui` exposes the terminal UI through HTTPS and WebSocket. It
   is a separate, network-facing mode with different risks.
 
-```text
-application or reverse-proxy logs
-              |
-              v
-       syswarden-core
-       |            |
-       v            v
-local telemetry   requested bans
-       |            |
-       v            v
-syswarden-tui   nftables or pf
-```
+<p align="center">
+  <a href="assets/syswarden_architecture.svg">
+    <img src="assets/syswarden_architecture.svg" alt="SysWarden HIDS, HIPS and WAAP out-of-band architecture">
+  </a>
+</p>
 
 The WAAP engine is out-of-band log analysis. A detection can lead to a later
 firewall update, but SysWarden is not in the HTTP request path and cannot clean
@@ -116,7 +109,7 @@ parameter. Restrict the listener with `--bind`, protect the port with a trusted
 network control, and do not place tokens in URLs or logs.
 
 A package-level `[webtui] enabled = false` switch and conditional ownership of
-TCP 62027 are not part of v4.02.10. They remain a separate Lot 2 change. The
+TCP 62027 are not part of v4.02.11. They remain a separate Lot 2 change. The
 current package behavior must therefore be treated as Web-TUI enabled.
 
 ### High availability
@@ -191,60 +184,17 @@ avoids synchronization loops.
 BunkerWeb's scheduler can push temporary Layer 7 bans to SysWarden and retrieve
 SysWarden blocklist, whitelist, status and telemetry data through the HA API.
 
-```mermaid
-flowchart LR
-    accTitle: BunkerWeb and SysWarden security flow
-    accDescr: Client traffic crosses the SysWarden nftables forward protection before BunkerWeb. The BunkerWeb scheduler sends source-owned temporary bans directly to every configured peer, while SysWarden nodes continue their authenticated durable synchronization whether the partner integration is disabled or enabled.
+<p align="center">
+  <a href="assets/syswarden_bunkerweb_integration.svg">
+    <img src="assets/syswarden_bunkerweb_integration.svg" alt="SysWarden and BunkerWeb authenticated Layer 7 ban integration contract">
+  </a>
+</p>
 
-    client(["Client traffic"])
-
-    subgraph host["Protected host: data plane"]
-        direction TB
-        nft{"nftables<br/>input + docker_protect forward"}
-        drop["Kernel drop"]
-        bunker["BunkerWeb Layer 7<br/>partner component"]
-        service["BunkerWeb-protected upstream"]
-        sets[("Verified dynamic<br/>kernel sets")]
-
-        nft -->|"banned source or destination"| drop
-        nft -->|"allowed"| bunker
-        bunker -->|"allowed"| service
-        sets -->|"referenced by rules"| nft
-    end
-
-    subgraph control["SysWarden control plane"]
-        direction TB
-        api["HA API :62026<br/>TLS 1.3 + bearer<br/>IP/CIDR peer scope"]
-        state[("Durable lists +<br/>source-owned TTL ledger")]
-        gate{"integrations.bunkerweb.enabled?"}
-        extensions["TTL, batch and<br/>provenance extensions"]
-        reject["Reject enriched mutation<br/>durable node HA unchanged"]
-
-        api <-->|"durable mutations + authenticated reads"| state
-        state --> sets
-        api -->|"enriched mutation only"| gate
-        gate -->|"true"| extensions
-        gate -->|"false"| reject
-        extensions --> state
-    end
-
-    subgraph partner["BunkerWeb plugin plane"]
-        direction TB
-        scheduler["Scheduler<br/>isolated per peer"]
-        cache[("Last valid Layer 7<br/>lists and UI state")]
-        scheduler <--> cache
-    end
-
-    peer["Other SysWarden node HA API<br/>durable always; enriched only<br/>with advertised capabilities"]
-
-    client --> nft
-    bunker -.->|"temporary Layer 7 ban"| scheduler
-    scheduler -->|"temporary ban: direct peer A<br/>POST / DELETE, max 500"| api
-    scheduler -.->|"same source-owned ban:<br/>direct peer B"| peer
-    api -->|"bounded authenticated reads"| scheduler
-    peer <-->|"durable IP/CIDR and L7/WAAP lists<br/>two scheduled pushes, gate false or true"| api
-
-```
+In the "Protected host: data plane", client traffic reaches nftables before
+BunkerWeb. The A-to-B and B-to-A arrows represent two scheduled pushes, gate
+false or true, rather than a continuously open synchronization session.
+Source-owned temporary bans are sent directly by the scheduler to each peer;
+SysWarden nodes do not relay them.
 
 The final `false` branch means only that secure SysWarden node-to-node HA stays
 available; it does not route partner requests through the other node.
@@ -366,7 +316,7 @@ default HTTP client without an explicit timeout.
 | Package and PF recovery state | `/var/db/syswarden` |
 | rc.d services | `/usr/local/etc/rc.d/syswarden`, `/usr/local/etc/rc.d/syswardenwebtui` |
 
-The v4.02.10 PF contract is intentionally bounded. A fresh installation
+The v4.02.11 PF contract is intentionally bounded. A fresh installation
 requires PF to be disabled with an empty live ruleset before SysWarden first
 mutates it. The separately byte-bound historical v4.02.8 transition is also covered. This
 does not claim safe coexistence with an arbitrary pre-existing operator PF
@@ -418,10 +368,10 @@ selected release.
 
 The historical v4.02.8 binary predates the signed updater and cannot perform
 the first signed hop. Linux hosts must install the separately verified
-v4.02.10 package with their native package manager. FreeBSD hosts must first
+v4.02.11 package with their native package manager. FreeBSD hosts must first
 install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then use
-`pkg add -f` on the checksum-verified v4.02.10 TXZ. Starting from an installed
-v4.02.10, the signed updater supports the six Linux package targets and
+`pkg add -f` on the checksum-verified v4.02.11 TXZ. Starting from an installed
+v4.02.11, the signed updater supports the six Linux package targets and
 FreeBSD amd64.
 
 ### Install the latest verified Release
@@ -430,7 +380,7 @@ The procedure below downloads exactly one package for the detected operating
 system and architecture. Use it only after that tag is visible in GitHub
 Releases and the release qualification is complete. For the first hop from
 historical v4.02.8, run it as
-`VERSION=v4.02.10 sh ./install-release.sh` after saving the block as
+`VERSION=v4.02.11 sh ./install-release.sh` after saving the block as
 `install-release.sh`; leaving `VERSION` unset selects the latest published
 Release automatically.
 
@@ -665,8 +615,8 @@ access recovery.
   verifies the selected OS/architecture filename, size and SHA-256 again
   immediately before invoking the package manager, and uses a private temporary
   workspace. The historical v4.02.8 binary predates this trust root, so its
-  first upgrade to v4.02.10 must be a separately verified manual package
-  upgrade. From v4.02.10 onward, FreeBSD amd64 uses the same signed contract and
+  first upgrade to v4.02.11 must be a separately verified manual package
+  upgrade. From v4.02.11 onward, FreeBSD amd64 uses the same signed contract and
   invokes native `pkg add -f` only after all verification succeeds.
 - `syswarden uninstall` is destructive. It deletes SysWarden configuration,
   data, logs, services and firewall tables. It does not restore every previous
@@ -712,8 +662,8 @@ maintainer-controlled publication gate; a wiki page may lag the source until
 that gate is completed. When the wiki and this README disagree, prefer tested
 behavior in the source candidate and report the inconsistency.
 
-The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.10.md)
-records the v4.02.10 source scope, evidence, platform boundaries and final
+The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.11.md)
+records the v4.02.11 source scope, evidence, platform boundaries and final
 release decision.
 
 ## Target and support

--- a/assets/syswarden_architecture.svg
+++ b/assets/syswarden_architecture.svg
@@ -1,0 +1,383 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1080" viewBox="0 0 1600 1080" role="img" aria-labelledby="title description">
+  <title id="title">SysWarden HIDS, HIPS and WAAP out-of-band architecture</title>
+  <desc id="description">Live requests go directly to protected APIs, websites, applications and services. SysWarden observes access, security and host telemetry out of band, analyzes HIDS and WAAP signals, then applies HIPS enforcement through nftables on Linux or PF on FreeBSD. Operators use the privileged CLI, local TUI or network-facing Web TUI. TLS 1.3, bearer-authenticated HA peers and the gated BunkerWeb partner API exchange ban, unban, TTL and provenance data.</desc>
+
+  <defs>
+    <linearGradient id="brandGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00A3FF"/>
+      <stop offset="1" stop-color="#0055FF"/>
+    </linearGradient>
+    <linearGradient id="coreGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14263A"/>
+      <stop offset="1" stop-color="#101826"/>
+    </linearGradient>
+    <radialGradient id="aura" cx="50%" cy="45%" r="60%">
+      <stop offset="0" stop-color="#00A3FF" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="#00A3FF" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#30363D" stroke-width="1" stroke-opacity="0.22"/>
+    </pattern>
+    <filter id="blueGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="7" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrowCyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#00A3FF"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#00E676"/>
+    </marker>
+    <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#FFB000"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#F44336"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#A371F7"/>
+    </marker>
+    <style>
+      .sans { font-family: Inter, "Segoe UI", Arial, sans-serif; }
+      .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+      .panel { fill: #161B22; stroke: #30363D; stroke-width: 2; }
+      .panel-soft { fill: #111820; stroke: #30363D; stroke-width: 2; }
+      .eyebrow { fill: #8B949E; font-size: 16px; font-weight: 700; letter-spacing: 2.4px; }
+      .heading { fill: #F0F6FC; font-size: 27px; font-weight: 750; }
+      .subheading { fill: #C9D1D9; font-size: 18px; font-weight: 650; }
+      .body { fill: #8B949E; font-size: 15px; }
+      .small { fill: #8B949E; font-size: 13px; }
+      .pill-text { fill: #F0F6FC; font-size: 13px; font-weight: 700; letter-spacing: 0.5px; }
+      .flow { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="1080" fill="#0D1117"/>
+  <rect width="1600" height="1080" fill="url(#grid)"/>
+  <ellipse cx="810" cy="555" rx="620" ry="500" fill="url(#aura)"/>
+  <circle cx="1500" cy="90" r="230" fill="#0055FF" opacity="0.07"/>
+  <circle cx="90" cy="1020" r="260" fill="#00A3FF" opacity="0.06"/>
+
+  <!-- Header -->
+  <g class="sans">
+    <g transform="translate(48 24) scale(0.52)">
+      <path d="M50 0L100 20V60C100 90 75 110 50 120C25 110 0 90 0 60V20L50 0Z" fill="#161B22" stroke="url(#brandGradient)" stroke-width="5" filter="url(#blueGlow)"/>
+      <path d="M50 15L85 30V55C85 75 65 90 50 100C35 90 15 75 15 55V30L50 15Z" fill="none" stroke="#00A3FF" stroke-width="2" opacity="0.6"/>
+      <path d="M34 43L49 58L34 73" fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M56 74H72" stroke="#00A3FF" stroke-width="5" stroke-linecap="round"/>
+    </g>
+    <text x="120" y="58" fill="#FFFFFF" font-size="39" font-weight="800" letter-spacing="1">SYSWARDEN</text>
+    <text x="120" y="84" fill="#8B949E" font-size="15" font-weight="600" letter-spacing="2.1">ACTIVE DEFENSE HIDS / HIPS / WAAP</text>
+    <text x="790" y="50" fill="#F0F6FC" font-size="26" font-weight="750" text-anchor="middle">OUT-OF-BAND DEFENSE ARCHITECTURE</text>
+    <text x="790" y="77" fill="#8B949E" font-size="14" text-anchor="middle">Observe host and application signals, decide locally, enforce at the host edge</text>
+
+    <g transform="translate(1210 25)">
+      <rect width="338" height="64" rx="14" fill="#111820" stroke="#30363D" stroke-width="2"/>
+      <circle cx="24" cy="22" r="5" fill="#00A3FF"/>
+      <text x="38" y="27" class="small">Observe</text>
+      <circle cx="113" cy="22" r="5" fill="#FFB000"/>
+      <text x="127" y="27" class="small">Analyze</text>
+      <circle cx="218" cy="22" r="5" fill="#F44336"/>
+      <text x="232" y="27" class="small">Block</text>
+      <circle cx="24" cy="47" r="5" fill="#00E676"/>
+      <text x="38" y="52" class="small">Serve</text>
+      <circle cx="113" cy="47" r="5" fill="#A371F7"/>
+      <text x="127" y="52" class="small">Orchestrate</text>
+    </g>
+  </g>
+
+  <!-- Live request path -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="40" y="120" width="1520" height="250" rx="24" class="panel-soft"/>
+    <text x="72" y="153" class="eyebrow">1  LIVE REQUEST PATH</text>
+    <g transform="translate(902 133)">
+      <rect width="338" height="28" rx="14" fill="#0D1117" stroke="#00A3FF" stroke-opacity="0.6"/>
+      <text x="169" y="19" class="mono" fill="#00A3FF" font-size="12" font-weight="700" text-anchor="middle">SYSWARDEN IS NOT AN INLINE PROXY</text>
+    </g>
+
+    <!-- Legitimate activity -->
+    <g transform="translate(72 178)">
+      <rect width="238" height="142" rx="18" fill="#10251E" stroke="#1D8F5E" stroke-width="2"/>
+      <circle cx="54" cy="54" r="34" fill="#00E676" opacity="0.15"/>
+      <circle cx="47" cy="43" r="11" fill="#00E676"/>
+      <path d="M27 79C30 60 64 60 68 79" fill="#00E676"/>
+      <circle cx="82" cy="48" r="8" fill="#78F5B1"/>
+      <path d="M69 72C72 59 93 59 96 72" fill="#78F5B1"/>
+      <text x="112" y="47" fill="#00E676" font-size="18" font-weight="750">LEGITIMATE</text>
+      <text x="112" y="69" fill="#00E676" font-size="18" font-weight="750">ACTIVITY</text>
+      <text x="20" y="112" class="body">Users and trusted clients</text>
+      <circle cx="208" cy="111" r="12" fill="none" stroke="#00E676" stroke-width="2"/>
+      <path d="M202 111L207 116L215 106" fill="none" stroke="#00E676" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+
+    <!-- Suspicious automation -->
+    <g transform="translate(335 178)">
+      <rect width="238" height="142" rx="18" fill="#2A2110" stroke="#B97900" stroke-width="2"/>
+      <circle cx="55" cy="54" r="34" fill="#FFB000" opacity="0.15"/>
+      <rect x="30" y="34" width="50" height="42" rx="10" fill="#FFB000"/>
+      <circle cx="44" cy="54" r="5" fill="#0D1117"/>
+      <circle cx="66" cy="54" r="5" fill="#0D1117"/>
+      <path d="M44 66H66" stroke="#0D1117" stroke-width="4" stroke-linecap="round"/>
+      <path d="M55 25V34M50 25H60" stroke="#FFB000" stroke-width="3" stroke-linecap="round"/>
+      <text x="105" y="47" fill="#FFB000" font-size="18" font-weight="750">SUSPICIOUS</text>
+      <text x="105" y="69" fill="#FFB000" font-size="18" font-weight="750">AUTOMATION</text>
+      <text x="20" y="112" class="body">Bots, scans and bursts</text>
+      <circle cx="208" cy="111" r="12" fill="none" stroke="#FFB000" stroke-width="2"/>
+      <path d="M208 103V111L214 115" fill="none" stroke="#FFB000" stroke-width="2.5" stroke-linecap="round"/>
+    </g>
+
+    <!-- Hostile activity -->
+    <g transform="translate(598 178)">
+      <rect width="238" height="142" rx="18" fill="#2A1418" stroke="#B52E35" stroke-width="2"/>
+      <circle cx="54" cy="54" r="34" fill="#F44336" opacity="0.14"/>
+      <path d="M54 25L79 70H29Z" fill="#F44336"/>
+      <path d="M54 41V56M54 64V65" stroke="#0D1117" stroke-width="5" stroke-linecap="round"/>
+      <text x="105" y="47" fill="#F44336" font-size="18" font-weight="750">HOSTILE</text>
+      <text x="105" y="69" fill="#F44336" font-size="18" font-weight="750">ACTIVITY</text>
+      <text x="20" y="112" class="body">Exploits and brute force</text>
+      <circle cx="208" cy="111" r="12" fill="none" stroke="#F44336" stroke-width="2"/>
+      <path d="M202 105L214 117M214 105L202 117" stroke="#F44336" stroke-width="2.5" stroke-linecap="round"/>
+    </g>
+
+    <!-- Host edge firewall -->
+    <g transform="translate(1054 174)">
+      <rect width="160" height="152" rx="18" fill="#111D2A" stroke="#00A3FF" stroke-width="2"/>
+      <text x="80" y="25" fill="#8B949E" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="1.6">HOST EDGE</text>
+      <path d="M80 38L111 50V76C111 96 95 110 80 117C65 110 49 96 49 76V50Z" fill="#161B22" stroke="url(#brandGradient)" stroke-width="3"/>
+      <path d="M64 67H96M64 77H96M64 87H96" stroke="#00A3FF" stroke-width="3" stroke-linecap="round"/>
+      <text x="80" y="137" fill="#C9D1D9" font-size="12" font-weight="650" text-anchor="middle">nftables / PF</text>
+    </g>
+
+    <!-- Protected workloads -->
+    <g transform="translate(1270 162)">
+      <rect width="252" height="176" rx="20" fill="#122219" stroke="#238B57" stroke-width="2"/>
+      <text x="126" y="28" fill="#00E676" font-size="14" font-weight="750" text-anchor="middle" letter-spacing="1.4">PROTECTED WORKLOADS</text>
+      <g transform="translate(26 48)">
+        <rect width="200" height="100" rx="12" fill="#0D1117" stroke="#30363D"/>
+        <rect x="15" y="15" width="50" height="28" rx="5" fill="#00A3FF" opacity="0.18" stroke="#00A3FF"/>
+        <rect x="75" y="15" width="50" height="28" rx="5" fill="#00E676" opacity="0.16" stroke="#00E676"/>
+        <rect x="135" y="15" width="50" height="28" rx="5" fill="#A371F7" opacity="0.16" stroke="#A371F7"/>
+        <text x="40" y="34" class="mono" fill="#00A3FF" font-size="11" text-anchor="middle">API</text>
+        <text x="100" y="34" class="mono" fill="#00E676" font-size="11" text-anchor="middle">WEB</text>
+        <text x="160" y="34" class="mono" fill="#A371F7" font-size="11" text-anchor="middle">APP</text>
+        <path d="M17 61H183M17 74H150M17 87H170" stroke="#8B949E" stroke-width="5" stroke-linecap="round" opacity="0.55"/>
+      </g>
+      <text x="126" y="166" class="small" text-anchor="middle">Linux and FreeBSD hosts</text>
+    </g>
+
+    <!-- Request arrows -->
+    <path d="M191 320V330H1016V222H1038M1214 222H1260" class="flow" stroke="#00E676" stroke-width="4" marker-end="url(#arrowGreen)"/>
+    <path d="M454 320V340H1027V259H1038M1214 259H1260" class="flow" stroke="#FFB000" stroke-width="4" marker-end="url(#arrowAmber)"/>
+    <path d="M836 229C920 229 966 286 1038 286M1214 286H1260" class="flow" stroke="#F44336" stroke-width="3" stroke-dasharray="7 8" opacity="0.48" marker-end="url(#arrowRed)"/>
+    <path d="M836 306H1024" class="flow" stroke="#F44336" stroke-width="4"/>
+    <circle cx="1038" cy="306" r="14" fill="#2A1418" stroke="#F44336" stroke-width="3"/>
+    <path d="M1031 299L1045 313M1045 299L1031 313" stroke="#F44336" stroke-width="3" stroke-linecap="round"/>
+    <text x="864" y="214" fill="#F44336" font-size="12" font-weight="650">first event can be logged</text>
+    <text x="860" y="359" fill="#F44336" font-size="12" font-weight="650">later requests blocked</text>
+  </g>
+
+  <!-- Telemetry return path from workloads -->
+  <path d="M1396 338V398H444" class="flow" stroke="#00A3FF" stroke-width="4" stroke-dasharray="8 8" marker-end="url(#arrowCyan)"/>
+  <rect x="760" y="381" width="320" height="28" rx="14" fill="#0D1117" stroke="#00A3FF" stroke-opacity="0.5"/>
+  <text x="920" y="400" class="mono" fill="#00A3FF" font-size="12" font-weight="700" text-anchor="middle">LOGS + HOST SECURITY TELEMETRY</text>
+
+  <!-- Signal intake -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="40" y="430" width="400" height="360" rx="24" class="panel"/>
+    <text x="72" y="469" class="eyebrow">2  HIDS / WAAP SIGNAL INTAKE</text>
+    <text x="72" y="504" class="heading">Observe local evidence</text>
+    <text x="72" y="529" class="body">Read-only inputs from configured sources</text>
+
+    <g transform="translate(72 558)">
+      <rect width="336" height="45" rx="11" fill="#101D29" stroke="#22587A"/>
+      <circle cx="24" cy="22" r="8" fill="#00A3FF" opacity="0.9"/>
+      <path d="M21 22H27M24 19V25" stroke="#0D1117" stroke-width="2" stroke-linecap="round"/>
+      <text x="45" y="20" class="subheading" font-size="16">Authentication and service logs</text>
+      <text x="45" y="36" class="small">SSH, system and security events</text>
+    </g>
+    <g transform="translate(72 613)">
+      <rect width="336" height="45" rx="11" fill="#101D29" stroke="#22587A"/>
+      <circle cx="24" cy="22" r="8" fill="#00A3FF" opacity="0.9"/>
+      <path d="M19 18H29V26H19Z" fill="none" stroke="#0D1117" stroke-width="2"/>
+      <text x="45" y="20" class="subheading" font-size="16">Application and proxy logs</text>
+      <text x="45" y="36" class="small">Access, reverse proxy and WAAP events</text>
+    </g>
+    <g transform="translate(72 668)">
+      <rect width="336" height="45" rx="11" fill="#101D29" stroke="#22587A"/>
+      <circle cx="24" cy="22" r="8" fill="#00A3FF" opacity="0.9"/>
+      <path d="M19 25L23 20L27 23L31 17" fill="none" stroke="#0D1117" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="45" y="20" class="subheading" font-size="16">Configured log streams</text>
+      <text x="45" y="36" class="small">Previously written evidence only</text>
+    </g>
+    <g transform="translate(72 723)">
+      <rect width="336" height="39" rx="11" fill="#14231C" stroke="#1D8F5E"/>
+      <text x="168" y="25" fill="#00E676" font-size="13" font-weight="700" text-anchor="middle">OUT-OF-BAND COLLECTION</text>
+    </g>
+  </g>
+
+  <!-- SysWarden core -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="490" y="430" width="650" height="360" rx="26" fill="url(#coreGradient)" stroke="#00A3FF" stroke-width="2.5"/>
+    <circle cx="815" cy="610" r="270" fill="#00A3FF" opacity="0.035"/>
+    <g transform="translate(520 456) scale(0.38)">
+      <path d="M50 0L100 20V60C100 90 75 110 50 120C25 110 0 90 0 60V20L50 0Z" fill="#161B22" stroke="url(#brandGradient)" stroke-width="6"/>
+      <path d="M34 43L49 58L34 73" fill="none" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M56 74H72" stroke="#00A3FF" stroke-width="6" stroke-linecap="round"/>
+    </g>
+    <text x="575" y="478" class="eyebrow" fill="#00A3FF">3  SYSWARDEN CORE</text>
+    <text x="1080" y="478" fill="#00A3FF" font-size="13" font-weight="750" text-anchor="end">LOCAL DECISION ENGINE</text>
+    <text x="525" y="526" class="heading">Correlate, decide and record</text>
+
+    <g transform="translate(525 554)">
+      <rect width="174" height="116" rx="16" fill="#111820" stroke="#00A3FF"/>
+      <circle cx="27" cy="27" r="13" fill="#00A3FF" opacity="0.18"/>
+      <path d="M21 27H33M27 21V33" stroke="#00A3FF" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="50" y="32" fill="#00A3FF" font-size="17" font-weight="800">HIDS</text>
+      <text x="18" y="61" class="body">Normalize events</text>
+      <text x="18" y="82" class="body">Correlate host signals</text>
+      <text x="18" y="103" class="body">Track thresholds</text>
+    </g>
+    <path d="M706 612H727" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(734 554)">
+      <rect width="174" height="116" rx="16" fill="#221D11" stroke="#FFB000"/>
+      <circle cx="27" cy="27" r="13" fill="#FFB000" opacity="0.18"/>
+      <path d="M20 31L27 20L34 31Z" fill="none" stroke="#FFB000" stroke-width="2.5" stroke-linejoin="round"/>
+      <text x="50" y="32" fill="#FFB000" font-size="17" font-weight="800">WAAP</text>
+      <text x="18" y="61" class="body">Match signatures</text>
+      <text x="18" y="82" class="body">Detect brute force</text>
+      <text x="18" y="103" class="body">Classify L7 events</text>
+    </g>
+    <path d="M915 612H936" class="flow" stroke="#FFB000" stroke-width="3" marker-end="url(#arrowAmber)"/>
+    <g transform="translate(943 554)">
+      <rect width="162" height="116" rx="16" fill="#1B1725" stroke="#A371F7"/>
+      <circle cx="27" cy="27" r="13" fill="#A371F7" opacity="0.18"/>
+      <path d="M20 27L25 32L35 21" fill="none" stroke="#A371F7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="50" y="32" fill="#A371F7" font-size="16" font-weight="800">DECIDE</text>
+      <text x="18" y="61" class="body">Policy and scope</text>
+      <text x="18" y="82" class="body">TTL and provenance</text>
+      <text x="18" y="103" class="body">Ban or unban</text>
+    </g>
+
+    <g transform="translate(525 691)">
+      <rect width="580" height="70" rx="14" fill="#0D1117" stroke="#30363D"/>
+      <g transform="translate(18 15)">
+        <rect width="118" height="30" rx="15" fill="#10251E" stroke="#1D8F5E"/>
+        <text x="59" y="20" class="pill-text" text-anchor="middle">Atomic state</text>
+      </g>
+      <g transform="translate(148 15)">
+        <rect width="118" height="30" rx="15" fill="#101D29" stroke="#22587A"/>
+        <text x="59" y="20" class="pill-text" text-anchor="middle">Telemetry</text>
+      </g>
+      <g transform="translate(278 15)">
+        <rect width="118" height="30" rx="15" fill="#1B1725" stroke="#6E4AA8"/>
+        <text x="59" y="20" class="pill-text" text-anchor="middle">Ban ledger</text>
+      </g>
+      <text x="414" y="35" fill="#8B949E" font-size="12">Detection changes later traffic.</text>
+      <text x="414" y="51" fill="#8B949E" font-size="12">Requests are not rewritten.</text>
+    </g>
+  </g>
+
+  <!-- HIPS enforcement -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="1190" y="430" width="370" height="360" rx="24" class="panel"/>
+    <text x="1222" y="469" class="eyebrow">4  HIPS ENFORCEMENT</text>
+    <text x="1222" y="504" class="heading">Apply at the host edge</text>
+    <text x="1222" y="529" class="body">Local rules, outside the HTTP pipeline</text>
+
+    <g transform="translate(1222 555)">
+      <rect width="306" height="76" rx="15" fill="#111D2A" stroke="#00A3FF"/>
+      <path d="M38 14L63 24V45C63 61 50 70 38 76C26 70 13 61 13 45V24Z" fill="#161B22" stroke="#00A3FF" stroke-width="2.5"/>
+      <path d="M25 39H51M25 48H51" stroke="#00A3FF" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="84" y="31" fill="#F0F6FC" font-size="17" font-weight="750">nftables on Linux</text>
+      <text x="84" y="55" fill="#F0F6FC" font-size="17" font-weight="750">PF on FreeBSD</text>
+    </g>
+    <g transform="translate(1222 648)">
+      <rect width="306" height="40" rx="10" fill="#2A1418" stroke="#B52E35"/>
+      <circle cx="20" cy="20" r="7" fill="#F44336"/>
+      <text x="39" y="25" class="subheading" font-size="15">Ban, unban and dynamic TTL</text>
+    </g>
+    <g transform="translate(1222 698)">
+      <rect width="306" height="40" rx="10" fill="#10251E" stroke="#1D8F5E"/>
+      <circle cx="20" cy="20" r="7" fill="#00E676"/>
+      <text x="39" y="25" class="subheading" font-size="15">IPv4, IPv6 and scoped CIDR</text>
+    </g>
+    <g transform="translate(1222 748)">
+      <text x="153" y="0" fill="#8B949E" font-size="12" text-anchor="middle">Validated before mutation, verified after commit</text>
+    </g>
+  </g>
+
+  <!-- Main processing arrows -->
+  <path d="M440 612H478" class="flow" stroke="#00A3FF" stroke-width="5" marker-end="url(#arrowCyan)"/>
+  <path d="M1140 612H1178" class="flow" stroke="#F44336" stroke-width="5" marker-end="url(#arrowRed)"/>
+  <text x="459" y="596" class="mono" fill="#00A3FF" font-size="11" text-anchor="middle">EVENTS</text>
+  <text x="1159" y="596" class="mono" fill="#F44336" font-size="11" text-anchor="middle">POLICY</text>
+  <path d="M1516 430V394H1134V337" class="flow" stroke="#0055FF" stroke-width="4" marker-end="url(#arrowCyan)"/>
+  <text x="1380" y="387" class="mono" fill="#00A3FF" font-size="11" text-anchor="middle">RULESET UPDATE</text>
+
+  <!-- Bottom planes -->
+  <g class="sans" filter="url(#softShadow)">
+    <!-- Operator plane -->
+    <rect x="40" y="835" width="490" height="202" rx="24" class="panel-soft"/>
+    <text x="72" y="874" class="eyebrow">OPERATOR PLANE</text>
+    <g transform="translate(72 898)">
+      <rect width="426" height="36" rx="10" fill="#111D2A" stroke="#22587A"/>
+      <text x="16" y="24" class="mono" fill="#00A3FF" font-size="14" font-weight="700">syswarden-cli</text>
+      <text x="156" y="24" class="body">privileged control interface</text>
+    </g>
+    <g transform="translate(72 944)">
+      <rect width="426" height="36" rx="10" fill="#14231C" stroke="#1D8F5E"/>
+      <text x="16" y="24" class="mono" fill="#00E676" font-size="14" font-weight="700">syswarden-tui</text>
+      <text x="156" y="24" class="body">local display, no listener</text>
+    </g>
+    <g transform="translate(72 990)">
+      <rect width="426" height="36" rx="10" fill="#221D11" stroke="#B97900"/>
+      <text x="16" y="24" class="mono" fill="#FFB000" font-size="14" font-weight="700">web-tui</text>
+      <text x="116" y="24" class="body">network-facing HTTPS + WebSocket service</text>
+    </g>
+
+    <!-- State and telemetry -->
+    <rect x="555" y="835" width="405" height="202" rx="24" class="panel-soft"/>
+    <text x="587" y="874" class="eyebrow">LOCAL STATE + TELEMETRY</text>
+    <g transform="translate(587 901)">
+      <circle cx="22" cy="22" r="20" fill="#00A3FF" opacity="0.14" stroke="#00A3FF"/>
+      <path d="M11 27L18 20L25 24L34 13" fill="none" stroke="#00A3FF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="58" y="16" class="subheading" font-size="16">Status and audit data</text>
+      <text x="58" y="37" class="body">Atomic telemetry publication</text>
+    </g>
+    <g transform="translate(587 957)">
+      <circle cx="22" cy="22" r="20" fill="#A371F7" opacity="0.14" stroke="#A371F7"/>
+      <path d="M14 16H30V29H14ZM18 12H26" fill="none" stroke="#A371F7" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="58" y="16" class="subheading" font-size="16">Ledger and provenance</text>
+      <text x="58" y="37" class="body">TTL-aware local ban history</text>
+    </g>
+
+    <!-- Orchestration plane -->
+    <rect x="985" y="835" width="575" height="202" rx="24" class="panel-soft"/>
+    <text x="1017" y="874" class="eyebrow">5  OUT-OF-BAND ORCHESTRATION</text>
+    <g transform="translate(1017 899)">
+      <circle cx="30" cy="30" r="27" fill="#A371F7" opacity="0.14" stroke="#A371F7"/>
+      <circle cx="21" cy="28" r="8" fill="none" stroke="#A371F7" stroke-width="2.5"/>
+      <circle cx="39" cy="28" r="8" fill="none" stroke="#A371F7" stroke-width="2.5"/>
+      <path d="M27 28H33" stroke="#A371F7" stroke-width="2.5"/>
+      <text x="73" y="17" class="subheading" font-size="16">TLS 1.3 + bearer authenticated HA peers</text>
+      <text x="73" y="39" class="body">Ban, unban, TTL and source provenance</text>
+    </g>
+    <g transform="translate(1017 963)">
+      <circle cx="30" cy="30" r="27" fill="#00E676" opacity="0.12" stroke="#00E676"/>
+      <path d="M16 30H44M30 16V44M20 20L40 40M40 20L20 40" stroke="#00E676" stroke-width="2" stroke-linecap="round"/>
+      <text x="73" y="17" class="subheading" font-size="16">BunkerWeb partner API, gate off by default</text>
+      <text x="73" y="39" class="body">SysWarden contract only, external partner proof</text>
+    </g>
+  </g>
+
+  <!-- Bottom plane connections -->
+  <path d="M665 790V818H285V835" class="flow" stroke="#8B949E" stroke-width="3" stroke-dasharray="6 7" marker-end="url(#arrowCyan)"/>
+  <path d="M815 790V835" class="flow" stroke="#00A3FF" stroke-width="4" marker-end="url(#arrowCyan)"/>
+  <path d="M965 790V818H1272V835" class="flow" stroke="#A371F7" stroke-width="4" marker-end="url(#arrowPurple)"/>
+</svg>

--- a/assets/syswarden_bunkerweb_integration.svg
+++ b/assets/syswarden_bunkerweb_integration.svg
@@ -1,0 +1,307 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title description">
+  <title id="title">SysWarden and BunkerWeb integration contract</title>
+  <desc id="description">Client traffic crosses SysWarden nftables input and docker_protect forward protection before BunkerWeb. Banned traffic is dropped by the kernel, while allowed traffic reaches BunkerWeb and its protected upstream. The BunkerWeb scheduler sends source-owned temporary Layer 7 bans directly to each configured SysWarden peer. Durable authenticated SysWarden node synchronization remains active whether the optional enriched BunkerWeb gate is disabled or enabled. This is the SysWarden-side contract; BunkerWeb plugin, UI, cache, latency and no-reload behavior require external partner evidence.</desc>
+
+  <defs>
+    <linearGradient id="brandGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00A3FF"/>
+      <stop offset="1" stop-color="#0055FF"/>
+    </linearGradient>
+    <linearGradient id="controlGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14263A"/>
+      <stop offset="1" stop-color="#101826"/>
+    </linearGradient>
+    <radialGradient id="aura" cx="50%" cy="50%" r="60%">
+      <stop offset="0" stop-color="#00A3FF" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="#00A3FF" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#30363D" stroke-width="1" stroke-opacity="0.22"/>
+    </pattern>
+    <filter id="blueGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="7" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="9" stdDeviation="11" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+    <marker id="arrowCyan" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#00A3FF"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#00E676"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#F44336"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#A371F7"/>
+    </marker>
+    <style>
+      .sans { font-family: Inter, "Segoe UI", Arial, sans-serif; }
+      .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
+      .panel { fill: #161B22; stroke: #30363D; stroke-width: 2; }
+      .panel-soft { fill: #111820; stroke: #30363D; stroke-width: 2; }
+      .eyebrow { fill: #8B949E; font-size: 15px; font-weight: 750; letter-spacing: 2px; }
+      .heading { fill: #F0F6FC; font-size: 24px; font-weight: 750; }
+      .subheading { fill: #C9D1D9; font-size: 17px; font-weight: 700; }
+      .body { fill: #8B949E; font-size: 14px; }
+      .small { fill: #8B949E; font-size: 12px; }
+      .flow { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="940" fill="#0D1117"/>
+  <rect width="1600" height="940" fill="url(#grid)"/>
+  <ellipse cx="810" cy="510" rx="650" ry="440" fill="url(#aura)"/>
+  <circle cx="1490" cy="70" r="230" fill="#0055FF" opacity="0.07"/>
+
+  <!-- Header -->
+  <g class="sans">
+    <g transform="translate(48 21) scale(0.5)">
+      <path d="M50 0L100 20V60C100 90 75 110 50 120C25 110 0 90 0 60V20L50 0Z" fill="#161B22" stroke="url(#brandGradient)" stroke-width="5" filter="url(#blueGlow)"/>
+      <path d="M50 15L85 30V55C85 75 65 90 50 100C35 90 15 75 15 55V30L50 15Z" fill="none" stroke="#00A3FF" stroke-width="2" opacity="0.6"/>
+      <path d="M34 43L49 58L34 73" fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M56 74H72" stroke="#00A3FF" stroke-width="5" stroke-linecap="round"/>
+    </g>
+    <text x="116" y="52" fill="#FFFFFF" font-size="34" font-weight="800" letter-spacing="1">SYSWARDEN</text>
+    <text x="116" y="77" fill="#8B949E" font-size="13" font-weight="650" letter-spacing="1.7">BUNKERWEB INTEGRATION CONTRACT</text>
+    <text x="785" y="49" fill="#F0F6FC" font-size="25" font-weight="750" text-anchor="middle">AUTHENTICATED L7 BAN ORCHESTRATION</text>
+    <text x="785" y="76" fill="#8B949E" font-size="14" text-anchor="middle">Kernel enforcement, isolated peer scheduling and durable HA independence</text>
+
+    <g transform="translate(1250 22)">
+      <rect width="300" height="58" rx="14" fill="#111820" stroke="#30363D" stroke-width="2"/>
+      <circle cx="23" cy="20" r="5" fill="#00E676"/>
+      <text x="36" y="25" class="small">Allowed data path</text>
+      <circle cx="168" cy="20" r="5" fill="#F44336"/>
+      <text x="181" y="25" class="small">Kernel drop</text>
+      <circle cx="23" cy="43" r="5" fill="#A371F7"/>
+      <text x="36" y="48" class="small">Authenticated API</text>
+      <circle cx="168" cy="43" r="5" fill="#00A3FF"/>
+      <text x="181" y="48" class="small">Verified state</text>
+    </g>
+  </g>
+
+  <!-- Protected host data plane -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="40" y="112" width="1520" height="298" rx="24" class="panel-soft"/>
+    <text x="72" y="147" class="eyebrow">PROTECTED LINUX HOST: DATA PLANE</text>
+    <g transform="translate(72 176)">
+      <rect width="220" height="148" rx="18" fill="#10251E" stroke="#1D8F5E" stroke-width="2"/>
+      <circle cx="58" cy="55" r="34" fill="#00E676" opacity="0.14"/>
+      <circle cx="58" cy="44" r="12" fill="#00E676"/>
+      <path d="M35 79C39 58 77 58 81 79" fill="#00E676"/>
+      <text x="109" y="50" fill="#00E676" font-size="18" font-weight="750">CLIENT</text>
+      <text x="109" y="72" fill="#00E676" font-size="18" font-weight="750">TRAFFIC</text>
+      <text x="20" y="119" class="body">Internet or private network</text>
+    </g>
+
+    <g transform="translate(350 158)">
+      <rect width="240" height="184" rx="20" fill="#111D2A" stroke="#00A3FF" stroke-width="2"/>
+      <text x="120" y="27" fill="#00A3FF" font-size="13" font-weight="750" text-anchor="middle" letter-spacing="1.4">SYSWARDEN HOST EDGE</text>
+      <path d="M120 42L158 57V89C158 113 139 130 120 139C101 130 82 113 82 89V57Z" fill="#161B22" stroke="url(#brandGradient)" stroke-width="3"/>
+      <path d="M101 77H139M101 89H139M101 101H139" stroke="#00A3FF" stroke-width="3" stroke-linecap="round"/>
+      <text x="120" y="160" fill="#F0F6FC" font-size="14" font-weight="700" text-anchor="middle">nftables input</text>
+      <text x="120" y="177" fill="#C9D1D9" font-size="13" text-anchor="middle">docker_protect forward</text>
+    </g>
+
+    <g transform="translate(680 162)">
+      <rect width="250" height="176" rx="20" fill="#122219" stroke="#238B57" stroke-width="2"/>
+      <text x="125" y="28" fill="#00E676" font-size="14" font-weight="750" text-anchor="middle" letter-spacing="1.5">BUNKERWEB L7</text>
+      <g transform="translate(73 47)">
+        <path d="M0 18H104V91H0Z" fill="#0D1117" stroke="#00E676" stroke-width="2"/>
+        <path d="M0 18L13 0H91L104 18" fill="#00E676" opacity="0.18" stroke="#00E676" stroke-width="2"/>
+        <path d="M15 40H38V60H15ZM41 40H64V60H41ZM67 40H90V60H67ZM28 64H51V84H28ZM54 64H77V84H54Z" fill="#00E676" opacity="0.75"/>
+      </g>
+      <text x="125" y="157" class="body" text-anchor="middle">Partner component</text>
+    </g>
+
+    <g transform="translate(1032 158)">
+      <rect width="452" height="184" rx="20" fill="#122219" stroke="#238B57" stroke-width="2"/>
+      <text x="226" y="28" fill="#00E676" font-size="14" font-weight="750" text-anchor="middle" letter-spacing="1.5">BUNKERWEB-PROTECTED UPSTREAM</text>
+      <g transform="translate(28 53)">
+        <rect width="118" height="78" rx="12" fill="#0D1117" stroke="#00A3FF"/>
+        <rect x="18" y="17" width="82" height="44" rx="6" fill="#00A3FF" opacity="0.16"/>
+        <text x="59" y="45" class="mono" fill="#00A3FF" font-size="15" text-anchor="middle">API</text>
+      </g>
+      <g transform="translate(167 53)">
+        <rect width="118" height="78" rx="12" fill="#0D1117" stroke="#00E676"/>
+        <path d="M18 20H100V60H18Z" fill="#00E676" opacity="0.12" stroke="#00E676"/>
+        <path d="M25 30H93M25 41H75M25 52H84" stroke="#00E676" stroke-width="3" stroke-linecap="round"/>
+        <text x="59" y="72" class="mono" fill="#00E676" font-size="10" text-anchor="middle">WEBSITE</text>
+      </g>
+      <g transform="translate(306 53)">
+        <rect width="118" height="78" rx="12" fill="#0D1117" stroke="#A371F7"/>
+        <path d="M24 20H94V60H24Z" fill="#A371F7" opacity="0.12" stroke="#A371F7"/>
+        <circle cx="38" cy="33" r="5" fill="#A371F7"/>
+        <path d="M50 32H82M34 47H84" stroke="#A371F7" stroke-width="3" stroke-linecap="round"/>
+        <text x="59" y="72" class="mono" fill="#A371F7" font-size="10" text-anchor="middle">WEB APP</text>
+      </g>
+      <text x="226" y="167" class="body" text-anchor="middle">Allowed requests only</text>
+    </g>
+
+    <!-- Dynamic sets -->
+    <g transform="translate(350 352)">
+      <rect width="240" height="40" rx="12" fill="#101D29" stroke="#22587A"/>
+      <circle cx="22" cy="20" r="8" fill="#00A3FF"/>
+      <path d="M18 18H26M18 22H26" stroke="#0D1117" stroke-width="2"/>
+      <text x="41" y="24" fill="#C9D1D9" font-size="13" font-weight="650">Verified dynamic kernel sets</text>
+    </g>
+
+    <!-- Kernel drop -->
+    <g transform="translate(616 348)">
+      <rect width="260" height="44" rx="12" fill="#2A1418" stroke="#B52E35"/>
+      <circle cx="24" cy="22" r="11" fill="none" stroke="#F44336" stroke-width="2"/>
+      <path d="M18 16L30 28M30 16L18 28" stroke="#F44336" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="46" y="27" fill="#F44336" font-size="14" font-weight="700">KERNEL DROP FOR BANNED IP</text>
+    </g>
+
+    <!-- Data path arrows -->
+    <path d="M292 249H338" class="flow" stroke="#00E676" stroke-width="5" marker-end="url(#arrowGreen)"/>
+    <path d="M590 222H668" class="flow" stroke="#00E676" stroke-width="5" marker-end="url(#arrowGreen)"/>
+    <text x="629" y="207" fill="#00E676" font-size="12" font-weight="700" text-anchor="middle">ALLOWED</text>
+    <path d="M930 249H1020" class="flow" stroke="#00E676" stroke-width="5" marker-end="url(#arrowGreen)"/>
+    <path d="M590 275C626 275 632 322 676 340" class="flow" stroke="#F44336" stroke-width="4" marker-end="url(#arrowRed)"/>
+    <text x="627" y="298" fill="#F44336" font-size="12" font-weight="700">BANNED</text>
+    <path d="M470 352V340" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+  </g>
+
+  <!-- BunkerWeb plugin plane -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="40" y="452" width="420" height="402" rx="24" class="panel"/>
+    <text x="72" y="490" class="eyebrow">BUNKERWEB PLUGIN PLANE</text>
+    <text x="72" y="524" class="heading">Scheduler isolated per peer</text>
+    <g transform="translate(72 551)">
+      <rect width="356" height="102" rx="16" fill="#122219" stroke="#238B57"/>
+      <circle cx="44" cy="43" r="27" fill="#00E676" opacity="0.12" stroke="#00E676"/>
+      <path d="M31 43H57M44 30V56M35 34L53 52M53 34L35 52" stroke="#00E676" stroke-width="2" stroke-linecap="round"/>
+      <text x="86" y="35" fill="#00E676" font-size="17" font-weight="750">MULTI-PEER SCHEDULER</text>
+      <text x="86" y="58" class="body">Direct POST / DELETE per peer</text>
+      <text x="86" y="80" class="body">Maximum 500 enriched bans per batch</text>
+    </g>
+    <g transform="translate(72 678)">
+      <rect width="356" height="100" rx="16" fill="#101D29" stroke="#22587A"/>
+      <path d="M22 22H70V73H22Z" fill="#00A3FF" opacity="0.12" stroke="#00A3FF" stroke-width="2"/>
+      <path d="M30 34H62M30 45H55M30 56H59" stroke="#00A3FF" stroke-width="3" stroke-linecap="round"/>
+      <text x="88" y="35" fill="#00A3FF" font-size="17" font-weight="750">LAST VALID CACHE</text>
+      <text x="88" y="58" class="body">Layer 7 lists and status data</text>
+      <text x="88" y="80" class="body">Peer failures remain isolated</text>
+    </g>
+    <path d="M250 653V666" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+    <path d="M232 666V653" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+    <rect x="72" y="801" width="356" height="30" rx="15" fill="#1B1725" stroke="#6E4AA8"/>
+    <text x="250" y="821" fill="#A371F7" font-size="12" font-weight="700" text-anchor="middle">NO SYSWARDEN FILE, CLI OR SOCKET ACCESS</text>
+  </g>
+
+  <!-- SysWarden control plane -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="500" y="452" width="650" height="402" rx="24" fill="url(#controlGradient)" stroke="#00A3FF" stroke-width="2.5"/>
+    <text x="532" y="490" class="eyebrow" fill="#00A3FF">SYSWARDEN CONTROL PLANE: PEER A</text>
+    <g transform="translate(532 518)">
+      <rect width="250" height="104" rx="16" fill="#111D2A" stroke="#00A3FF"/>
+      <path d="M24 27H56V55H24Z" fill="none" stroke="#00A3FF" stroke-width="2.5"/>
+      <path d="M32 27V20C32 10 48 10 48 20V27" fill="none" stroke="#00A3FF" stroke-width="2.5"/>
+      <text x="78" y="31" fill="#00A3FF" font-size="18" font-weight="800">HA API :62026</text>
+      <text x="24" y="72" class="body">TLS 1.3 + bearer token</text>
+      <text x="24" y="92" class="body">Exact IP or canonical CIDR scope</text>
+    </g>
+    <g transform="translate(850 518)">
+      <rect width="268" height="104" rx="16" fill="#101D29" stroke="#22587A"/>
+      <path d="M22 25H62V73H22Z" fill="#00A3FF" opacity="0.12" stroke="#00A3FF" stroke-width="2"/>
+      <path d="M30 38H54M30 49H54M30 60H49" stroke="#00A3FF" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="82" y="34" fill="#00A3FF" font-size="17" font-weight="750">DURABLE STATE</text>
+      <text x="82" y="58" class="body">Lists + source-owned TTL ledger</text>
+      <text x="82" y="80" class="body">Verified kernel reconciliation</text>
+    </g>
+    <path d="M789 560H838" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+    <path d="M838 580H789" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+
+    <g transform="translate(532 659)">
+      <rect width="190" height="132" rx="16" fill="#221D11" stroke="#FFB000"/>
+      <text x="95" y="27" fill="#FFB000" font-size="13" font-weight="750" text-anchor="middle">PARTNER GATE</text>
+      <text x="95" y="52" class="mono" fill="#F0F6FC" font-size="12" text-anchor="middle">integrations.bunkerweb</text>
+      <text x="95" y="72" class="mono" fill="#F0F6FC" font-size="12" text-anchor="middle">.enabled ?</text>
+      <text x="95" y="94" class="small" text-anchor="middle">Requires capabilities:</text>
+      <text x="95" y="111" class="mono" fill="#FFB000" font-size="10" text-anchor="middle">sync_ttl + sync_provenance</text>
+      <text x="95" y="126" class="small" text-anchor="middle">Default: false</text>
+    </g>
+    <g transform="translate(750 659)">
+      <rect width="164" height="132" rx="16" fill="#10251E" stroke="#1D8F5E"/>
+      <circle cx="82" cy="29" r="13" fill="#00E676" opacity="0.16" stroke="#00E676"/>
+      <path d="M75 29L80 34L89 23" fill="none" stroke="#00E676" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="82" y="59" fill="#00E676" font-size="15" font-weight="800" text-anchor="middle">TRUE</text>
+      <text x="82" y="82" class="small" text-anchor="middle">TTL + batch</text>
+      <text x="82" y="100" class="small" text-anchor="middle">+ provenance</text>
+      <text x="82" y="119" class="small" text-anchor="middle">extensions accepted</text>
+    </g>
+    <g transform="translate(942 659)">
+      <rect width="176" height="132" rx="16" fill="#2A1418" stroke="#B52E35"/>
+      <circle cx="88" cy="29" r="13" fill="#F44336" opacity="0.16" stroke="#F44336"/>
+      <path d="M82 23L94 35M94 23L82 35" stroke="#F44336" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="88" y="59" fill="#F44336" font-size="15" font-weight="800" text-anchor="middle">FALSE</text>
+      <text x="88" y="82" class="small" text-anchor="middle">Enriched mutation</text>
+      <text x="88" y="100" class="small" text-anchor="middle">rejected</text>
+      <text x="88" y="119" class="small" text-anchor="middle">durable HA unchanged</text>
+    </g>
+    <path d="M657 622V647" class="flow" stroke="#FFB000" stroke-width="3" marker-end="url(#arrowPurple)"/>
+    <path d="M722 725H738" class="flow" stroke="#00E676" stroke-width="3" marker-end="url(#arrowGreen)"/>
+    <path d="M722 755V812H930V755" class="flow" stroke="#F44336" stroke-width="3" marker-end="url(#arrowRed)"/>
+    <path d="M832 659V642H984V622" class="flow" stroke="#00E676" stroke-width="3" marker-end="url(#arrowCyan)"/>
+  </g>
+
+  <!-- Other SysWarden peer -->
+  <g class="sans" filter="url(#softShadow)">
+    <rect x="1190" y="452" width="370" height="402" rx="24" class="panel"/>
+    <text x="1222" y="490" class="eyebrow">OTHER SYSWARDEN PEER B</text>
+    <g transform="translate(1222 522)">
+      <rect width="306" height="126" rx="17" fill="#111D2A" stroke="#00A3FF"/>
+      <path d="M47 19L77 31V56C77 75 62 88 47 95C32 88 17 75 17 56V31Z" fill="#161B22" stroke="#00A3FF" stroke-width="2.5"/>
+      <path d="M36 48L45 57L60 39" fill="none" stroke="#00A3FF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <text x="96" y="36" fill="#00A3FF" font-size="17" font-weight="750">HA API :62026</text>
+      <text x="96" y="60" class="body">Authenticated exact peer</text>
+      <text x="96" y="82" class="body">Capabilities advertised</text>
+      <text x="96" y="104" class="body">Own durable local state</text>
+    </g>
+    <g transform="translate(1222 674)">
+      <rect width="306" height="60" rx="14" fill="#1B1725" stroke="#6E4AA8"/>
+      <text x="153" y="25" fill="#A371F7" font-size="14" font-weight="750" text-anchor="middle">DURABLE HA ALWAYS ACTIVE</text>
+      <text x="153" y="44" class="small" text-anchor="middle">Gate false or true on either node</text>
+    </g>
+    <g transform="translate(1222 754)">
+      <rect width="306" height="72" rx="14" fill="#2A1418" stroke="#B52E35"/>
+      <text x="153" y="25" fill="#F44336" font-size="13" font-weight="750" text-anchor="middle">NO TRANSITIVE TEMPORARY RELAY</text>
+      <text x="153" y="46" class="small" text-anchor="middle">Scheduler contacts each peer directly</text>
+      <text x="153" y="62" class="small" text-anchor="middle">TTL and source remain unambiguous</text>
+    </g>
+  </g>
+
+  <!-- Cross-plane flows -->
+  <path d="M805 338V418H250V539" class="flow" stroke="#A371F7" stroke-width="3.5" stroke-dasharray="8 8" marker-end="url(#arrowPurple)"/>
+  <rect x="630" y="407" width="300" height="24" rx="12" fill="#0D1117" stroke="#A371F7" stroke-opacity="0.6"/>
+  <text x="780" y="424" class="mono" fill="#A371F7" font-size="10" font-weight="700" text-anchor="middle">TEMPORARY L7 BAN OBSERVED</text>
+
+  <path d="M460 574H488" class="flow" stroke="#A371F7" stroke-width="4" marker-end="url(#arrowPurple)"/>
+  <text x="474" y="558" class="mono" fill="#A371F7" font-size="10" text-anchor="middle">PUSH</text>
+  <path d="M500 608H472" class="flow" stroke="#00A3FF" stroke-width="3" marker-end="url(#arrowCyan)"/>
+  <text x="486" y="627" class="mono" fill="#00A3FF" font-size="10" text-anchor="middle">READ</text>
+
+  <path d="M1118 570H1178" class="flow" stroke="#A371F7" stroke-width="4" marker-end="url(#arrowPurple)"/>
+  <path d="M1178 598H1118" class="flow" stroke="#A371F7" stroke-width="4" marker-end="url(#arrowPurple)"/>
+  <rect x="1018" y="617" width="260" height="28" rx="14" fill="#0D1117" stroke="#A371F7" stroke-opacity="0.6"/>
+  <text x="1148" y="636" class="mono" fill="#A371F7" font-size="9" font-weight="700" text-anchor="middle">TWO SCHEDULED ONE-WAY PUSHES</text>
+
+  <path d="M428 615H476V878H1375V842" class="flow" stroke="#A371F7" stroke-width="3.5" stroke-dasharray="8 8" marker-end="url(#arrowPurple)"/>
+  <rect x="600" y="864" width="430" height="28" rx="14" fill="#0D1117" stroke="#A371F7" stroke-opacity="0.6"/>
+  <text x="815" y="883" class="mono" fill="#A371F7" font-size="11" font-weight="700" text-anchor="middle">SAME SOURCE-OWNED BAN SENT DIRECTLY TO PEER B</text>
+
+  <path d="M984 518V444H470V352" class="flow" stroke="#00A3FF" stroke-width="3.5" marker-end="url(#arrowCyan)"/>
+
+  <!-- Contract boundary -->
+  <g class="sans">
+    <rect x="40" y="900" width="1520" height="32" rx="16" fill="#111820" stroke="#30363D"/>
+    <text x="800" y="921" fill="#8B949E" font-size="12" font-weight="650" text-anchor="middle">SYSWARDEN-SIDE CONTRACT ONLY: PARTNER PLUGIN, UI, CACHE AND NO-RELOAD BEHAVIOR REQUIRE EXTERNAL BUNKERWEB EVIDENCE</text>
+  </g>
+</svg>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,25 @@
+# Release v4.02.11
+
+### FIXED 🐛
+- **Qualification environment:** Preserve the valid `protected_branches=false` GitHub API value instead of treating it as missing, while continuing to reject absent, null, string or otherwise non-boolean policy fields.
+- **Release publication:** Apply the same fail-closed boolean parsing to the protected production environment so a correctly restricted `v*` tag policy can reach the publisher.
+- **Regression coverage:** Execute the environment-policy parser against real JSON booleans and adversarial missing, null and string values instead of relying only on source-text assertions.
+
+### RELEASE STATUS 📦
+- v4.02.10 was merged as a source candidate but was never tagged or published because the protected qualification gate rejected GitHub's valid boolean `false`. No v4.02.10 Release asset was exposed to users.
+- v4.02.11 supersedes that unpublished candidate and is the first Lot 1 package set eligible for protected qualification, immutable tagging and publication of the complete 14-asset Release.
+
+### UPGRADE NOTES 📦
+- The immutable v4.02.8 binary predates the signed updater. Do not use `syswarden update` for its first hop. Download exactly one v4.02.11 package matching the host plus `SHA256SUMS.txt`, verify that exact package, then install it with the native package manager.
+- **Debian or Ubuntu:** after checksum verification, run `sudo apt-get install -y ./syswarden_4.02.11_amd64.deb` or use the `arm64` filename on an ARM64 host.
+- **RHEL, AlmaLinux or Rocky Linux:** after checksum verification, run `sudo dnf install -y ./syswarden-4.02.11-1.x86_64.rpm` or use the `aarch64` filename on an ARM64 host.
+- **Alpine Linux:** after checksum verification, run `sudo apk add --allow-untrusted ./syswarden_4.02.11_x86_64.apk` or use the `aarch64` filename on an ARM64 host. Never use `--allow-untrusted` before the SHA-256 check succeeds.
+- **FreeBSD 14 amd64:** install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then run `sudo pkg add -f ./syswarden-4.02.11.txz` after checksum verification.
+- Starting from an installed v4.02.11, `syswarden update` uses the signed Ed25519 manifest for the six Linux targets and FreeBSD amd64.
+- Review the package post-install result with `sudo syswarden manual` and `sudo syswarden config`. The complete architecture-selecting procedure remains in the README section [Install the latest verified Release](README.md#install-the-latest-verified-release).
+
+---
+
 # Release v4.02.10
 
 ### FIXED 🐛

--- a/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.11.md
+++ b/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.11.md
@@ -1,0 +1,126 @@
+# SysWarden Lot 1 Public Security Delivery Report
+
+| Field | Value |
+| :--- | :--- |
+| Lot 1 source status | CANDIDATE |
+| Product release decision | NO-GO until protected qualification |
+| Candidate | v4.02.11 |
+| Historical public baseline | v4.02.8 |
+| Prior source candidate | v4.02.10, merged but never tagged or published |
+| Report date | 15 August 2026 |
+| Scope | Lot 1 source, package and release-qualification closure |
+| Audience | Public, anonymized |
+
+## 1. Executive outcome
+
+This report describes the v4.02.11 repository candidate. It does not claim
+that an untagged build is a public release, that every environment is
+supported, or that a package is safe merely because a workflow produced it.
+
+The v4.02.10 source candidate was merged, but it was never tagged and was never
+published as a GitHub Release. It therefore has no public v4.02.10 Release
+inventory. The replacement v4.02.11 candidate is NO-GO until the complete
+protected qualification passes on its exact commit and produces byte-bound
+evidence. No v4.02.11 tag or public Release is authorized before that result.
+
+## 2. Delivered controls
+
+| Area | Candidate behavior | Security boundary |
+| :--- | :--- | :--- |
+| Configuration | Transactional migration, strict validation, durable recovery phases, concurrency controls and preservation of operator overrides | Mutating commands stop when the active configuration is unavailable or degraded |
+| Linux firewall | Validated nftables candidate, shared lock, atomic commit, post-commit verification, TTL preservation and bounded compatibility wrappers | A policy change can still interrupt remote access; console recovery remains mandatory |
+| High availability | TLS 1.3, bearer authentication, bounded payloads, canonical peer scope, durable ledgers and bidirectional persistent-ban exchange | CIDRs authorize inbound peers only and are never dialed as outbound destinations |
+| BunkerWeb integration | Additive TTL, provenance and batch extensions behind an explicit gate | Durable node-to-node L7 and WAAP ban exchange remains active with the partner gate false or true |
+| Signed updates | Canonical manifest, detached Ed25519 signature, exact platform binding, private staging and a final size and SHA-256 verification before installation | The historical v4.02.8 binary predates this trust root and requires one separately verified manual first hop |
+| Alpine packages | Dedicated CGO-free static x86_64 and aarch64 package executables | Exact protected lifecycle evidence is still required for the release commit |
+| FreeBSD package | ABI 14 amd64 TXZ, native `/usr/local` layout, rc.d services, PF recovery contract, host-state restoration and native signed updater support | Fresh installation requires PF disabled with an empty live ruleset; arbitrary pre-existing PF coexistence is not claimed |
+| Release governance | Exact tag ruleset, protected signing environment, byte-bound qualification evidence and independent publisher revalidation | A public tag and Release remain blocked until protected qualification succeeds |
+
+## 3. Upgrade contract
+
+The signed update protocol applies to v4.02.9 and later candidates. A qualified
+v4.02.11 manifest must bind seven package identities: two DEB, two RPM, two APK
+and one FreeBSD TXZ. A package is selected by exact operating system,
+architecture, name, size and SHA-256, then rehashed immediately before its
+package manager is invoked.
+
+The immutable v4.02.8 binary has no embedded signed-manifest verifier. Its first
+hop to v4.02.11 must therefore use a separately verified package and the native
+package manager. On FreeBSD, the standalone TXZ also requires `curl`, `jq`,
+`libqrencode`, `rsyslog` and `wireguard-tools` to be installed first. Once
+v4.02.11 is installed from a qualified Release, signed updates support the six
+Linux targets and FreeBSD amd64.
+
+## 4. Package and platform boundaries
+
+| Platform | Candidate evidence | Remaining release gate |
+| :--- | :--- | :--- |
+| DEB amd64 and arm64 | Contents, dependencies, maintainer scripts and lifecycle contracts | Protected exact-package lifecycle |
+| RPM x86_64 and aarch64 | Contents, dependencies, maintainer scripts and lifecycle contracts | Protected exact-package lifecycle |
+| APK x86_64 and aarch64 | Static package executables; amd64 executes on standard Alpine musl | Protected x86_64 and aarch64 lifecycle |
+| FreeBSD amd64 | Cross-build, ABI, inventory, native paths, rc.d, PF, uninstall and updater contracts | Disposable VM lifecycle and signed updater transition |
+
+Raw `pkg delete` is not the supported FreeBSD cleanup path because the package
+manager does not guarantee that a failing pre-deinstall script aborts payload
+removal, and its no-script mode bypasses recovery hooks. Operators must use
+`syswarden uninstall` with backups and console access.
+
+The Web-TUI is enabled by the current package path. A package-level disabled
+default and conditional TCP 62027 ownership remain Lot 2 work.
+
+## 5. Qualification state
+
+The v4.02.10 protected pre-tag attempt stopped before privileged platform labs.
+It produced no successful qualification artifact, tag or Release. Its source
+checks are not final release evidence for v4.02.11.
+
+The v4.02.11 candidate must pass all source and governance checks again on its
+exact commit. The protected run must then verify package install, upgrade,
+restart and rollback lifecycles; ARM64 execution; the FreeBSD PF and package
+lifecycle; the signed FreeBSD updater transition; staged artifact integrity;
+and publisher revalidation. Any failed coordinate keeps the release closed.
+
+## 6. Expected public Release inventory
+
+A qualified v4.02.11 Release must contain exactly these 14 public assets:
+
+1. `syswarden_4.02.11_amd64.deb`;
+2. `syswarden_4.02.11_arm64.deb`;
+3. `syswarden-4.02.11-1.x86_64.rpm`;
+4. `syswarden-4.02.11-1.aarch64.rpm`;
+5. `syswarden_4.02.11_x86_64.apk`;
+6. `syswarden_4.02.11_aarch64.apk`;
+7. `syswarden-4.02.11.txz`;
+8. `SHA256SUMS.txt`;
+9. `RELEASE_SHA256SUMS.txt`;
+10. `syswarden-release.tar.gz`;
+11. `syswarden-sbom.spdx.json`;
+12. `plumber-report.zip`;
+13. `syswarden-update-manifest-v1.json`;
+14. `syswarden-update-manifest-v1.json.sig`.
+
+This inventory contains seven packages plus seven evidence and update assets.
+A successful source merge alone does not create the tag or these Release
+assets.
+
+## 7. Deferred Lot 2 work
+
+The following items remain outside this Lot 1 closure:
+
+- a package-level `[webtui] enabled = false` default and conditional TCP 62027
+  ownership;
+- an external BunkerWeb plugin, UI and end-to-end partner qualification;
+- per-client HA tokens and remote whitelist mutation privileges;
+- FreeBSD jails and coexistence with arbitrary pre-existing PF policy;
+- a public FreeBSD package repository instead of standalone TXZ installation;
+- additional product UX and policy controls that do not alter the v4.02.11
+  upgrade safety boundary.
+
+## 8. Final decision rule
+
+v4.02.11 remains NO-GO. The tag may be created only after protected
+qualification binds the exact release commit and passes the package, ARM64,
+FreeBSD, PF, signed-updater and release-governance gates. The publisher must
+then revalidate the qualified evidence and exact asset inventory before it can
+publish the GitHub Release. Any failed coordinate keeps the public Release
+closed.

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -412,9 +412,9 @@
     {
       "case": "root",
       "stream": "stdout",
-      "reason": "Advance the Patch version to v4.02.10 while preserving the bounded built-in operator reference introduced after v4.02.8.",
+      "reason": "Advance the Patch version to v4.02.11 while preserving the bounded built-in operator reference introduced after v4.02.8.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.02.10 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.02.11 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     }
   ],
   "product_command_count": 24,
@@ -443,6 +443,8 @@
     "CIDRs authorize inbound peers only and are never converted into outbound URLs.",
     "Enriched requests are limited to 500 bans per batch",
     "The BunkerWeb extensions are also disabled by default",
+    "assets/syswarden_architecture.svg",
+    "assets/syswarden_bunkerweb_integration.svg",
     "Disabling the BunkerWeb integration does not disable node-to-node HA.",
     "Enabling BunkerWeb is equally additive",
     "SysWarden nodes do not relay those records transitively",
@@ -469,7 +471,7 @@
     "If that restart fails, the command returns nonzero and reports partial state",
     "`syswarden uninstall` is destructive",
     "The procedure below downloads exactly one package for the detected operating system and architecture.",
-    "VERSION=v4.02.10 sh ./install-release.sh",
+    "VERSION=v4.02.11 sh ./install-release.sh",
     "checksum manifest must contain exactly one entry for $PACKAGE",
     "## Security posture and limitations",
     "Goal: 37% reached/year (Goal)"
@@ -478,7 +480,7 @@
     "it is not a compliance certification",
     "v4.02.9+ requires a trusted Ed25519 release manifest",
     "dedicated CGO-free static APK binaries are built for x86_64 and aarch64",
-    "v4.02.10 uses native /usr/local paths and rc.d on amd64",
+    "v4.02.11 uses native /usr/local paths and rc.d on amd64",
     "default bind 0.0.0.0:62027",
     "persistent self-signed TLS 1.3 identity",
     "/var/lib/syswarden/ha/server.crt and /var/lib/syswarden/ha/server.key",
@@ -522,7 +524,7 @@
       "Disabling BunkerWeb leaves this authenticated node-to-node exchange available",
       "signed Ed25519 update manifest",
       "The procedure below downloads exactly one package for the detected operating system and architecture.",
-      "VERSION=v4.02.10 sh ./install-release.sh",
+      "VERSION=v4.02.11 sh ./install-release.sh",
       "checksum manifest must contain exactly one entry for $PACKAGE",
       "On FreeBSD, use `syswarden uninstall` rather than raw `pkg delete`."
     ],
@@ -533,10 +535,11 @@
       "A-to-B and B-to-A exchange",
       "through TLS 1.3 and bearer authentication",
       "removes partner TTL, batch and provenance capabilities",
-      "any package artifact that has not passed the exact protected v4.02.10 lifecycle",
+      "any package artifact that has not passed the exact protected v4.02.11 lifecycle",
       "FreeBSD coexistence with an arbitrary pre-existing PF policy"
     ],
     "BunkerWeb-Integration.md": [
+      "assets/syswarden_bunkerweb_integration.svg",
       "`docker_protect` nftables chain is attached to the `forward` hook",
       "Protected host: data plane",
       "two scheduled pushes, gate false or true",
@@ -557,7 +560,7 @@
       "Start with `SYSWARDEN_ENFORCEMENT=audit`",
       "An external-only row is never reported as a SysWarden test success.",
       "Never copy `server.key` to a client.",
-      "v4.02.10 does not expose remote whitelist writes or per-client scoped tokens."
+      "v4.02.11 does not expose remote whitelist writes or per-client scoped tokens."
     ]
   },
   "package_platform_contract": {
@@ -695,7 +698,7 @@
         "header": [
           "Package family",
           "Architectures produced by the workflow",
-          "Decision for v4.02.10"
+          "Decision for v4.02.11"
         ],
         "rows": [
           [

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest import mock
 
@@ -18,6 +19,30 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class DocumentationGateTest(unittest.TestCase):
+    def test_architecture_diagrams_are_safe_native_svg_and_readme_mermaid_free(self) -> None:
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("assets/syswarden_architecture.svg", readme)
+        self.assertIn("assets/syswarden_bunkerweb_integration.svg", readme)
+        self.assertNotIn("```mermaid", readme)
+
+        for relative_path in (
+            "assets/syswarden_architecture.svg",
+            "assets/syswarden_bunkerweb_integration.svg",
+        ):
+            root = ET.parse(REPO_ROOT / relative_path).getroot()
+            self.assertEqual(root.attrib.get("role"), "img")
+            labelled_by = root.attrib.get("aria-labelledby", "").split()
+            self.assertEqual(labelled_by, ["title", "description"])
+            element_names = {
+                element.tag.rsplit("}", 1)[-1] for element in root.iter()
+            }
+            self.assertNotIn("script", element_names)
+            self.assertNotIn("foreignObject", element_names)
+            for element in root.iter():
+                for attribute in element.attrib:
+                    self.assertFalse(attribute.lower().startswith("on"))
+                    self.assertNotIn(attribute.rsplit("}", 1)[-1], {"href"})
+
     def test_repository_documentation_contract(self) -> None:
         records, errors = documentation_gate.validate_repository(REPO_ROOT)
         self.assertEqual(errors, [])
@@ -481,7 +506,7 @@ invented_key = true
         ]
         deployment = """## 1. Target decision
 
-| Package family | Architectures produced by the workflow | Decision for v4.02.10 |
+| Package family | Architectures produced by the workflow | Decision for v4.02.11 |
 | :--- | :--- | :--- |
 | DEB | amd64, arm64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |
 | RPM | x86_64, aarch64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |

--- a/scripts/ci/fixtures/package-forward-only-v4.02.8.json
+++ b/scripts/ci/fixtures/package-forward-only-v4.02.8.json
@@ -1,5 +1,5 @@
 {
-  "candidate_version": "4.02.10",
+  "candidate_version": "4.02.11",
   "previous_version": "4.02.8",
   "artifacts": {
     "aarch64": {

--- a/scripts/ci/freebsd_updater_vm_probe_test.py
+++ b/scripts/ci/freebsd_updater_vm_probe_test.py
@@ -44,7 +44,7 @@ def passing_evidence() -> dict[str, str]:
         "UPDATER_RESULT_SHA256": "a" * 64,
         "UPDATER_RESULT_EXACT": "1",
         "UPDATER_RESULT_LINE": f"--- PASS: {subject.TEST_NAME} (1.23s)",
-        "CANDIDATE_VERSION": "4.02.10",
+        "CANDIDATE_VERSION": "4.02.11",
         "CORE_ENABLED": "YES",
         "WEB_ENABLED": "YES",
         "CORE_STATUS_RC": "0",
@@ -80,13 +80,13 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
-        self.candidate_path = fixture(self.root / "syswarden-4.02.10.txz", b"candidate")
+        self.candidate_path = fixture(self.root / "syswarden-4.02.11.txz", b"candidate")
         self.previous_path = fixture(self.root / "syswarden-4.02.8.txz", b"previous")
         self.manifest = fixture(self.root / "syswarden-update-manifest-v1.json", b"{}\n")
         self.signature = fixture(self.root / "syswarden-update-manifest-v1.json.sig", b"signature\n")
         self.test_binary = fixture(self.root / subject.TEST_BINARY_NAME, b"ELF", 0o700)
         self.candidate = vm_lab.PackageArtifact(
-            self.candidate_path, "4.02.10", hashlib.sha256(b"candidate").hexdigest()
+            self.candidate_path, "4.02.11", hashlib.sha256(b"candidate").hexdigest()
         )
         self.previous = vm_lab.PackageArtifact(
             self.previous_path, "4.02.8", hashlib.sha256(b"previous").hexdigest()
@@ -116,7 +116,7 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         report = self.report()
         self.assertTrue(report["release_ready"])
         self.assertEqual(report["blocker_ids"], [])
-        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.10")
+        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.11")
         self.assertEqual(report["inputs"]["previous"]["version"], "4.02.8")
 
     def test_each_material_observation_is_fail_closed(self) -> None:

--- a/scripts/ci/freebsd_vm_lab.py
+++ b/scripts/ci/freebsd_vm_lab.py
@@ -547,10 +547,10 @@ def version_tuple(version: str) -> tuple[int, int, int]:
 def is_forward_only_transition(
     candidate: PackageArtifact, previous: PackageArtifact
 ) -> bool:
-    """Recognize only the immutable v4.02.8 to v4.02.10 transition."""
+    """Recognize only the immutable v4.02.8 to v4.02.11 transition."""
 
     return (
-        candidate.version == "4.02.10"
+        candidate.version == "4.02.11"
         and previous.version == FORWARD_ONLY_PREVIOUS_VERSION
         and previous.path.name == FORWARD_ONLY_PREVIOUS_PACKAGE
         and previous.sha256 == FORWARD_ONLY_PREVIOUS_SHA256
@@ -570,7 +570,7 @@ def validate_forward_only_binding(
     ):
         raise FreeBSDVMLabError(
             "the historical FreeBSD transition is allowed only for the exact "
-            "v4.02.8 package bytes followed by candidate v4.02.10"
+            "v4.02.8 package bytes followed by candidate v4.02.11"
         )
 
 
@@ -1181,7 +1181,7 @@ fi
 if [ "$previous_expected_version" = "4.02.8" ]; then
     if [ "$previous_package_name" != "syswarden-4.02.8.txz" ] || \
        [ "$previous_expected_sha" != "8b3b489821450b3afd74548c6db5ad92001b8a69f923e2b9a99ce550353b6e37" ] || \
-       [ "$candidate_expected_version" != "4.02.10" ]; then
+       [ "$candidate_expected_version" != "4.02.11" ]; then
         exit 91
     fi
 fi
@@ -1779,7 +1779,7 @@ emit REMOVE_PF_SNAPSHOT_SHA256 "$remove_pf_snapshot_sha"
 emit REMOVE_PF_BASELINE_RESTORED "$remove_pf_restored"
 emit REMOVE_PF_SYSWARDEN_TABLE_ABSENT "$remove_syswarden_tables_absent"
 
-# Exercise the fresh v4.02.10 PF boundary with the exact candidate CLI after
+# Exercise the fresh v4.02.11 PF boundary with the exact candidate CLI after
 # the historical package snapshot has been consumed. Fresh capture is allowed
 # only on the disabled empty baseline; a nonempty anchor must be rejected
 # before any PF or snapshot mutation.
@@ -2352,7 +2352,7 @@ def product_checks(
                     "nonempty_rejected": evidence["PF_NONEMPTY_CAPTURE_REJECTED"],
                     "nonempty_state_preserved": evidence["PF_NONEMPTY_STATE_PRESERVED"],
                 },
-                "Fresh v4.02.10 PF ownership is restricted to a disabled empty host and must reject coexistence before mutation.",
+                "Fresh v4.02.11 PF ownership is restricted to a disabled empty host and must reject coexistence before mutation.",
             ),
             check("SW-PKG-FBSD-START-CORE-001", "startup", evidence["RC_CORE_START_RC"] == "0" and evidence["RC_CORE_STATUS_RC"] == "0", "core starts and reports running", {"start": evidence["RC_CORE_START_RC"], "status": evidence["RC_CORE_STATUS_RC"]}, "The candidate core must start through rc.d."),
             check("SW-PKG-FBSD-RESTART-CORE-001", "startup", all(evidence[key] == "0" for key in ("RC_CORE_RESTART_ONE_RC", "RC_CORE_RESTART_ONE_STATUS_RC", "RC_CORE_RESTART_TWO_RC", "RC_CORE_RESTART_TWO_STATUS_RC")), "two consecutive core restarts succeed and report running", {key: evidence[key] for key in ("RC_CORE_RESTART_ONE_RC", "RC_CORE_RESTART_ONE_STATUS_RC", "RC_CORE_RESTART_TWO_RC", "RC_CORE_RESTART_TWO_STATUS_RC")}, "A second consecutive restart is the bounded rc.d idempotence check."),

--- a/scripts/ci/freebsd_vm_lab_test.py
+++ b/scripts/ci/freebsd_vm_lab_test.py
@@ -344,7 +344,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
 
     def forward_candidate_artifact(self) -> freebsd_vm_lab.PackageArtifact:
         return freebsd_vm_lab.PackageArtifact(
-            self.root / "syswarden-4.02.10.txz", "4.02.10", self.package_sha
+            self.root / "syswarden-4.02.11.txz", "4.02.11", self.package_sha
         )
 
     def forward_previous_artifact(self) -> freebsd_vm_lab.PackageArtifact:
@@ -365,9 +365,9 @@ class FreeBSDVMLabTests(unittest.TestCase):
         self.assertEqual(candidate, self.artifact())
         self.assertEqual(previous, self.previous_artifact())
 
-    def test_candidate_v40210_requires_exact_dependency_manifest(self) -> None:
+    def test_candidate_v40211_requires_exact_dependency_manifest(self) -> None:
         self.package.unlink()
-        candidate = self.packages / "syswarden-4.02.10.txz"
+        candidate = self.packages / "syswarden-4.02.11.txz"
         candidate.write_bytes(b"candidate with dependency gate")
         digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
         (self.packages / "SHA256SUMS.txt").write_text(
@@ -775,7 +775,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
             "CANDIDATE_REINSTALL",
             "CANDIDATE_RESTART_IDEMPOTENCE",
         ):
-            evidence[f"{phase}_PKG_VERSION"] = "4.02.10"
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.11"
         for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
             evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
             evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -359,7 +359,7 @@ PACKAGE_PAYLOAD_PATHS = (
     "/usr/local/bin/syswarden",
     "/usr/local/bin/syswarden-tui",
 )
-FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.10"
+FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.11"
 FORWARD_ONLY_APK_PREVIOUS_VERSION = "4.02.8"
 FORWARD_ONLY_APK_PREVIOUS = {
     "x86_64": {
@@ -570,7 +570,7 @@ def validate_forward_only_apk_pair(spec: PlatformSpec, pair: PackagePair) -> boo
     if historical_binding_touched and not forward_only:
         raise LifecycleLabError(
             "historical APK transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.10 contract for "
+            "v4.02.8 -> v4.02.11 contract for "
             f"{spec.package_architecture}"
         )
     return forward_only

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -391,8 +391,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             pair = package_lifecycle_lab.PackagePair(
                 candidate=package_lifecycle_lab.PackageArtifact(
                     self.candidate
-                    / f"syswarden_4.02.10_{spec.package_architecture}.apk",
-                    "4.02.10",
+                    / f"syswarden_4.02.11_{spec.package_architecture}.apk",
+                    "4.02.11",
                     "a" * 64,
                 ),
                 previous=package_lifecycle_lab.PackageArtifact(
@@ -959,11 +959,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
             f'CALLS="{calls}"\n'
             f'RESTART_STATE_FILE="{restart}"\n'
             'PREVIOUS_PACKAGE="/previous/exact-v4.02.8.apk"\n'
-            'CANDIDATE_PACKAGE="/candidate/v4.02.10.apk"\n'
+            'CANDIDATE_PACKAGE="/candidate/v4.02.11.apk"\n'
             'PREVIOUS_VERSION="4.02.8"\n'
-            'CANDIDATE_VERSION="4.02.10"\n'
+            'CANDIDATE_VERSION="4.02.11"\n'
             'EXPECTED_PREVIOUS_VERSION="4.02.8"\n'
-            'EXPECTED_CANDIDATE_VERSION="4.02.10"\n'
+            'EXPECTED_CANDIDATE_VERSION="4.02.11"\n'
             'FORWARD_ONLY_APK_TRANSITION="1"\n'
             "prepare_expected_payloads() { return 0; }\n"
             "seed_state() { :; }\n"
@@ -1468,11 +1468,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 architecture
             ]
             platform_result.update(
-                candidate_version="4.02.10",
+                candidate_version="4.02.11",
                 previous_version="4.02.8",
                 candidate={
-                    "filename": f"syswarden_4.02.10_{architecture}.apk",
-                    "version": "4.02.10",
+                    "filename": f"syswarden_4.02.11_{architecture}.apk",
+                    "version": "4.02.11",
                     "sha256": "c" * 64,
                 },
                 previous={

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -10,12 +10,81 @@ import os
 import subprocess
 import tarfile
 import tempfile
+import textwrap
 import unittest
 import zipfile
 from pathlib import Path
 from unittest import mock
 
 import release_gate
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+RELEASE_MANAGER_WORKFLOW = (
+    REPOSITORY / ".github" / "workflows" / "release-manager.yml"
+)
+
+
+def workflow_step_script(workflow: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    if workflow.count(marker) != 1:
+        raise AssertionError(f"expected exactly one workflow step named {step_name}")
+    step = workflow.split(marker, 1)[1].split("\n      - name:", 1)[0]
+    run_marker = "        run: |\n"
+    if step.count(run_marker) != 1:
+        raise AssertionError(f"expected one shell body for workflow step {step_name}")
+    return textwrap.dedent(step.split(run_marker, 1)[1])
+
+
+def run_environment_gate(
+    script: str,
+    environment: dict[str, object],
+    policies: list[dict[str, object]],
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        binary_directory = Path(temporary) / "bin"
+        binary_directory.mkdir()
+        gh = binary_directory / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"/deployment-branch-policies"*)
+    printf '%s\\n' "${TEST_POLICIES_JSON:?}"
+    ;;
+  *"/environments/"*)
+    printf '%s\\n' "${TEST_ENVIRONMENT_JSON:?}"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 64
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o700)
+        process_environment = os.environ.copy()
+        process_environment.update(
+            {
+                "GITHUB_REPOSITORY": "duggytuxy/syswarden",
+                "GITHUB_REPOSITORY_OWNER": "duggytuxy",
+                "PATH": f"{binary_directory}{os.pathsep}{process_environment['PATH']}",
+                "TEST_ENVIRONMENT_JSON": json.dumps(
+                    environment, separators=(",", ":")
+                ),
+                "TEST_POLICIES_JSON": json.dumps(policies, separators=(",", ":")),
+            }
+        )
+        return subprocess.run(
+            ["/bin/bash", "-c", script],
+            cwd=REPOSITORY,
+            env=process_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
 
 
 class ReleaseGateTests(unittest.TestCase):
@@ -896,12 +965,7 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         self.assertNotIn("syswarden-release-qualification", release_creation)
 
     def test_privileged_publisher_requires_a_protected_maintainer_environment(self) -> None:
-        workflow = (
-            Path(__file__).resolve().parents[2]
-            / ".github"
-            / "workflows"
-            / "release-manager.yml"
-        ).read_text(encoding="utf-8")
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(
             workflow.count("name: syswarden-release-production"),
             1,
@@ -922,8 +986,86 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         self.assertIn('deployment-branch-policies', workflow)
         self.assertIn('.name == "v*" and .type == "tag"', workflow)
         self.assertIn('"${release_tag_policy_count}" != "1"', workflow)
+        environment_script = workflow_step_script(
+            workflow, "Require Protected Maintainer Release Environment"
+        )
+        self.assertIn("required_environment_boolean()", environment_script)
+        self.assertIn('if type == "boolean" then', environment_script)
+        self.assertIn("tostring", environment_script)
+        self.assertNotIn('// "missing"', environment_script)
         privileged_job = workflow.split("  attest-and-publish:", 1)[1]
         self.assertIn("environment:\n      name: syswarden-release-production", privileged_job)
+
+    def test_production_environment_boolean_gate_is_typed_and_fail_closed(self) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        script = workflow_step_script(
+            workflow, "Require Protected Maintainer Release Environment"
+        )
+        valid = {
+            "name": "syswarden-release-production",
+            "protection_rules": [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": False,
+                    "reviewers": [
+                        {
+                            "type": "User",
+                            "reviewer": {"login": "duggytuxy"},
+                        }
+                    ],
+                },
+                {"type": "branch_policy"},
+            ],
+            "deployment_branch_policy": {
+                "protected_branches": False,
+                "custom_branch_policies": True,
+            },
+        }
+        policies = [
+            {
+                "total_count": 1,
+                "branch_policies": [{"name": "v*", "type": "tag"}],
+            }
+        ]
+        result = run_environment_gate(script, valid, policies)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        for name, field, value in (
+            ("protected true", "protected_branches", True),
+            ("custom false", "custom_branch_policies", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                mutated["deployment_branch_policy"][field] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertNotIn("must be boolean", diagnostic)
+                self.assertIn(
+                    "must require exactly one approval", diagnostic
+                )
+
+        for name, field, value, missing in (
+            ("protected missing", "protected_branches", None, True),
+            ("protected null", "protected_branches", None, False),
+            ("protected string", "protected_branches", "false", False),
+            ("custom missing", "custom_branch_policies", None, True),
+            ("custom null", "custom_branch_policies", None, False),
+            ("custom string", "custom_branch_policies", "true", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                if missing:
+                    del mutated["deployment_branch_policy"][field]
+                else:
+                    mutated["deployment_branch_policy"][field] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertIn(
+                    f"deployment_branch_policy.{field} must be boolean",
+                    diagnostic,
+                )
 
     def test_privileged_publisher_requires_exact_immutable_tag_ruleset(self) -> None:
         workflow = (

--- a/scripts/ci/release_qualification_adapter.py
+++ b/scripts/ci/release_qualification_adapter.py
@@ -1123,8 +1123,8 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
         _string(item["version"], f"freebsd.inputs.{side}.version")
         _sha256(item["sha256"], f"freebsd.inputs.{side}.sha256")
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.10.txz"
-        and inputs["candidate"]["version"] == "4.02.10"
+        inputs["candidate"]["package"] == "syswarden-4.02.11.txz"
+        and inputs["candidate"]["version"] == "4.02.11"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]
@@ -1143,7 +1143,7 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
     if historical_binding_touched and not forward_only:
         _fail(
             "FreeBSD historical transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.10 contract"
+            "v4.02.8 -> v4.02.11 contract"
         )
     _string(inputs["pf_fixture"], "freebsd.inputs.pf_fixture")
     _sha256(inputs["pf_fixture_sha256"], "freebsd.inputs.pf_fixture_sha256")
@@ -1365,8 +1365,8 @@ def _validate_freebsd(
     derived_product = "pass"
     inputs = document["inputs"]
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.10.txz"
-        and inputs["candidate"]["version"] == "4.02.10"
+        inputs["candidate"]["package"] == "syswarden-4.02.11.txz"
+        and inputs["candidate"]["version"] == "4.02.11"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -494,6 +494,65 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture.save_raw("freebsd-vm-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 
+    def test_freebsd_forward_only_v40211_contract_is_exercised(self) -> None:
+        evidence = passing_evidence()
+        evidence["PF_SNAPSHOT_PROVENANCE"] = "legacy_derived"
+        evidence["PREVIOUS_PACKAGE_SHA256"] = (
+            freebsd_vm_lab.FORWARD_ONLY_PREVIOUS_SHA256
+        )
+        for phase in (
+            "CANDIDATE_UPGRADE",
+            "CANDIDATE_REINSTALL",
+            "CANDIDATE_RESTART_IDEMPOTENCE",
+        ):
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.11"
+        for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
+            evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"
+            evidence[f"{phase}_ELF_CORE_ARCH"] = "arm64"
+            evidence[f"{phase}_ELF_TUI_ARCH"] = "arm64"
+            evidence[f"{phase}_PKG_INVENTORY"] = "\n".join(
+                sorted(freebsd_vm_lab.FORWARD_ONLY_PREVIOUS_INVENTORY)
+            )
+            evidence[f"{phase}_SIGNATURE_ENGINE_COUNT"] = ""
+            evidence[f"{phase}_SIGNATURE_PROBE_RC"] = "2"
+
+        pf_fixture = self.fixture.repo / "testdata/firewall/pf-v4.02.8.conf"
+        report = freebsd_vm_lab.build_report(
+            evidence,
+            freebsd_vm_lab.PackageArtifact(
+                self.fixture.root / "syswarden-4.02.11.txz",
+                "4.02.11",
+                evidence["CANDIDATE_PACKAGE_SHA256"],
+            ),
+            freebsd_vm_lab.PackageArtifact(
+                self.fixture.root / freebsd_vm_lab.FORWARD_ONLY_PREVIOUS_PACKAGE,
+                freebsd_vm_lab.FORWARD_ONLY_PREVIOUS_VERSION,
+                freebsd_vm_lab.FORWARD_ONLY_PREVIOUS_SHA256,
+            ),
+            freebsd_vm_lab.ProductAssets(
+                self.fixture.repo,
+                pf_fixture,
+                self.fixture._digest(pf_fixture),
+                False,
+            ),
+            "127.0.0.1",
+            2222,
+            evidence["PF_ANCHOR_NAME"],
+        )
+        self.assertTrue(report["release_ready"])
+
+        with mock.patch.object(
+            adapter,
+            "_freebsd_check_passes",
+            wraps=adapter._freebsd_check_passes,
+        ) as check_passes:
+            _, _, failed = adapter._validate_freebsd_schema(report)
+        self.assertEqual(failed, [])
+        self.assertTrue(
+            any(call.args[2]["forward_only"] is True for call in check_passes.call_args_list)
+        )
+
     def test_duplicate_json_key_and_unknown_schema_key_are_rejected(self) -> None:
         path = self.fixture.raw / "nftables-raw.json"
         path.write_text(

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import subprocess
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -12,6 +17,68 @@ REPOSITORY = Path(__file__).resolve().parents[2]
 WORKFLOW = REPOSITORY / ".github" / "workflows" / "release-qualification.yml"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 ACTION = re.compile(r"(?m)^\s*uses:\s*([^@\s]+)@([^\s#]+)")
+
+
+def workflow_step_script(workflow: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    if workflow.count(marker) != 1:
+        raise AssertionError(f"expected exactly one workflow step named {step_name}")
+    step = workflow.split(marker, 1)[1].split("\n      - name:", 1)[0]
+    run_marker = "        run: |\n"
+    if step.count(run_marker) != 1:
+        raise AssertionError(f"expected one shell body for workflow step {step_name}")
+    return textwrap.dedent(step.split(run_marker, 1)[1])
+
+
+def run_environment_gate(
+    script: str,
+    environment: dict[str, object],
+    policies: list[dict[str, object]],
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        binary_directory = Path(temporary) / "bin"
+        binary_directory.mkdir()
+        gh = binary_directory / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *"/deployment-branch-policies"*)
+    printf '%s\\n' "${TEST_POLICIES_JSON:?}"
+    ;;
+  *"/environments/"*)
+    printf '%s\\n' "${TEST_ENVIRONMENT_JSON:?}"
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 64
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o700)
+        process_environment = os.environ.copy()
+        process_environment.update(
+            {
+                "GITHUB_REPOSITORY": "duggytuxy/syswarden",
+                "GITHUB_REPOSITORY_OWNER": "duggytuxy",
+                "PATH": f"{binary_directory}{os.pathsep}{process_environment['PATH']}",
+                "TEST_ENVIRONMENT_JSON": json.dumps(
+                    environment, separators=(",", ":")
+                ),
+                "TEST_POLICIES_JSON": json.dumps(policies, separators=(",", ":")),
+            }
+        )
+        return subprocess.run(
+            ["/bin/bash", "-c", script],
+            cwd=REPOSITORY,
+            env=process_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
 
 
 class ReleaseQualificationWorkflowTests(unittest.TestCase):
@@ -91,8 +158,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"${branch_policy_rule_count}" != "1"',
             '"${protection_rule_count}" != "1"',
             "must require no reviewer or wait gate",
-            ".deployment_branch_policy.protected_branches",
-            ".deployment_branch_policy.custom_branch_policies",
+            ".deployment_branch_policy[$field]",
+            "required_environment_boolean",
             "deployment-branch-policies",
             '.name == "main" and .type == "branch"',
             '"${policy_count}" != "1"',
@@ -105,6 +172,66 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertGreaterEqual(
             self.workflow.count("gh api --paginate --slurp --method GET"), 3
         )
+
+    def test_environment_boolean_gate_is_typed_and_fail_closed(self) -> None:
+        step_name = "Require Restricted Automatic Qualification Environment"
+        script = workflow_step_script(self.workflow, step_name)
+        self.assertIn("required_environment_boolean()", script)
+        self.assertIn('if type == "boolean" then', script)
+        self.assertIn("tostring", script)
+        self.assertNotIn('// "missing"', script)
+
+        valid = {
+            "name": "syswarden-release-qualification",
+            "protection_rules": [{"type": "branch_policy"}],
+            "deployment_branch_policy": {
+                "protected_branches": False,
+                "custom_branch_policies": True,
+            },
+        }
+        policies = [
+            {
+                "total_count": 1,
+                "branch_policies": [{"name": "main", "type": "branch"}],
+            }
+        ]
+        result = run_environment_gate(script, valid, policies)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        for name, field, value in (
+            ("protected true", "protected_branches", True),
+            ("custom false", "custom_branch_policies", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                mutated["deployment_branch_policy"][field] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertNotIn("must be boolean", diagnostic)
+                self.assertIn("must require no reviewer or wait gate", diagnostic)
+
+        for name, field, value, missing in (
+            ("protected missing", "protected_branches", None, True),
+            ("protected null", "protected_branches", None, False),
+            ("protected string", "protected_branches", "false", False),
+            ("custom missing", "custom_branch_policies", None, True),
+            ("custom null", "custom_branch_policies", None, False),
+            ("custom string", "custom_branch_policies", "true", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                if missing:
+                    del mutated["deployment_branch_policy"][field]
+                else:
+                    mutated["deployment_branch_policy"][field] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertIn(
+                    f"deployment_branch_policy.{field} must be boolean",
+                    diagnostic,
+                )
 
     def test_candidate_context_is_exact_main_sha_and_pre_tag(self) -> None:
         required = (

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -122,7 +122,7 @@ var installCmd = &cobra.Command{
 		fmt.Printf("    Password: %s\n", token)
 		fmt.Printf("======================================================\n\n")
 
-		fmt.Println("[SYSWARDEN] v4.02.10 Native Installation Complete.")
+		fmt.Println("[SYSWARDEN] v4.02.11 Native Installation Complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/cmd/manual.go
+++ b/src/core/syswarden-cli/cmd/manual.go
@@ -92,10 +92,10 @@ var manualCmd = &cobra.Command{
 
 		fmt.Printf("%s--- 5. SAFETY LIMITS ---%s\n", ansiYellow, ansiReset)
 		fmt.Printf("  %sRELOAD:%s the Linux nftables candidate is committed atomically and verified; compatibility-wrapper failure leaves nftables authoritative and returns an error. The core normally restarts, so keep console access and a ruleset backup.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.10. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
+		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.11. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sUNINSTALL:%s configuration, data, logs, services and firewall tables are deleted; it is not a rollback. On FreeBSD, use this command instead of raw pkg delete.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sALPINE:%s dedicated CGO-free static APK binaries are built for x86_64 and aarch64; install only an exact release-qualified artifact.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sFREEBSD:%s v4.02.10 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
+		fmt.Printf("  %sFREEBSD:%s v4.02.11 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
 
 		fmt.Printf("%s================================================================================%s\n", ansiCyan, ansiReset)
 		fmt.Printf("%sRead README.md and the command-specific --help output before a host-mutating action.%s\n", ansiWhite, ansiReset)

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.02.10
+# Version=v4.02.11
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/firewall/pf_restore_freebsd.go
+++ b/src/core/syswarden-cli/pkg/firewall/pf_restore_freebsd.go
@@ -33,7 +33,7 @@ const (
 type PFSnapshotProvenance string
 
 const (
-	// PFSnapshotExactLive records the live policy before the first v4.02.10 mutation.
+	// PFSnapshotExactLive records the live policy before the first v4.02.11 mutation.
 	PFSnapshotExactLive PFSnapshotProvenance = "exact_live"
 	// PFSnapshotLegacyDerived records only the configured policy when v4.02.8
 	// has already overwritten the live PF policy.

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.02.10", Inline: true},
+						{Name: "Version", Value: "v4.02.11", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var Version = "v4.02.10"
+var Version = "v4.02.11"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -79,7 +79,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.10 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.11 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -147,7 +147,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.10 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.11 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -359,7 +359,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.10 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.11 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.02.10"
+const SysWardenVersion = "v4.02.11"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary
- preserve real false and true GitHub environment booleans in qualification and publication gates
- supersede the unpublished v4.02.10 candidate with v4.02.11
- retarget the verified v4.02.8 first-hop contracts to v4.02.11
- add native SysWarden HIDS, HIPS and WAAP architecture diagrams and replace the BunkerWeb Mermaid contract
- publish the anonymized v4.02.11 Lot 1 source report

## Validation
- workflow boolean gate tests: 47 passed
- package and FreeBSD retarget tests: 117 passed
- documentation tests: 24 passed
- documentation truth gate: README, manual and four wiki pages passed
- CLI process compatibility: 52 passed
- targeted Go, FreeBSD cross-build, XML, YAML, ShellCheck, diff and privacy checks passed

## Release contract
- previous public release remains v4.02.8
- v4.02.10 was never tagged or published
- protected qualification must use v4.02.11, the exact merged SHA and previous tag v4.02.8
- no tag or Release is created by this PR