### PR TITLE
Patch : qualify v4.02.13

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -345,7 +345,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_stage_gate.py \
             linux --root "${STAGING_APK_ARM64}"
 
-      - name: Build Debian Package (.deb)
+      - name: Prepare Linux Maintainer Scripts
         run: |
           set -euo pipefail
           cat << 'EOF' > "${PACKAGE_SCRIPTS}/preinst.sh"
@@ -561,8 +561,28 @@ jobs:
           syswarden_cleanup_cron_work() {
               [ -n "${cron_work:-}" ] || return 0
               syswarden_cron_cleanup_target="${cron_work}"
+              if [ "${XDG_CACHE_HOME:-}" = "${syswarden_cron_cleanup_target}/cache" ]; then
+                  unset XDG_CACHE_HOME
+              fi
+              cron_cache=
+              rm -rf -- "${syswarden_cron_cleanup_target}" || return 1
+              if [ -e "${syswarden_cron_cleanup_target}" ] || [ -L "${syswarden_cron_cleanup_target}" ]; then
+                  printf '%s\n' 'private cron work directory remains after cleanup' >&2
+                  return 1
+              fi
               cron_work=
-              rm -rf -- "${syswarden_cron_cleanup_target}"
+          }
+          syswarden_prepare_cron_work() {
+              cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || return 1
+              chmod 0700 "${cron_work}" || return 1
+              cron_cache="${cron_work}/cache"
+              mkdir "${cron_cache}" || return 1
+              chmod 0700 "${cron_cache}" || return 1
+              XDG_CACHE_HOME="${cron_cache}"
+              export XDG_CACHE_HOME
+              cron_backup="${cron_work}/backup"
+              cron_error="${cron_work}/error"
+              cron_filtered="${cron_work}/filtered"
           }
           syswarden_cleanup_crontab() {
               syswarden_cron_backup="$1"
@@ -612,11 +632,7 @@ jobs:
                   trap 'syswarden_cleanup_cron_work; exit 129' 1
                   trap 'syswarden_cleanup_cron_work; exit 130' 2
                   trap 'syswarden_cleanup_cron_work; exit 143' 15
-                  cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || return 1
-                  chmod 0700 "${cron_work}" || return 1
-                  cron_backup="${cron_work}/backup"
-                  cron_error="${cron_work}/error"
-                  cron_filtered="${cron_work}/filtered"
+                  syswarden_prepare_cron_work || return 1
                   syswarden_cleanup_crontab \
                       "${cron_backup}" "${cron_error}" "${cron_filtered}" \
                       /opt/syswarden/bin/syswarden-cli || return 1
@@ -726,8 +742,28 @@ jobs:
           syswarden_cleanup_cron_work() {
               [ -n "${cron_work:-}" ] || return 0
               syswarden_cron_cleanup_target="${cron_work}"
+              if [ "${XDG_CACHE_HOME:-}" = "${syswarden_cron_cleanup_target}/cache" ]; then
+                  unset XDG_CACHE_HOME
+              fi
+              cron_cache=
+              rm -rf -- "${syswarden_cron_cleanup_target}" || return 1
+              if [ -e "${syswarden_cron_cleanup_target}" ] || [ -L "${syswarden_cron_cleanup_target}" ]; then
+                  printf '%s\n' 'private cron work directory remains after cleanup' >&2
+                  return 1
+              fi
               cron_work=
-              rm -rf -- "${syswarden_cron_cleanup_target}"
+          }
+          syswarden_prepare_cron_work() {
+              cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || return 1
+              chmod 0700 "${cron_work}" || return 1
+              cron_cache="${cron_work}/cache"
+              mkdir "${cron_cache}" || return 1
+              chmod 0700 "${cron_cache}" || return 1
+              XDG_CACHE_HOME="${cron_cache}"
+              export XDG_CACHE_HOME
+              cron_backup="${cron_work}/backup"
+              cron_error="${cron_work}/error"
+              cron_filtered="${cron_work}/filtered"
           }
           syswarden_cleanup_crontab() {
               syswarden_cron_backup="$1"
@@ -784,14 +820,10 @@ jobs:
               trap 'syswarden_cleanup_cron_work; exit 129' 1
               trap 'syswarden_cleanup_cron_work; exit 130' 2
               trap 'syswarden_cleanup_cron_work; exit 143' 15
-              cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || {
+              syswarden_prepare_cron_work || {
                   echo "Unable to create the private cron backup" >&2
                   exit 1
               }
-              chmod 0700 "${cron_work}" || exit 1
-              cron_backup="${cron_work}/backup"
-              cron_error="${cron_work}/error"
-              cron_filtered="${cron_work}/filtered"
               syswarden_cleanup_crontab \
                   "${cron_backup}" "${cron_error}" "${cron_filtered}" \
                   /opt/syswarden/bin/syswarden-cli || exit 1
@@ -808,6 +840,9 @@ jobs:
             "${PACKAGE_SCRIPTS}/postrm.sh" \
             "${PACKAGE_SCRIPTS}/prerm.sh"
 
+      - name: Build Debian Package (.deb)
+        run: |
+          set -euo pipefail
           fpm -s dir -t deb \
             -n syswarden \
             -v "${VERSION}" \
@@ -897,6 +932,7 @@ jobs:
           homepage: "https://github.com/${{ github.repository }}"
           depends:
             - nftables
+            - openrc
             - curl
             - wget
             - rsyslog
@@ -915,6 +951,9 @@ jobs:
             postinstall: "${PACKAGE_SCRIPTS}/postinst.sh"
             preremove: "${PACKAGE_SCRIPTS}/prerm.sh"
             postremove: "${PACKAGE_SCRIPTS}/postrm.sh"
+          apk:
+            scripts:
+              postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"
           EOF
 
           cat << EOF > "${PACKAGE_CONFIGS}/nfpm_alpine_aarch64.yaml"
@@ -928,6 +967,7 @@ jobs:
           homepage: "https://github.com/${{ github.repository }}"
           depends:
             - nftables
+            - openrc
             - curl
             - wget
             - rsyslog
@@ -946,6 +986,9 @@ jobs:
             postinstall: "${PACKAGE_SCRIPTS}/postinst.sh"
             preremove: "${PACKAGE_SCRIPTS}/prerm.sh"
             postremove: "${PACKAGE_SCRIPTS}/postrm.sh"
+          apk:
+            scripts:
+              postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"
           EOF
 
           "${TOOL_DIR}/nfpm" pkg \
@@ -1189,8 +1232,28 @@ jobs:
           syswarden_cleanup_cron_work() {
               [ -n "${cron_work:-}" ] || return 0
               syswarden_cron_cleanup_target="${cron_work}"
+              if [ "${XDG_CACHE_HOME:-}" = "${syswarden_cron_cleanup_target}/cache" ]; then
+                  unset XDG_CACHE_HOME
+              fi
+              cron_cache=
+              rm -rf -- "${syswarden_cron_cleanup_target}" || return 1
+              if [ -e "${syswarden_cron_cleanup_target}" ] || [ -L "${syswarden_cron_cleanup_target}" ]; then
+                  printf '%s\n' 'private cron work directory remains after cleanup' >&2
+                  return 1
+              fi
               cron_work=
-              rm -rf -- "${syswarden_cron_cleanup_target}"
+          }
+          syswarden_prepare_cron_work() {
+              cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || return 1
+              chmod 0700 "${cron_work}" || return 1
+              cron_cache="${cron_work}/cache"
+              mkdir "${cron_cache}" || return 1
+              chmod 0700 "${cron_cache}" || return 1
+              XDG_CACHE_HOME="${cron_cache}"
+              export XDG_CACHE_HOME
+              cron_backup="${cron_work}/backup"
+              cron_error="${cron_work}/error"
+              cron_filtered="${cron_work}/filtered"
           }
           syswarden_cleanup_crontab() {
               syswarden_cron_backup="$1"
@@ -1226,11 +1289,7 @@ jobs:
               trap 'syswarden_cleanup_cron_work; exit 129' 1
               trap 'syswarden_cleanup_cron_work; exit 130' 2
               trap 'syswarden_cleanup_cron_work; exit 143' 15
-              cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || exit 1
-              chmod 0700 "${cron_work}" || exit 1
-              cron_backup="${cron_work}/backup"
-              cron_error="${cron_work}/error"
-              cron_filtered="${cron_work}/filtered"
+              syswarden_prepare_cron_work || exit 1
               syswarden_cleanup_crontab \
                   "${cron_backup}" "${cron_error}" "${cron_filtered}" \
                   /usr/local/syswarden/bin/syswarden-cli \
@@ -1328,11 +1387,25 @@ jobs:
             local metadata
             local package_version
             local package_architecture
+            local -a postinstall_members=()
+            local -a postupgrade_members=()
             member="$(tar --list --file "${path}" | awk '/(^|\/)\.PKGINFO$/ { print }')"
             [[ "$(wc -l <<< "${member}")" -eq 1 ]]
             metadata="$(tar --extract --to-stdout --file "${path}" "${member}")"
             [[ "$(grep --count '^pkgver = ' <<< "${metadata}")" -eq 1 ]]
             [[ "$(grep --count '^arch = ' <<< "${metadata}")" -eq 1 ]]
+            [[ "$(grep --count '^depend = openrc$' <<< "${metadata}")" -eq 1 ]]
+            mapfile -t postinstall_members < <(
+              tar --list --file "${path}" | awk '/(^|\/)\.post-install$/ { print }'
+            )
+            mapfile -t postupgrade_members < <(
+              tar --list --file "${path}" | awk '/(^|\/)\.post-upgrade$/ { print }'
+            )
+            [[ "${#postinstall_members[@]}" -eq 1 ]]
+            [[ "${#postupgrade_members[@]}" -eq 1 ]]
+            cmp -s \
+              <(tar --extract --to-stdout --file "${path}" "${postinstall_members[0]}") \
+              <(tar --extract --to-stdout --file "${path}" "${postupgrade_members[0]}")
             package_version="$(sed -n 's/^pkgver = //p' <<< "${metadata}")"
             package_architecture="$(sed -n 's/^arch = //p' <<< "${metadata}")"
             python3 - "${VERSION}" "${package_version}" <<'PY'

--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -675,7 +675,13 @@ jobs:
           test -z "$(find "${QUALIFICATION_ROOT}" -mindepth 1 ! -type f ! -type d -print -quit)"
           qualification_root_directories=(aggregate bound packages raw status)
           qualification_all_directories=(aggregate bound packages packages/candidate packages/previous raw status)
-          qualification_raw_files=(freebsd-vm-raw.json nftables-raw.json package-lifecycle-raw.json)
+          qualification_raw_files=(
+            freebsd-vm-raw.json
+            nftables-raw.json
+            package-lifecycle-amd64.json
+            package-lifecycle-arm64.json
+            package-lifecycle-raw.json
+          )
           if [[ "${SIGNED_UPDATE_REQUIRED}" == "true" ]]; then
             qualification_root_directories+=(tools update)
             qualification_all_directories+=(tools update)
@@ -786,6 +792,14 @@ jobs:
               (.id | type) == "number" and .id > 0 and
               (.name | type) == "string" and (.name | length) > 0
             )' "${QUALIFICATION_ROOT}/qualification-context.json"
+          candidate_run_id="$(jq -r '.candidate_package_run_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          candidate_artifact_id="$(jq -r '.candidate_package_artifact_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          candidate_artifact_name="$(jq -r '.candidate_package_artifact_name' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          previous_release_id="$(jq -r '.previous_release_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
           jq --exit-status \
             --argjson signed_update_required "${SIGNED_UPDATE_REQUIRED}" '
             (keys | sort) == (if $signed_update_required then [
@@ -817,7 +831,16 @@ jobs:
             --previous-packages-dir "${QUALIFICATION_ROOT}/packages/previous" \
             --nft-raw "${QUALIFICATION_ROOT}/raw/nftables-raw.json" \
             --package-raw "${QUALIFICATION_ROOT}/raw/package-lifecycle-raw.json" \
+            --package-amd64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-amd64.json" \
+            --package-arm64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-arm64.json" \
             --freebsd-raw "${QUALIFICATION_ROOT}/raw/freebsd-vm-raw.json" \
+            --expected-repository "${GITHUB_REPOSITORY}" \
+            --expected-workflow-run-id "${QUALIFICATION_RUN_ID}" \
+            --expected-workflow-run-attempt 1 \
+            --expected-candidate-run-id "${candidate_run_id}" \
+            --expected-candidate-artifact-id "${candidate_artifact_id}" \
+            --expected-candidate-artifact-name "${candidate_artifact_name}" \
+            --expected-previous-release-id "${previous_release_id}" \
             --max-age-seconds 172800 \
             --max-report-skew-seconds 0 \
             --nft-envelope "${QUALIFICATION_ROOT}/bound/nftables-bound.json" \
@@ -936,6 +959,17 @@ jobs:
               end
             ' <<< "${environment_json}"
           }
+          required_top_level_environment_boolean() {
+            local field="${1:?environment boolean field is required}"
+            jq -er --arg field "${field}" '
+              .[$field] |
+              if type == "boolean" then
+                tostring
+              else
+                error($field + " must be boolean")
+              end
+            ' <<< "${environment_json}"
+          }
           environment_name="$(jq -r '.name // ""' <<< "${environment_json}")"
           reviewer_rule_count="$(jq --arg owner "${GITHUB_REPOSITORY_OWNER}" '[
             .protection_rules[]? |
@@ -957,13 +991,16 @@ jobs:
             "protected_branches")"
           custom_branch_policies="$(required_environment_boolean \
             "custom_branch_policies")"
+          can_admins_bypass="$(required_top_level_environment_boolean \
+            "can_admins_bypass")"
           if [[ "${environment_name}" != "syswarden-release-production" || \
                 "${reviewer_rule_count}" != "1" || \
                 "${branch_policy_rule_count}" != "1" || \
                 "${protection_rule_count}" != "2" || \
                 "${protected_branches}" != "false" || \
-                "${custom_branch_policies}" != "true" ]]; then
-            echo "ERROR: syswarden-release-production must require exactly one approval from the repository owner and one custom tag policy." >&2
+                "${custom_branch_policies}" != "true" || \
+                "${can_admins_bypass}" != "false" ]]; then
+            echo "ERROR: syswarden-release-production must forbid administrator bypass, require exactly one approval from the repository owner, and allow one custom tag policy." >&2
             echo "Publication is blocked until the maintainer configures that GitHub Environment." >&2
             exit 1
           fi
@@ -1173,7 +1210,13 @@ jobs:
           test -z "$(find "${QUALIFICATION_ROOT}" -mindepth 1 ! -type f ! -type d -print -quit)"
           qualification_root_directories=(aggregate bound packages raw status)
           qualification_all_directories=(aggregate bound packages packages/candidate packages/previous raw status)
-          qualification_raw_files=(freebsd-vm-raw.json nftables-raw.json package-lifecycle-raw.json)
+          qualification_raw_files=(
+            freebsd-vm-raw.json
+            nftables-raw.json
+            package-lifecycle-amd64.json
+            package-lifecycle-arm64.json
+            package-lifecycle-raw.json
+          )
           if [[ "${SIGNED_UPDATE_REQUIRED}" == "true" ]]; then
             qualification_root_directories+=(tools update)
             qualification_all_directories+=(tools update)
@@ -1284,6 +1327,14 @@ jobs:
               (.id | type) == "number" and .id > 0 and
               (.name | type) == "string" and (.name | length) > 0
             )' "${QUALIFICATION_ROOT}/qualification-context.json"
+          candidate_run_id="$(jq -r '.candidate_package_run_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          candidate_artifact_id="$(jq -r '.candidate_package_artifact_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          candidate_artifact_name="$(jq -r '.candidate_package_artifact_name' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
+          previous_release_id="$(jq -r '.previous_release_id' \
+            "${QUALIFICATION_ROOT}/qualification-context.json")"
           jq --exit-status \
             --argjson signed_update_required "${SIGNED_UPDATE_REQUIRED}" '
             (keys | sort) == (if $signed_update_required then [
@@ -1315,7 +1366,16 @@ jobs:
             --previous-packages-dir "${QUALIFICATION_ROOT}/packages/previous" \
             --nft-raw "${QUALIFICATION_ROOT}/raw/nftables-raw.json" \
             --package-raw "${QUALIFICATION_ROOT}/raw/package-lifecycle-raw.json" \
+            --package-amd64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-amd64.json" \
+            --package-arm64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-arm64.json" \
             --freebsd-raw "${QUALIFICATION_ROOT}/raw/freebsd-vm-raw.json" \
+            --expected-repository "${GITHUB_REPOSITORY}" \
+            --expected-workflow-run-id "${QUALIFICATION_RUN_ID}" \
+            --expected-workflow-run-attempt 1 \
+            --expected-candidate-run-id "${candidate_run_id}" \
+            --expected-candidate-artifact-id "${candidate_artifact_id}" \
+            --expected-candidate-artifact-name "${candidate_artifact_name}" \
+            --expected-previous-release-id "${previous_release_id}" \
             --max-age-seconds 172800 \
             --max-report-skew-seconds 0 \
             --nft-envelope "${QUALIFICATION_ROOT}/bound/nftables-bound.json" \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -28,8 +28,323 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  package-lifecycle-arm64:
+    name: Native ARM64 Package Lifecycle Shard
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      artifact_name: ${{ steps.seal.outputs.artifact_name }}
+      report_sha256: ${{ steps.seal.outputs.report_sha256 }}
+      candidate_run_id: ${{ steps.candidate.outputs.run_id }}
+      candidate_artifact_id: ${{ steps.candidate.outputs.artifact_id }}
+      candidate_artifact_name: ${{ steps.candidate.outputs.artifact_name }}
+      previous_release_id: ${{ steps.previous.outputs.release_id }}
+
+    steps:
+      - name: Checkout Exact ARM64 Candidate Commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.release_sha }}
+
+      - name: Validate Native ARM64 Shard Context
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_REF_NAME: ${{ github.ref_name }}
+          EVENT_REF_TYPE: ${{ github.ref_type }}
+          EVENT_SHA: ${{ github.sha }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" != "workflow_dispatch" || \
+                "${EVENT_REF_TYPE}" != "branch" || \
+                "${EVENT_REF_NAME}" != "main" || \
+                "${EVENT_REF}" != "refs/heads/main" || \
+                "${EVENT_SHA}" != "${RELEASE_SHA}" || \
+                ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ || \
+                ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]{2}\.[0-9]+$ || \
+                ! "${PREVIOUS_TAG}" =~ ^v[0-9]+\.[0-9]{2}\.[0-9]+$ || \
+                "${RELEASE_TAG}" == "${PREVIOUS_TAG}" ]]; then
+            echo "ERROR: native ARM64 qualification context is not the exact main candidate." >&2
+            exit 1
+          fi
+          test "$(git rev-parse --verify 'HEAD^{commit}')" = "${RELEASE_SHA}"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$(./scripts/versioning.sh inspect --repo "${GITHUB_WORKSPACE}")" = \
+            "${RELEASE_TAG}"
+          test "$(uname -m)" = "aarch64"
+          command -v gh >/dev/null
+          command -v jq >/dev/null
+          command -v podman >/dev/null
+          command -v python3 >/dev/null
+          command -v sha256sum >/dev/null
+
+      - name: Create Native ARM64 Shard Workspace
+        id: arm_workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          test -n "${RUNNER_TEMP:-}"
+          test -d "${RUNNER_TEMP}"
+          test ! -L "${RUNNER_TEMP}"
+          shard_root="$(mktemp -d \
+            "${RUNNER_TEMP%/}/syswarden-package-arm64.XXXXXX")"
+          candidate_packages="${shard_root}/packages/candidate"
+          previous_packages="${shard_root}/packages/previous"
+          evidence_dir="${shard_root}/evidence"
+          install -d -m 0700 \
+            "${candidate_packages}" \
+            "${previous_packages}" \
+            "${evidence_dir}"
+          {
+            printf 'SHARD_ROOT=%s\n' "${shard_root}"
+            printf 'ARM_CANDIDATE_PACKAGES_DIR=%s\n' "${candidate_packages}"
+            printf 'ARM_PREVIOUS_PACKAGES_DIR=%s\n' "${previous_packages}"
+            printf 'ARM_EVIDENCE_DIR=%s\n' "${evidence_dir}"
+          } >> "${GITHUB_ENV}"
+          {
+            printf 'candidate_packages_dir=%s\n' "${candidate_packages}"
+            printf 'previous_packages_dir=%s\n' "${previous_packages}"
+            printf 'evidence_dir=%s\n' "${evidence_dir}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve Exact ARM64 Candidate Package Artifact
+        id: candidate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          runs_json="$(gh api --paginate --slurp --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/package.yml/runs" \
+            -f event=push \
+            -f head_sha="${RELEASE_SHA}" \
+            -f per_page=100)"
+          matches="$(jq --arg sha "${RELEASE_SHA}" '[
+            .[] | .workflow_runs[]? |
+            select(
+              .head_sha == $sha and
+              .head_branch == "main" and
+              .event == "push"
+            )
+          ]' <<< "${runs_json}")"
+          if [[ "$(jq 'length' <<< "${matches}")" != "1" ]]; then
+            echo "ERROR: expected one ARM64 source package run for ${RELEASE_SHA}." >&2
+            exit 1
+          fi
+          run_id="$(jq -r '.[0].id' <<< "${matches}")"
+          run_status="$(jq -r '.[0].status' <<< "${matches}")"
+          run_conclusion="$(jq -r '.[0].conclusion // ""' <<< "${matches}")"
+          if [[ ! "${run_id}" =~ ^[0-9]+$ || \
+                "${run_status}" != "completed" || \
+                "${run_conclusion}" != "success" ]]; then
+            echo "ERROR: exact ARM64 source package run is not a completed success." >&2
+            exit 1
+          fi
+          artifact_name="syswarden-packages-${version}"
+          artifacts_json="$(gh api --paginate --slurp --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
+            -f per_page=100)"
+          artifact_matches="$(jq --arg name "${artifact_name}" '[
+            .[] | .artifacts[]? | select(.name == $name)
+          ]' <<< "${artifacts_json}")"
+          if [[ "$(jq 'length' <<< "${artifact_matches}")" != "1" ]]; then
+            echo "ERROR: exact ARM64 source artifact is absent or ambiguous." >&2
+            exit 1
+          fi
+          artifact_id="$(jq -r '.[0].id' <<< "${artifact_matches}")"
+          expired="$(jq -r '.[0].expired' <<< "${artifact_matches}")"
+          size="$(jq -r '.[0].size_in_bytes' <<< "${artifact_matches}")"
+          if [[ ! "${artifact_id}" =~ ^[0-9]+$ || \
+                "${expired}" != "false" || \
+                ! "${size}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: exact ARM64 source artifact is expired, empty, or malformed." >&2
+            exit 1
+          fi
+          {
+            printf 'run_id=%s\n' "${run_id}"
+            printf 'artifact_id=%s\n' "${artifact_id}"
+            printf 'artifact_name=%s\n' "${artifact_name}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Download Exact ARM64 Candidate Packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.candidate.outputs.artifact_name }}
+          path: ${{ steps.arm_workspace.outputs.candidate_packages_dir }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.candidate.outputs.run_id }}
+
+      - name: Verify Exact ARM64 Candidate Package Inventory
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/release_gate.py \
+            verify-packages \
+            --tag "${RELEASE_TAG}" \
+            --packages "${ARM_CANDIDATE_PACKAGES_DIR}"
+
+      - name: Download Exact ARM64 Previous Packages
+        id: previous
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+        run: |
+          set -euo pipefail
+          umask 077
+          previous_version="${PREVIOUS_TAG#v}"
+          release_json="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/releases/latest")"
+          release_id="$(jq -r '.id' <<< "${release_json}")"
+          if [[ "$(jq -r '.tag_name' <<< "${release_json}")" != "${PREVIOUS_TAG}" || \
+                "$(jq -r '.draft' <<< "${release_json}")" != "false" || \
+                "$(jq -r '.prerelease' <<< "${release_json}")" != "false" || \
+                "$(jq -r '.published_at // ""' <<< "${release_json}")" == "" || \
+                ! "${release_id}" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: ARM64 previous_tag is not the latest public release." >&2
+            exit 1
+          fi
+          assets_json="$(gh api --paginate --slurp --method GET \
+            "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets" \
+            -f per_page=100)"
+          expected_assets=(
+            "syswarden_${previous_version}_amd64.deb"
+            "syswarden_${previous_version}_arm64.deb"
+            "syswarden-${previous_version}-1.x86_64.rpm"
+            "syswarden-${previous_version}-1.aarch64.rpm"
+            "syswarden_${previous_version}_x86_64.apk"
+            "syswarden_${previous_version}_aarch64.apk"
+            "syswarden-${previous_version}.txz"
+            "SHA256SUMS.txt"
+          )
+          for asset_name in "${expected_assets[@]}"; do
+            matches="$(jq --arg name "${asset_name}" '[
+              .[] | .[] | select(.name == $name)
+            ]' <<< "${assets_json}")"
+            if [[ "$(jq 'length' <<< "${matches}")" != "1" ]]; then
+              echo "ERROR: ARM64 previous asset ${asset_name} is absent or ambiguous." >&2
+              exit 1
+            fi
+            asset_id="$(jq -r '.[0].id' <<< "${matches}")"
+            asset_state="$(jq -r '.[0].state' <<< "${matches}")"
+            asset_size="$(jq -r '.[0].size' <<< "${matches}")"
+            if [[ ! "${asset_id}" =~ ^[0-9]+$ || \
+                  "${asset_state}" != "uploaded" || \
+                  ! "${asset_size}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "ERROR: ARM64 previous asset ${asset_name} is invalid." >&2
+              exit 1
+            fi
+            destination="${ARM_PREVIOUS_PACKAGES_DIR}/${asset_name}"
+            gh api --method GET \
+              -H 'Accept: application/octet-stream' \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
+              > "${destination}"
+            test -s "${destination}"
+            test -f "${destination}"
+            test ! -L "${destination}"
+            chmod 0600 "${destination}"
+          done
+          printf 'release_id=%s\n' "${release_id}" >> "${GITHUB_OUTPUT}"
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/release_gate.py \
+            verify-packages \
+            --tag "${PREVIOUS_TAG}" \
+            --packages "${ARM_PREVIOUS_PACKAGES_DIR}"
+
+      - name: Run Native ARM64 Package Lifecycle Shard
+        shell: bash
+        env:
+          CANDIDATE_ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
+          CANDIDATE_ARTIFACT_NAME: ${{ steps.candidate.outputs.artifact_name }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
+          PREVIOUS_RELEASE_ID: ${{ steps.previous.outputs.release_id }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          set +e
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
+            --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
+            --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \
+            --architecture-shard arm64 \
+            --qualification-repository "${GITHUB_REPOSITORY}" \
+            --qualification-release-sha "${RELEASE_SHA}" \
+            --qualification-release-tag "${RELEASE_TAG}" \
+            --qualification-previous-tag "${PREVIOUS_TAG}" \
+            --qualification-workflow-run-id "${GITHUB_RUN_ID}" \
+            --qualification-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --qualification-candidate-run-id "${CANDIDATE_RUN_ID}" \
+            --qualification-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}" \
+            --qualification-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}" \
+            --qualification-previous-release-id "${PREVIOUS_RELEASE_ID}" \
+            --pull-policy always \
+            --output "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json" \
+            --pretty
+          shard_rc=$?
+          set -e
+          printf '%s\n' "${shard_rc}" > \
+            "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
+          chmod 0600 "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
+
+      - name: Seal Native ARM64 Package Lifecycle Shard
+        id: seal
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          umask 077
+          report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"
+          status="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
+          for path in "${report}" "${status}"; do
+            test -s "${path}"
+            test -f "${path}"
+            test ! -L "${path}"
+          done
+          report_sha256="$(sha256sum "${report}")"
+          report_sha256="${report_sha256%% *}"
+          [[ "${report_sha256}" =~ ^[0-9a-f]{64}$ ]]
+          (
+            cd "${ARM_EVIDENCE_DIR}"
+            sha256sum \
+              package-lifecycle-arm64.json \
+              package-lifecycle-arm64.rc > SHA256SUMS.txt
+            sha256sum --check --strict SHA256SUMS.txt
+          )
+          artifact_name="syswarden-package-lifecycle-arm64-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"
+          {
+            printf 'artifact_name=%s\n' "${artifact_name}"
+            printf 'report_sha256=%s\n' "${report_sha256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload Native ARM64 Package Lifecycle Shard
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.seal.outputs.artifact_name }}
+          path: ${{ steps.arm_workspace.outputs.evidence_dir }}
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0
+
   qualify-release:
     name: Qualify Exact Pre-Tag Commit
+    needs: package-lifecycle-arm64
     runs-on:
       - self-hosted
       - linux
@@ -64,6 +379,17 @@ jobs:
               end
             ' <<< "${environment_json}"
           }
+          required_top_level_environment_boolean() {
+            local field="${1:?environment boolean field is required}"
+            jq -er --arg field "${field}" '
+              .[$field] |
+              if type == "boolean" then
+                tostring
+              else
+                error($field + " must be boolean")
+              end
+            ' <<< "${environment_json}"
+          }
           environment_name="$(jq -r '.name // ""' <<< "${environment_json}")"
           reviewer_rule_count="$(jq '[
             .protection_rules[]? | select(.type == "required_reviewers")
@@ -77,13 +403,16 @@ jobs:
             "protected_branches")"
           custom_branch_policies="$(required_environment_boolean \
             "custom_branch_policies")"
+          can_admins_bypass="$(required_top_level_environment_boolean \
+            "can_admins_bypass")"
           if [[ "${environment_name}" != "syswarden-release-qualification" || \
                 "${reviewer_rule_count}" != "0" || \
                 "${branch_policy_rule_count}" != "1" || \
                 "${protection_rule_count}" != "1" || \
                 "${protected_branches}" != "false" || \
-                "${custom_branch_policies}" != "true" ]]; then
-            echo "ERROR: the qualification environment must require no reviewer or wait gate and exactly one custom branch policy." >&2
+                "${custom_branch_policies}" != "true" || \
+                "${can_admins_bypass}" != "false" ]]; then
+            echo "ERROR: the qualification environment must require no reviewer or wait gate, forbid administrator bypass, and have exactly one custom branch policy." >&2
             exit 1
           fi
 
@@ -190,8 +519,6 @@ jobs:
       - name: Create Isolated Qualification Workspace
         id: workspace
         shell: bash
-        env:
-          QEMU_AARCH64_STATIC: ${{ vars.SYSWARDEN_QEMU_AARCH64_STATIC }}
         run: |
           set -euo pipefail
           umask 077
@@ -244,31 +571,6 @@ jobs:
             "${secrets_dir}" \
             "${signing_tool_dir}"
 
-          if [[ -z "${QEMU_AARCH64_STATIC}" || \
-                "${QEMU_AARCH64_STATIC}" != /* || \
-                ! -f "${QEMU_AARCH64_STATIC}" || \
-                -L "${QEMU_AARCH64_STATIC}" || \
-                ! -x "${QEMU_AARCH64_STATIC}" ]]; then
-            echo "ERROR: SYSWARDEN_QEMU_AARCH64_STATIC must name an absolute, executable, non-symlink regular file." >&2
-            exit 1
-          fi
-          binfmt_entry=/proc/sys/fs/binfmt_misc/qemu-aarch64
-          if [[ ! -f "${binfmt_entry}" || -L "${binfmt_entry}" ]]; then
-            echo "ERROR: the dedicated runner has no trustworthy aarch64 binfmt registration." >&2
-            exit 1
-          fi
-          mapfile -t binfmt_interpreters < <(
-            sed -n 's/^interpreter //p' "${binfmt_entry}"
-          )
-          binfmt_flags="$(sed -n 's/^flags: //p' "${binfmt_entry}")"
-          if ! grep -Fxq enabled "${binfmt_entry}" || \
-             [[ "${#binfmt_interpreters[@]}" -ne 1 ]] || \
-             [[ "${binfmt_interpreters[0]}" != "${QEMU_AARCH64_STATIC}" ]] || \
-             [[ "${binfmt_flags}" != *F* ]]; then
-            echo "ERROR: aarch64 binfmt must be enabled with the exact QEMU interpreter and fix-binary flag." >&2
-            exit 1
-          fi
-
           {
             printf 'QUALIFICATION_ROOT=%s\n' "${qualification_root}"
             printf 'ARTIFACT_ROOT=%s\n' "${artifact_root}"
@@ -281,12 +583,18 @@ jobs:
             printf 'STATUS_DIR=%s\n' "${status_dir}"
             printf 'SECRETS_DIR=%s\n' "${secrets_dir}"
             printf 'SIGNING_TOOL_DIR=%s\n' "${signing_tool_dir}"
-            printf 'QEMU_AARCH64_STATIC=%s\n' "${QEMU_AARCH64_STATIC}"
           } >> "${GITHUB_ENV}"
           {
+            printf 'qualification_root=%s\n' "${qualification_root}"
             printf 'artifact_root=%s\n' "${artifact_root}"
             printf 'candidate_packages_dir=%s\n' "${candidate_packages}"
           } >> "${GITHUB_OUTPUT}"
+
+      - name: Download Exact Native ARM64 Lifecycle Shard
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.package-lifecycle-arm64.outputs.artifact_name }}
+          path: ${{ steps.workspace.outputs.qualification_root }}/arm64-shard
 
       - name: Resolve Unique Successful Main Package Artifact
         id: candidate
@@ -552,22 +860,110 @@ jobs:
             }' > "${ARTIFACT_ROOT}/qualification-context.json"
           chmod 0600 "${ARTIFACT_ROOT}/qualification-context.json"
 
-      - name: Run Linux Package Lifecycle Laboratory
+      - name: Verify and Aggregate Native Package Lifecycle Shards
         shell: bash
+        env:
+          ARM_ARTIFACT_NAME: ${{ needs.package-lifecycle-arm64.outputs.artifact_name }}
+          ARM_CANDIDATE_ARTIFACT_ID: ${{ needs.package-lifecycle-arm64.outputs.candidate_artifact_id }}
+          ARM_CANDIDATE_ARTIFACT_NAME: ${{ needs.package-lifecycle-arm64.outputs.candidate_artifact_name }}
+          ARM_CANDIDATE_RUN_ID: ${{ needs.package-lifecycle-arm64.outputs.candidate_run_id }}
+          ARM_PREVIOUS_RELEASE_ID: ${{ needs.package-lifecycle-arm64.outputs.previous_release_id }}
+          ARM_REPORT_SHA256: ${{ needs.package-lifecycle-arm64.outputs.report_sha256 }}
+          CANDIDATE_ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
+          CANDIDATE_ARTIFACT_NAME: ${{ steps.candidate.outputs.artifact_name }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
+          PREVIOUS_RELEASE_ID: ${{ steps.previous.outputs.release_id }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+          arm_dir="${QUALIFICATION_ROOT}/arm64-shard"
+          expected_arm_artifact="syswarden-package-lifecycle-arm64-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"
+          if [[ "${ARM_ARTIFACT_NAME}" != "${expected_arm_artifact}" || \
+                "${ARM_CANDIDATE_RUN_ID}" != "${CANDIDATE_RUN_ID}" || \
+                "${ARM_CANDIDATE_ARTIFACT_ID}" != "${CANDIDATE_ARTIFACT_ID}" || \
+                "${ARM_CANDIDATE_ARTIFACT_NAME}" != "${CANDIDATE_ARTIFACT_NAME}" || \
+                "${ARM_PREVIOUS_RELEASE_ID}" != "${PREVIOUS_RELEASE_ID}" || \
+                ! "${ARM_REPORT_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "ERROR: native ARM64 shard provenance differs from the exact qualification inputs." >&2
+            exit 1
+          fi
+          mapfile -t arm_files < <(
+            find -P "${arm_dir}" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' |
+              LC_ALL=C sort
+          )
+          expected_arm_files=(
+            SHA256SUMS.txt
+            package-lifecycle-arm64.json
+            package-lifecycle-arm64.rc
+          )
+          if [[ "${arm_files[*]}" != "${expected_arm_files[*]}" ]]; then
+            echo "ERROR: native ARM64 shard inventory is not exact." >&2
+            exit 1
+          fi
+          while IFS= read -r -d '' entry; do
+            test -f "${entry}"
+            test ! -L "${entry}"
+          done < <(find -P "${arm_dir}" -mindepth 1 -maxdepth 1 -print0)
+          (
+            cd "${arm_dir}"
+            sha256sum --check --strict SHA256SUMS.txt
+          )
+          actual_arm_sha256="$(sha256sum \
+            "${arm_dir}/package-lifecycle-arm64.json")"
+          actual_arm_sha256="${actual_arm_sha256%% *}"
+          test "${actual_arm_sha256}" = "${ARM_REPORT_SHA256}"
+          arm_rc="$(cat "${arm_dir}/package-lifecycle-arm64.rc")"
+          [[ "${arm_rc}" =~ ^[0-9]+$ ]]
+          install -m 0600 \
+            "${arm_dir}/package-lifecycle-arm64.json" \
+            "${RAW_DIR}/package-lifecycle-arm64.json"
+
+          common_binding_arguments=(
+            --qualification-repository "${GITHUB_REPOSITORY}"
+            --qualification-release-sha "${RELEASE_SHA}"
+            --qualification-release-tag "${RELEASE_TAG}"
+            --qualification-previous-tag "${PREVIOUS_TAG}"
+            --qualification-workflow-run-id "${GITHUB_RUN_ID}"
+            --qualification-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}"
+            --qualification-candidate-run-id "${CANDIDATE_RUN_ID}"
+            --qualification-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}"
+            --qualification-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}"
+            --qualification-previous-release-id "${PREVIOUS_RELEASE_ID}"
+          )
           set +e
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
             --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
-            --arm64-emulator "${QEMU_AARCH64_STATIC}" \
+            --architecture-shard amd64 \
+            "${common_binding_arguments[@]}" \
             --pull-policy never \
+            --output "${RAW_DIR}/package-lifecycle-amd64.json" \
+            --pretty
+          amd64_rc=$?
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
+            --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
+            --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
+            --aggregate-amd64-report "${RAW_DIR}/package-lifecycle-amd64.json" \
+            --aggregate-arm64-report "${RAW_DIR}/package-lifecycle-arm64.json" \
+            "${common_binding_arguments[@]}" \
             --output "${RAW_DIR}/package-lifecycle-raw.json" \
             --pretty
-          laboratory_rc=$?
+          aggregate_rc=$?
           set -e
-          printf '%s\n' "${laboratory_rc}" > "${STATUS_DIR}/package-lab.rc"
-          chmod 0600 "${STATUS_DIR}/package-lab.rc"
+          if [[ "${aggregate_rc}" -eq 0 && "${amd64_rc}" -ne 0 ]] || \
+             [[ "${aggregate_rc}" -eq 0 && "${arm_rc}" -ne 0 ]]; then
+            echo "ERROR: a native shard returned nonzero while the aggregate claimed success." >&2
+            aggregate_rc=97
+          fi
+          printf '%s\n' "${amd64_rc}" > "${STATUS_DIR}/package-lab-amd64.rc"
+          printf '%s\n' "${arm_rc}" > "${STATUS_DIR}/package-lab-arm64.rc"
+          printf '%s\n' "${aggregate_rc}" > "${STATUS_DIR}/package-lab.rc"
+          chmod 0600 \
+            "${STATUS_DIR}/package-lab-amd64.rc" \
+            "${STATUS_DIR}/package-lab-arm64.rc" \
+            "${STATUS_DIR}/package-lab.rc"
 
       - name: Prepare Ephemeral FreeBSD Transport Secrets
         shell: bash
@@ -647,6 +1043,10 @@ jobs:
       - name: Build and Verify Bound Laboratory Envelopes
         shell: bash
         env:
+          CANDIDATE_ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
+          CANDIDATE_ARTIFACT_NAME: ${{ steps.candidate.outputs.artifact_name }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
+          PREVIOUS_RELEASE_ID: ${{ steps.previous.outputs.release_id }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
@@ -659,7 +1059,16 @@ jobs:
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}"
             --nft-raw "${RAW_DIR}/nftables-raw.json"
             --package-raw "${RAW_DIR}/package-lifecycle-raw.json"
+            --package-amd64-shard "${RAW_DIR}/package-lifecycle-amd64.json"
+            --package-arm64-shard "${RAW_DIR}/package-lifecycle-arm64.json"
             --freebsd-raw "${RAW_DIR}/freebsd-vm-raw.json"
+            --expected-repository "${GITHUB_REPOSITORY}"
+            --expected-workflow-run-id "${GITHUB_RUN_ID}"
+            --expected-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}"
+            --expected-candidate-run-id "${CANDIDATE_RUN_ID}"
+            --expected-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}"
+            --expected-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}"
+            --expected-previous-release-id "${PREVIOUS_RELEASE_ID}"
             --max-age-seconds 172800
             --max-report-skew-seconds 0
           )
@@ -932,6 +1341,8 @@ jobs:
             "qualification-context.json"
             "raw/freebsd-vm-raw.json"
             "raw/nftables-raw.json"
+            "raw/package-lifecycle-amd64.json"
+            "raw/package-lifecycle-arm64.json"
             "raw/package-lifecycle-raw.json"
             "status/qualification-exit-codes.json"
           )
@@ -1043,10 +1454,14 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
+          CANDIDATE_ARTIFACT_ID: ${{ steps.candidate.outputs.artifact_id }}
+          CANDIDATE_ARTIFACT_NAME: ${{ steps.candidate.outputs.artifact_name }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
           EXPECTED_RELEASE_SHA: ${{ inputs.release_sha }}
           EXPECTED_RELEASE_TAG: ${{ inputs.release_tag }}
           SIGNED_UPDATE_REQUIRED: ${{ steps.update_contract.outputs.required }}
           INVENTORY_OUTCOME: ${{ steps.inventory.outcome }}
+          PREVIOUS_RELEASE_ID: ${{ steps.previous.outputs.release_id }}
           UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
         run: |
           set -euo pipefail
@@ -1064,7 +1479,16 @@ jobs:
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
             --nft-raw "${RAW_DIR}/nftables-raw.json" \
             --package-raw "${RAW_DIR}/package-lifecycle-raw.json" \
+            --package-amd64-shard "${RAW_DIR}/package-lifecycle-amd64.json" \
+            --package-arm64-shard "${RAW_DIR}/package-lifecycle-arm64.json" \
             --freebsd-raw "${RAW_DIR}/freebsd-vm-raw.json" \
+            --expected-repository "${GITHUB_REPOSITORY}" \
+            --expected-workflow-run-id "${GITHUB_RUN_ID}" \
+            --expected-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --expected-candidate-run-id "${CANDIDATE_RUN_ID}" \
+            --expected-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}" \
+            --expected-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}" \
+            --expected-previous-release-id "${PREVIOUS_RELEASE_ID}" \
             --max-age-seconds 172800 \
             --max-report-skew-seconds 0 \
             --nft-envelope "${BOUND_DIR}/nftables-bound.json" \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # SysWarden v4
 
-Current source version: **v4.02.12**.
+Current source version: **v4.02.13**.
 
 > **Active Defense and HIDS/HIPS/WAAP Out-of-Band Orchestration for Critical Linux Infrastructure**
 
@@ -39,7 +39,7 @@ restart and rollback have passed on the target operating system.
 | Target | What the repository currently proves | Release qualification |
 | :--- | :--- | :--- |
 | Linux amd64 | The CLI, core and TUI compile and execute; unit, race, contract, package and golden-rule tests run in the candidate gates | The protected package lifecycle and privileged kernel labs must pass on the exact release SHA before a tag is created |
-| Linux arm64 | The three binaries cross-compile and package metadata is checked against the exact architecture | The protected binfmt lifecycle must execute the exact candidate packages before release |
+| Linux arm64 | The three binaries cross-compile and package metadata is checked against the exact architecture | The protected native ARM64 lifecycle must execute the exact candidate packages before release |
 | Debian/Ubuntu `.deb` | amd64 and arm64 package contents, dependencies, maintainer scripts and lifecycle contracts are validated | The final protected install, upgrade, restart and rollback run remains mandatory |
 | RHEL-family `.rpm` | x86_64 and aarch64 package contents, dependencies, maintainer scripts and lifecycle contracts are validated | The final protected install, upgrade, restart and rollback run remains mandatory |
 | Alpine `.apk` | Dedicated x86_64 and aarch64 CGO-free static executables are packaged; the amd64 binary has no ELF interpreter and executes on standard Alpine musl | The exact x86_64 and aarch64 packages must still pass the protected lifecycle run |
@@ -50,8 +50,8 @@ published release. Until the protected qualification passes for the exact
 commit and artifacts, use SysWarden only in an isolated laboratory with console
 access and a tested host snapshot or rollback path.
 
-The historical v4.02.11 source candidate failed protected qualification before
-signing and was never tagged or published. v4.02.12 supersedes it and remains
+The historical v4.02.12 source candidate failed protected qualification before
+signing and was never tagged or published. v4.02.13 supersedes it and remains
 NO-GO until protected qualification passes on the exact candidate commit.
 
 ## Components and data flow
@@ -115,7 +115,7 @@ parameter. Restrict the listener with `--bind`, protect the port with a trusted
 network control, and do not place tokens in URLs or logs.
 
 A package-level `[webtui] enabled = false` switch and conditional ownership of
-TCP 62027 are not part of v4.02.12. They remain a separate Lot 2 change. The
+TCP 62027 are not part of v4.02.13. They remain a separate Lot 2 change. The
 current package behavior must therefore be treated as Web-TUI enabled.
 
 ### High availability
@@ -322,7 +322,7 @@ default HTTP client without an explicit timeout.
 | Package and PF recovery state | `/var/db/syswarden` |
 | rc.d services | `/usr/local/etc/rc.d/syswarden`, `/usr/local/etc/rc.d/syswardenwebtui` |
 
-The v4.02.12 PF contract is intentionally bounded. A fresh installation
+The v4.02.13 PF contract is intentionally bounded. A fresh installation
 requires PF to be disabled with an empty live ruleset before SysWarden first
 mutates it. The separately byte-bound historical v4.02.8 transition is also covered. This
 does not claim safe coexistence with an arbitrary pre-existing operator PF
@@ -374,10 +374,10 @@ selected release.
 
 The historical v4.02.8 binary predates the signed updater and cannot perform
 the first signed hop. Linux hosts must install the separately verified
-v4.02.12 package with their native package manager. FreeBSD hosts must first
+v4.02.13 package with their native package manager. FreeBSD hosts must first
 install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then use
-`pkg add -f` on the checksum-verified v4.02.12 TXZ. Starting from an installed
-v4.02.12, the signed updater supports the six Linux package targets and
+`pkg add -f` on the checksum-verified v4.02.13 TXZ. Starting from an installed
+v4.02.13, the signed updater supports the six Linux package targets and
 FreeBSD amd64.
 
 ### Install the latest verified Release
@@ -386,7 +386,7 @@ The procedure below downloads exactly one package for the detected operating
 system and architecture. Use it only after that tag is visible in GitHub
 Releases and the release qualification is complete. For the first hop from
 historical v4.02.8, run it as
-`VERSION=v4.02.12 sh ./install-release.sh` after saving the block as
+`VERSION=v4.02.13 sh ./install-release.sh` after saving the block as
 `install-release.sh`; leaving `VERSION` unset selects the latest published
 Release automatically.
 
@@ -621,8 +621,8 @@ access recovery.
   verifies the selected OS/architecture filename, size and SHA-256 again
   immediately before invoking the package manager, and uses a private temporary
   workspace. The historical v4.02.8 binary predates this trust root, so its
-  first upgrade to v4.02.12 must be a separately verified manual package
-  upgrade. From v4.02.12 onward, FreeBSD amd64 uses the same signed contract and
+  first upgrade to v4.02.13 must be a separately verified manual package
+  upgrade. From v4.02.13 onward, FreeBSD amd64 uses the same signed contract and
   invokes native `pkg add -f` only after all verification succeeds.
 - `syswarden uninstall` is destructive. It deletes SysWarden configuration,
   data, logs, services and firewall tables. It does not restore every previous
@@ -668,8 +668,8 @@ maintainer-controlled publication gate; a wiki page may lag the source until
 that gate is completed. When the wiki and this README disagree, prefer tested
 behavior in the source candidate and report the inconsistency.
 
-The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.12.md)
-records the v4.02.12 source scope, evidence, platform boundaries and current
+The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md)
+records the v4.02.13 source scope, evidence, platform boundaries and current
 release decision.
 
 ## Target and support

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -253,8 +253,28 @@ syswarden_read_crontab() {
 syswarden_cleanup_cron_work() {
     [ -n "${cron_work:-}" ] || return 0
     syswarden_cron_cleanup_target="${cron_work}"
+    if [ "${XDG_CACHE_HOME:-}" = "${syswarden_cron_cleanup_target}/cache" ]; then
+        unset XDG_CACHE_HOME
+    fi
+    cron_cache=
+    rm -rf -- "${syswarden_cron_cleanup_target}" || return 1
+    if [ -e "${syswarden_cron_cleanup_target}" ] || [ -L "${syswarden_cron_cleanup_target}" ]; then
+        printf '%s\n' 'private cron work directory remains after cleanup' >&2
+        return 1
+    fi
     cron_work=
-    rm -rf -- "${syswarden_cron_cleanup_target}"
+}
+syswarden_prepare_cron_work() {
+    cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || return 1
+    chmod 0700 "${cron_work}" || return 1
+    cron_cache="${cron_work}/cache"
+    mkdir "${cron_cache}" || return 1
+    chmod 0700 "${cron_cache}" || return 1
+    XDG_CACHE_HOME="${cron_cache}"
+    export XDG_CACHE_HOME
+    cron_backup="${cron_work}/backup"
+    cron_error="${cron_work}/error"
+    cron_filtered="${cron_work}/filtered"
 }
 syswarden_cleanup_crontab() {
     syswarden_cron_backup="$1"
@@ -310,11 +330,7 @@ if [ "$1" = "0" ] || [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
     trap 'syswarden_cleanup_cron_work; exit 129' 1
     trap 'syswarden_cleanup_cron_work; exit 130' 2
     trap 'syswarden_cleanup_cron_work; exit 143' 15
-    cron_work="$(mktemp -d /var/tmp/syswarden-cron.XXXXXX)" || exit 1
-    chmod 0700 "${cron_work}" || exit 1
-    cron_backup="${cron_work}/backup"
-    cron_error="${cron_work}/error"
-    cron_filtered="${cron_work}/filtered"
+    syswarden_prepare_cron_work || exit 1
     syswarden_cleanup_crontab \
         "${cron_backup}" "${cron_error}" "${cron_filtered}" \
         /opt/syswarden/bin/syswarden-cli || exit 1
@@ -371,6 +387,7 @@ vendor: "SysWarden Security"
 homepage: "https://github.com/duggytuxy/syswarden"
 depends:
   - nftables
+  - openrc
   - curl
   - wget
   - rsyslog
@@ -386,6 +403,9 @@ scripts:
   postinstall: "./postinst.sh"
   preremove: "./prerm.sh"
   postremove: "./postrm.sh"
+apk:
+  scripts:
+    postupgrade: "./postinst.sh"
 EOF
 "$(go env GOPATH)/bin/nfpm" pkg --config nfpm_alpine_amd64.yaml --packager apk --target .
 rm -f nfpm_alpine_amd64.yaml

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,34 @@
+# Release v4.02.13
+
+### FIXED 🐛
+- **Alpine service runtime:** Declare OpenRC as an APK dependency and install it in the lifecycle bootstrap so fresh packages can create and control the three owned services.
+- **Alpine upgrades:** Attach the exact fail-closed installation contract to both APK `.post-install` and `.post-upgrade`, covering upgrade, reinstall, restart and recovery instead of fresh installation alone.
+- **RPM cron cleanup:** Confine Cronie's automatic crontab backup to a private 0700 work directory, remove that directory on success or failure, and reject any remaining SysWarden cron reference after package removal.
+- **Native ARM64 qualification:** Execute all five ARM64 DEB, RPM and APK coordinates on a GitHub-hosted ARM64 machine instead of QEMU user-mode, whose netlink limitation cannot prove nftables behavior.
+- **Lifecycle evidence:** Split the Linux package matrix into exact native amd64 and ARM64 shards, then require their complete, non-overlapping coordinate union before release readiness can be true.
+
+### SECURITY 🔒
+- **Shard binding:** Bind both native lifecycle reports to the same workflow run, attempt, release SHA, package artifact, previous public Release and candidate and previous checksum manifests; reject missing, duplicate, emulated or mismatched evidence.
+- **Cron privacy:** Ignore a hostile `TMPDIR`, redirect `XDG_CACHE_HOME` only inside a private `/var/tmp` directory, verify its type and mode, and prove that Cronie backup data is removed even after a write failure.
+- **Environment policy:** Require `can_admins_bypass=false` as a real JSON boolean in the protected qualification environment before accepting or signing any evidence.
+- **Fail-closed publication:** Keep signing, immutable tagging and the 14-asset publisher unreachable unless the native Linux shards, FreeBSD VM, signed updater, nftables and evidence adapters all pass for the exact merged commit.
+
+### RELEASE STATUS 📦
+- v4.02.12 was merged as a source candidate but was never tagged or published. Protected qualification run `31965382720` stopped before signing after detecting the missing Alpine OpenRC dependency and upgrade hook, Cronie backup residue after RPM removal, and the QEMU ARM64 netlink laboratory limitation. No v4.02.12 qualification artifact, signature, tag, Release or Release asset was created.
+- v4.02.13 supersedes the unpublished v4.02.12 candidate. The last public Release remains v4.02.8 until v4.02.13 passes protected qualification on its exact merged SHA and the immutable tag publisher verifies the complete inventory.
+- The expected Release inventory is seven native packages plus `SHA256SUMS.txt`, `RELEASE_SHA256SUMS.txt`, `syswarden-release.tar.gz`, `syswarden-sbom.spdx.json`, `plumber-report.zip`, `syswarden-update-manifest-v1.json` and `syswarden-update-manifest-v1.json.sig`, exactly 14 assets.
+
+### UPGRADE NOTES 📦
+- The immutable v4.02.8 binary predates the signed updater. Do not use `syswarden update` for its first hop. Download exactly one v4.02.13 package matching the host plus `SHA256SUMS.txt`, verify that exact package, then install it with the native package manager.
+- **Debian or Ubuntu:** after checksum verification, run `sudo apt-get install -y ./syswarden_4.02.13_amd64.deb` or use the `arm64` filename on an ARM64 host.
+- **RHEL, AlmaLinux or Rocky Linux:** after checksum verification, run `sudo dnf install -y ./syswarden-4.02.13-1.x86_64.rpm` or use the `aarch64` filename on an ARM64 host.
+- **Alpine Linux:** after checksum verification, run `sudo apk add --allow-untrusted ./syswarden_4.02.13_x86_64.apk` or use the `aarch64` filename on an ARM64 host. Never use `--allow-untrusted` before the SHA-256 check succeeds.
+- **FreeBSD 14 amd64:** install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then run `sudo pkg add -f ./syswarden-4.02.13.txz` after checksum verification. Use `syswarden uninstall` rather than raw `pkg delete`, whose script-failure behavior cannot guarantee PF recovery.
+- Starting from an installed v4.02.13, `syswarden update` verifies the signed Ed25519 manifest for the six Linux targets and FreeBSD amd64 before installing future published versions.
+- Review the package post-install result with `sudo syswarden manual` and `sudo syswarden config`. The complete architecture-selecting procedure remains in the README section [Install the latest verified Release](README.md#install-the-latest-verified-release).
+
+---
+
 # Release v4.02.12
 
 ### FIXED 🐛

--- a/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md
+++ b/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md
@@ -1,0 +1,152 @@
+# SysWarden Lot 1 Public Security Delivery Report
+
+| Field | Value |
+| :--- | :--- |
+| Lot 1 source status | CANDIDATE |
+| Product release decision | NO-GO until protected qualification |
+| Candidate | v4.02.13 |
+| Historical public baseline | v4.02.8 |
+| Prior source candidate | v4.02.12, merged but never tagged or published |
+| Report date | 16 August 2026 |
+| Scope | Lot 1 source, package and release-qualification closure |
+| Audience | Public, anonymized |
+
+## 1. Executive outcome
+
+This report describes the v4.02.13 repository candidate. It does not claim
+that an untagged build is a public release, that every environment is
+supported, or that a package is safe merely because a workflow produced it.
+
+The v4.02.12 source candidate was merged, but it was never tagged or published.
+Protected qualification run `31965382720` stopped before signing after the
+Linux package laboratory found missing OpenRC packaging and upgrade hooks,
+Cronie backup residue after RPM removal, and an ARM64 netlink limitation in the
+QEMU user-mode laboratory. No v4.02.12 qualification artifact, signature, tag,
+public Release or Release asset was created.
+
+v4.02.13 supersedes that unpublished candidate. It remains NO-GO until
+protected qualification passes on its exact commit and produces byte-bound
+evidence. No v4.02.13 tag or public Release is authorized before that result.
+
+## 2. Candidate corrections and delivered controls
+
+The v4.02.13 source candidate declares OpenRC as an APK dependency, executes the
+same fail-closed installation contract on fresh installation and package
+upgrade, confines Cronie backups to a private temporary cache that is removed
+and verified, and replaces QEMU lifecycle evidence with separate native amd64
+and ARM64 shards. The shards are bound to one workflow run, release SHA,
+package artifact, previous Release and checksum manifests before their exact
+coordinate union is accepted.
+
+| Area | Candidate behavior | Security boundary |
+| :--- | :--- | :--- |
+| Configuration | Transactional migration, strict validation, durable recovery phases, concurrency controls and preservation of operator overrides | Mutating commands stop when the active configuration is unavailable or degraded |
+| Linux firewall | Validated nftables candidate, shared lock, atomic commit, post-commit verification, TTL preservation and bounded compatibility wrappers | A policy change can still interrupt remote access; console recovery remains mandatory |
+| Scheduling | Feed and HA cron entries are reconciled independently; operator lines are preserved; Cronie backup data is confined to a verified private work directory | The exact package lifecycle must still prove these properties on every release coordinate |
+| Alpine packages | OpenRC is a declared runtime dependency and the installation contract is attached to both fresh-install and upgrade hooks | Exact native x86_64 and ARM64 lifecycle evidence remains mandatory |
+| Native Linux evidence | Independent native amd64 and ARM64 shards cover the exact DEB, RPM and APK coordinate sets and reject emulation, duplicates, omissions and binding mismatches | Both shards must originate from the same protected workflow run and exact candidate bytes |
+| High availability | TLS 1.3, bearer authentication, bounded payloads, canonical peer scope, durable ledgers and bidirectional persistent-ban exchange | CIDRs authorize inbound peers only and are never dialed as outbound destinations |
+| BunkerWeb integration | Additive TTL, provenance and batch extensions behind an explicit gate | Durable node-to-node L7 and WAAP ban exchange remains active with the partner gate false or true |
+| Signed updates | Canonical manifest, detached Ed25519 signature, exact platform binding, private staging and final size and SHA-256 verification before installation | The historical v4.02.8 binary predates this trust root and requires one separately verified manual first hop |
+| FreeBSD package | ABI 14 amd64 TXZ, native `/usr/local` layout, rc.d services, PF recovery contract, host-state restoration and native signed updater support | Fresh installation requires PF disabled with an empty live ruleset; arbitrary pre-existing PF coexistence is not claimed |
+| Release governance | Exact tag ruleset, non-bypassable protected environments, byte-bound qualification evidence and independent publisher revalidation | A public tag and Release remain blocked until protected qualification succeeds |
+
+## 3. Upgrade contract
+
+The signed update protocol applies to v4.02.9 and later candidates. A qualified
+v4.02.13 manifest must bind seven package identities: two DEB, two RPM, two APK
+and one FreeBSD TXZ. A package is selected by exact operating system,
+architecture, name, size and SHA-256, then rehashed immediately before its
+package manager is invoked.
+
+The immutable v4.02.8 binary has no embedded signed-manifest verifier. Its first
+hop to v4.02.13 must therefore use a separately verified package and the native
+package manager. On FreeBSD, the standalone TXZ also requires `curl`, `jq`,
+`libqrencode`, `rsyslog` and `wireguard-tools` to be installed first. Once
+v4.02.13 is installed from a qualified Release, signed updates support the six
+Linux targets and FreeBSD amd64.
+
+## 4. Package and platform boundaries
+
+| Platform | Candidate evidence | Remaining release gate |
+| :--- | :--- | :--- |
+| DEB amd64 and arm64 | Contents, dependencies, maintainer scripts and lifecycle contracts | Protected native amd64 and ARM64 lifecycle |
+| RPM x86_64 and aarch64 | Contents, dependencies, maintainer scripts and lifecycle contracts | Protected native amd64 and ARM64 lifecycle |
+| APK x86_64 and aarch64 | Static package executables, OpenRC dependency and fresh/upgrade hooks | Protected native x86_64 and ARM64 lifecycle |
+| FreeBSD amd64 | Cross-build, ABI, inventory, native paths, rc.d, PF, uninstall and updater contracts | Disposable VM lifecycle and signed updater transition |
+
+Raw `pkg delete` is not the supported FreeBSD cleanup path because the package
+manager does not guarantee that a failing pre-deinstall script aborts payload
+removal, and its no-script mode bypasses recovery hooks. Operators must use
+`syswarden uninstall` with backups and console access.
+
+The Web-TUI is enabled by the current package path. A package-level disabled
+default and conditional TCP 62027 ownership remain Lot 2 work.
+
+## 5. Qualification state
+
+The failed v4.02.12 protected attempt is diagnostic evidence only. It is not
+release evidence for v4.02.13, and none of its unfinished outputs may be reused
+to authorize a tag.
+
+The v4.02.13 candidate must pass all source and governance checks on its exact
+merged commit. The protected run must then verify package install, upgrade,
+reinstall, restart, rollback, recovery, removal and purge lifecycles on native
+amd64 and ARM64 hosts; independent IPv4 and IPv6 preservation; FreeBSD PF and
+package lifecycle; the signed FreeBSD updater transition; isolated nftables
+behavior; staged artifact integrity; and publisher revalidation. Any failed
+coordinate keeps the release closed.
+
+## 6. Expected public Release inventory
+
+A qualified v4.02.13 Release must contain exactly these 14 public assets:
+
+1. `syswarden_4.02.13_amd64.deb`;
+2. `syswarden_4.02.13_arm64.deb`;
+3. `syswarden-4.02.13-1.x86_64.rpm`;
+4. `syswarden-4.02.13-1.aarch64.rpm`;
+5. `syswarden_4.02.13_x86_64.apk`;
+6. `syswarden_4.02.13_aarch64.apk`;
+7. `syswarden-4.02.13.txz`;
+8. `SHA256SUMS.txt`;
+9. `RELEASE_SHA256SUMS.txt`;
+10. `syswarden-release.tar.gz`;
+11. `syswarden-sbom.spdx.json`;
+12. `plumber-report.zip`;
+13. `syswarden-update-manifest-v1.json`;
+14. `syswarden-update-manifest-v1.json.sig`.
+
+This inventory contains seven packages plus seven evidence and update assets.
+A successful source merge alone does not create the tag or these Release
+assets.
+
+## 7. Release notes contract
+
+The public v4.02.13 Release notes must come from the complete v4.02.13 changelog
+section. They must retain the fixes, security properties, release status and
+upgrade notes, including the manual v4.02.8 first hop, exact native package
+commands, the FreeBSD dependency and cleanup limits, and the 14-asset inventory.
+Publisher revalidation must bind those notes and every public asset to the
+qualified commit without rewriting the failed v4.02.12 history.
+
+## 8. Deferred Lot 2 work
+
+The following items remain outside this Lot 1 closure:
+
+- a package-level `[webtui] enabled = false` default and conditional TCP 62027
+  ownership;
+- an external BunkerWeb plugin, UI and end-to-end partner qualification;
+- per-client HA tokens and remote whitelist mutation privileges;
+- FreeBSD jails and coexistence with arbitrary pre-existing PF policy;
+- a public FreeBSD package repository instead of standalone TXZ installation;
+- additional product UX and policy controls that do not alter the v4.02.13
+  upgrade safety boundary.
+
+## 9. Final decision rule
+
+v4.02.13 remains NO-GO. The tag may be created only after protected
+qualification binds the exact release commit and passes the native amd64 and
+ARM64 package, FreeBSD, PF, nftables, signed-updater and release-governance
+gates. The publisher must then revalidate the qualified evidence, complete
+Release notes and exact asset inventory before it can publish the GitHub
+Release. Any failed coordinate keeps the public Release closed.

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -412,9 +412,9 @@
     {
       "case": "root",
       "stream": "stdout",
-      "reason": "Advance the Patch version to v4.02.12 while preserving the bounded built-in operator reference introduced after v4.02.8.",
+      "reason": "Advance the Patch version to v4.02.13 while preserving the bounded built-in operator reference introduced after v4.02.8.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.02.12 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.02.13 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     }
   ],
   "product_command_count": 24,
@@ -470,12 +470,12 @@
     "If no token is configured, `syswarden web-token` generates and persists one even without `--rotate`",
     "If that restart fails, the command returns nonzero and reports partial state",
     "`syswarden uninstall` is destructive",
-    "The historical v4.02.11 source candidate failed protected qualification before signing and was never tagged or published.",
-    "v4.02.12 supersedes it and remains NO-GO",
+    "The historical v4.02.12 source candidate failed protected qualification before signing and was never tagged or published.",
+    "v4.02.13 supersedes it and remains NO-GO",
     "The procedure below downloads exactly one package for the detected operating system and architecture.",
-    "VERSION=v4.02.12 sh ./install-release.sh",
+    "VERSION=v4.02.13 sh ./install-release.sh",
     "checksum manifest must contain exactly one entry for $PACKAGE",
-    "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.12.md",
+    "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md",
     "## Security posture and limitations",
     "Goal: 37% reached/year (Goal)"
   ],
@@ -483,7 +483,7 @@
     "it is not a compliance certification",
     "v4.02.9+ requires a trusted Ed25519 release manifest",
     "dedicated CGO-free static APK binaries are built for x86_64 and aarch64",
-    "v4.02.12 uses native /usr/local paths and rc.d on amd64",
+    "v4.02.13 uses native /usr/local paths and rc.d on amd64",
     "default bind 0.0.0.0:62027",
     "persistent self-signed TLS 1.3 identity",
     "/var/lib/syswarden/ha/server.crt and /var/lib/syswarden/ha/server.key",
@@ -507,35 +507,40 @@
     "configuration, data, logs, services and firewall tables are deleted"
   ],
   "public_report_contract": {
-    "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.12.md",
+    "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md",
     "preserved_reports": [
       {
         "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.11.md",
         "sha256": "7929482c62e42a1c5909c3de3ebd31d00f78d019d8ab4efd0e47bf20f1ec07d7"
+      },
+      {
+        "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.12.md",
+        "sha256": "eb920e37cc8b3700179149ee2ce14e13ab3221d3a622db39d41bdef81ab4285a"
       }
     ],
     "required_phrases": [
       "| Product release decision | NO-GO until protected qualification |",
-      "| Candidate | v4.02.12 |",
+      "| Candidate | v4.02.13 |",
       "| Historical public baseline | v4.02.8 |",
-      "| Prior source candidate | v4.02.11, merged but never tagged or published |",
-      "Protected qualification run `31905061431` stopped before signing",
-      "No v4.02.11 qualification artifact, tag, public Release or Release asset was created.",
-      "v4.02.12 remains NO-GO until protected qualification passes on its exact commit",
-      "first hop to v4.02.12 must therefore use a separately verified package and the native package manager",
-      "A qualified v4.02.12 Release must contain exactly these 14 public assets:",
+      "| Prior source candidate | v4.02.12, merged but never tagged or published |",
+      "Protected qualification run `31965382720` stopped before signing",
+      "No v4.02.12 qualification artifact, signature, tag, public Release or Release asset was created.",
+      "v4.02.13 supersedes that unpublished candidate",
+      "hop to v4.02.13 must therefore use a separately verified package and the native package manager",
+      "A qualified v4.02.13 Release must contain exactly these 14 public assets:",
+      "separate native amd64 and ARM64 shards",
       "Durable node-to-node L7 and WAAP ban exchange remains active with the partner gate false or true",
       "Raw `pkg delete` is not the supported FreeBSD cleanup path",
       "FreeBSD jails and coexistence with arbitrary pre-existing PF policy"
     ],
     "expected_assets": [
-      "syswarden_4.02.12_amd64.deb",
-      "syswarden_4.02.12_arm64.deb",
-      "syswarden-4.02.12-1.x86_64.rpm",
-      "syswarden-4.02.12-1.aarch64.rpm",
-      "syswarden_4.02.12_x86_64.apk",
-      "syswarden_4.02.12_aarch64.apk",
-      "syswarden-4.02.12.txz",
+      "syswarden_4.02.13_amd64.deb",
+      "syswarden_4.02.13_arm64.deb",
+      "syswarden-4.02.13-1.x86_64.rpm",
+      "syswarden-4.02.13-1.aarch64.rpm",
+      "syswarden_4.02.13_x86_64.apk",
+      "syswarden_4.02.13_aarch64.apk",
+      "syswarden-4.02.13.txz",
       "SHA256SUMS.txt",
       "RELEASE_SHA256SUMS.txt",
       "syswarden-release.tar.gz",
@@ -572,7 +577,7 @@
       "Disabling BunkerWeb leaves this authenticated node-to-node exchange available",
       "signed Ed25519 update manifest",
       "The procedure below downloads exactly one package for the detected operating system and architecture.",
-      "VERSION=v4.02.12 sh ./install-release.sh",
+      "VERSION=v4.02.13 sh ./install-release.sh",
       "checksum manifest must contain exactly one entry for $PACKAGE",
       "On FreeBSD, use `syswarden uninstall` rather than raw `pkg delete`."
     ],
@@ -583,7 +588,7 @@
       "A-to-B and B-to-A exchange",
       "through TLS 1.3 and bearer authentication",
       "removes partner TTL, batch and provenance capabilities",
-      "any package artifact that has not passed the exact protected v4.02.12 lifecycle",
+      "any package artifact that has not passed the exact protected v4.02.13 lifecycle",
       "FreeBSD coexistence with an arbitrary pre-existing PF policy"
     ],
     "BunkerWeb-Integration.md": [
@@ -608,7 +613,7 @@
       "Start with `SYSWARDEN_ENFORCEMENT=audit`",
       "An external-only row is never reported as a SysWarden test success.",
       "Never copy `server.key` to a client.",
-      "v4.02.12 does not expose remote whitelist writes or per-client scoped tokens."
+      "v4.02.13 does not expose remote whitelist writes or per-client scoped tokens."
     ]
   },
   "package_platform_contract": {
@@ -677,7 +682,7 @@
           [
             "Linux arm64",
             "The three binaries cross-compile and package metadata is checked against the exact architecture",
-            "The protected binfmt lifecycle must execute the exact candidate packages before release"
+            "The protected native ARM64 lifecycle must execute the exact candidate packages before release"
           ],
           [
             "Debian/Ubuntu `.deb`",
@@ -717,7 +722,7 @@
           [
             "Linux arm64",
             "Cross-build, exact metadata and package lifecycle contracts",
-            "Protected binfmt lifecycle remains mandatory"
+            "Protected native ARM64 lifecycle remains mandatory"
           ],
           [
             "Debian/Ubuntu DEB",
@@ -746,7 +751,7 @@
         "header": [
           "Package family",
           "Architectures produced by the workflow",
-          "Decision for v4.02.12"
+          "Decision for v4.02.13"
         ],
         "rows": [
           [

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -20,9 +20,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class DocumentationGateTest(unittest.TestCase):
-    def test_v40212_changelog_records_exact_nosec_reduction(self) -> None:
+    def test_v40212_historical_changelog_records_exact_nosec_reduction(self) -> None:
         changelog = (REPO_ROOT / "changelog.md").read_text(encoding="utf-8")
-        release_block = changelog.split("\n---\n", 1)[0]
+        release_block = changelog.split("# Release v4.02.12\n", 1)[1].split(
+            "\n---\n", 1
+        )[0]
         self.assertIn(
             "Remove only the eight resolved legacy crontab suppressions",
             release_block,
@@ -552,7 +554,7 @@ invented_key = true
         ]
         deployment = """## 1. Target decision
 
-| Package family | Architectures produced by the workflow | Decision for v4.02.12 |
+| Package family | Architectures produced by the workflow | Decision for v4.02.13 |
 | :--- | :--- | :--- |
 | DEB | amd64, arm64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |
 | RPM | x86_64, aarch64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |

--- a/scripts/ci/fixtures/package-forward-only-v4.02.8.json
+++ b/scripts/ci/fixtures/package-forward-only-v4.02.8.json
@@ -1,5 +1,5 @@
 {
-  "candidate_version": "4.02.12",
+  "candidate_version": "4.02.13",
   "previous_version": "4.02.8",
   "artifacts": {
     "aarch64": {

--- a/scripts/ci/freebsd_updater_vm_probe_test.py
+++ b/scripts/ci/freebsd_updater_vm_probe_test.py
@@ -44,7 +44,7 @@ def passing_evidence() -> dict[str, str]:
         "UPDATER_RESULT_SHA256": "a" * 64,
         "UPDATER_RESULT_EXACT": "1",
         "UPDATER_RESULT_LINE": f"--- PASS: {subject.TEST_NAME} (1.23s)",
-        "CANDIDATE_VERSION": "4.02.12",
+        "CANDIDATE_VERSION": "4.02.13",
         "CORE_ENABLED": "YES",
         "WEB_ENABLED": "YES",
         "CORE_STATUS_RC": "0",
@@ -80,13 +80,13 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
-        self.candidate_path = fixture(self.root / "syswarden-4.02.12.txz", b"candidate")
+        self.candidate_path = fixture(self.root / "syswarden-4.02.13.txz", b"candidate")
         self.previous_path = fixture(self.root / "syswarden-4.02.8.txz", b"previous")
         self.manifest = fixture(self.root / "syswarden-update-manifest-v1.json", b"{}\n")
         self.signature = fixture(self.root / "syswarden-update-manifest-v1.json.sig", b"signature\n")
         self.test_binary = fixture(self.root / subject.TEST_BINARY_NAME, b"ELF", 0o700)
         self.candidate = vm_lab.PackageArtifact(
-            self.candidate_path, "4.02.12", hashlib.sha256(b"candidate").hexdigest()
+            self.candidate_path, "4.02.13", hashlib.sha256(b"candidate").hexdigest()
         )
         self.previous = vm_lab.PackageArtifact(
             self.previous_path, "4.02.8", hashlib.sha256(b"previous").hexdigest()
@@ -116,7 +116,7 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         report = self.report()
         self.assertTrue(report["release_ready"])
         self.assertEqual(report["blocker_ids"], [])
-        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.12")
+        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.13")
         self.assertEqual(report["inputs"]["previous"]["version"], "4.02.8")
 
     def test_each_material_observation_is_fail_closed(self) -> None:

--- a/scripts/ci/freebsd_vm_lab.py
+++ b/scripts/ci/freebsd_vm_lab.py
@@ -547,10 +547,10 @@ def version_tuple(version: str) -> tuple[int, int, int]:
 def is_forward_only_transition(
     candidate: PackageArtifact, previous: PackageArtifact
 ) -> bool:
-    """Recognize only the immutable v4.02.8 to v4.02.12 transition."""
+    """Recognize only the immutable v4.02.8 to v4.02.13 transition."""
 
     return (
-        candidate.version == "4.02.12"
+        candidate.version == "4.02.13"
         and previous.version == FORWARD_ONLY_PREVIOUS_VERSION
         and previous.path.name == FORWARD_ONLY_PREVIOUS_PACKAGE
         and previous.sha256 == FORWARD_ONLY_PREVIOUS_SHA256
@@ -570,7 +570,7 @@ def validate_forward_only_binding(
     ):
         raise FreeBSDVMLabError(
             "the historical FreeBSD transition is allowed only for the exact "
-            "v4.02.8 package bytes followed by candidate v4.02.12"
+            "v4.02.8 package bytes followed by candidate v4.02.13"
         )
 
 
@@ -1181,7 +1181,7 @@ fi
 if [ "$previous_expected_version" = "4.02.8" ]; then
     if [ "$previous_package_name" != "syswarden-4.02.8.txz" ] || \
        [ "$previous_expected_sha" != "8b3b489821450b3afd74548c6db5ad92001b8a69f923e2b9a99ce550353b6e37" ] || \
-       [ "$candidate_expected_version" != "4.02.12" ]; then
+       [ "$candidate_expected_version" != "4.02.13" ]; then
         exit 91
     fi
 fi
@@ -1779,7 +1779,7 @@ emit REMOVE_PF_SNAPSHOT_SHA256 "$remove_pf_snapshot_sha"
 emit REMOVE_PF_BASELINE_RESTORED "$remove_pf_restored"
 emit REMOVE_PF_SYSWARDEN_TABLE_ABSENT "$remove_syswarden_tables_absent"
 
-# Exercise the fresh v4.02.12 PF boundary with the exact candidate CLI after
+# Exercise the fresh candidate PF boundary with the exact candidate CLI after
 # the historical package snapshot has been consumed. Fresh capture is allowed
 # only on the disabled empty baseline; a nonempty anchor must be rejected
 # before any PF or snapshot mutation.
@@ -2352,7 +2352,7 @@ def product_checks(
                     "nonempty_rejected": evidence["PF_NONEMPTY_CAPTURE_REJECTED"],
                     "nonempty_state_preserved": evidence["PF_NONEMPTY_STATE_PRESERVED"],
                 },
-                "Fresh v4.02.12 PF ownership is restricted to a disabled empty host and must reject coexistence before mutation.",
+                "Fresh candidate PF ownership is restricted to a disabled empty host and must reject coexistence before mutation.",
             ),
             check("SW-PKG-FBSD-START-CORE-001", "startup", evidence["RC_CORE_START_RC"] == "0" and evidence["RC_CORE_STATUS_RC"] == "0", "core starts and reports running", {"start": evidence["RC_CORE_START_RC"], "status": evidence["RC_CORE_STATUS_RC"]}, "The candidate core must start through rc.d."),
             check("SW-PKG-FBSD-RESTART-CORE-001", "startup", all(evidence[key] == "0" for key in ("RC_CORE_RESTART_ONE_RC", "RC_CORE_RESTART_ONE_STATUS_RC", "RC_CORE_RESTART_TWO_RC", "RC_CORE_RESTART_TWO_STATUS_RC")), "two consecutive core restarts succeed and report running", {key: evidence[key] for key in ("RC_CORE_RESTART_ONE_RC", "RC_CORE_RESTART_ONE_STATUS_RC", "RC_CORE_RESTART_TWO_RC", "RC_CORE_RESTART_TWO_STATUS_RC")}, "A second consecutive restart is the bounded rc.d idempotence check."),

--- a/scripts/ci/freebsd_vm_lab_test.py
+++ b/scripts/ci/freebsd_vm_lab_test.py
@@ -344,7 +344,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
 
     def forward_candidate_artifact(self) -> freebsd_vm_lab.PackageArtifact:
         return freebsd_vm_lab.PackageArtifact(
-            self.root / "syswarden-4.02.12.txz", "4.02.12", self.package_sha
+            self.root / "syswarden-4.02.13.txz", "4.02.13", self.package_sha
         )
 
     def forward_previous_artifact(self) -> freebsd_vm_lab.PackageArtifact:
@@ -365,9 +365,9 @@ class FreeBSDVMLabTests(unittest.TestCase):
         self.assertEqual(candidate, self.artifact())
         self.assertEqual(previous, self.previous_artifact())
 
-    def test_candidate_v40212_requires_exact_dependency_manifest(self) -> None:
+    def test_candidate_v40213_requires_exact_dependency_manifest(self) -> None:
         self.package.unlink()
-        candidate = self.packages / "syswarden-4.02.12.txz"
+        candidate = self.packages / "syswarden-4.02.13.txz"
         candidate.write_bytes(b"candidate with dependency gate")
         digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
         (self.packages / "SHA256SUMS.txt").write_text(
@@ -775,7 +775,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
             "CANDIDATE_REINSTALL",
             "CANDIDATE_RESTART_IDEMPOTENCE",
         ):
-            evidence[f"{phase}_PKG_VERSION"] = "4.02.12"
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.13"
         for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
             evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
             evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -19,6 +20,17 @@ REPOSITORY = Path(__file__).resolve().parents[2]
 PACKAGE_WORKFLOW = REPOSITORY / ".github" / "workflows" / "package.yml"
 BUILD_SCRIPT = REPOSITORY / "build.ps1"
 LOCAL_BUILD_SCRIPT = REPOSITORY / "build_packages.sh"
+
+
+def workflow_step_script(workflow: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    if workflow.count(marker) != 1:
+        raise AssertionError(f"expected exactly one workflow step named {step_name}")
+    step = workflow.split(marker, 1)[1].split("\n      - name:", 1)[0]
+    run_marker = "        run: |\n"
+    if step.count(run_marker) != 1:
+        raise AssertionError(f"expected one shell body for workflow step {step_name}")
+    return textwrap.dedent(step.split(run_marker, 1)[1])
 
 
 class PackageLifecycleContractTests(unittest.TestCase):
@@ -53,6 +65,20 @@ class PackageLifecycleContractTests(unittest.TestCase):
             f"package script {name} must have exactly one isolated heredoc",
         )
         return bodies[0]
+
+    def test_package_workflow_shell_steps_fit_github_limit(self) -> None:
+        for step_name in (
+            "Prepare Linux Maintainer Scripts",
+            "Build Debian Package (.deb)",
+        ):
+            with self.subTest(step=step_name):
+                script = workflow_step_script(self.workflow, step_name)
+                encoded_size = len(json.dumps(script, ensure_ascii=False))
+                self.assertLessEqual(
+                    encoded_size,
+                    21_000,
+                    f"GitHub rejects {step_name!r} above 21,000 encoded characters",
+                )
 
     def local_build_script(self, name: str) -> str:
         source = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
@@ -431,6 +457,13 @@ class PackageLifecycleContractTests(unittest.TestCase):
             fake_crontab = fake_bin / "crontab"
             fake_crontab.write_text(
                 "#!/bin/sh\n"
+                "record_cronie_backup() {\n"
+                "  [ \"${CRONTAB_CREATE_BACKUP:-0}\" -eq 1 ] || return 0\n"
+                "  [ -n \"${XDG_CACHE_HOME:-}\" ] || return 96\n"
+                "  mkdir -p \"${XDG_CACHE_HOME}/crontab\" || return 1\n"
+                "  printf 'previous cron\\n' > \"${XDG_CACHE_HOME}/crontab/crontab.bak\" || return 1\n"
+                "  printf '%s' \"${XDG_CACHE_HOME}\" > \"${CRONTAB_CACHE_PATH_OUTPUT}\" || return 1\n"
+                "}\n"
                 "case \"${1:-}\" in\n"
                 "  -l)\n"
                 "    if [ -e \"${CRONTAB_REMOVED_MARKER}\" ]; then\n"
@@ -443,6 +476,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "    exit \"${CRONTAB_READ_RC:-0}\"\n"
                 "    ;;\n"
                 "  -r)\n"
+                "    record_cronie_backup || exit $?\n"
                 "    crontab_remove_rc=${CRONTAB_REMOVE_RC:-0}\n"
                 "    if [ \"${crontab_remove_rc}\" -eq 0 ]; then\n"
                 "      : > \"${CRONTAB_REMOVED_MARKER}\"\n"
@@ -454,6 +488,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "    exit \"${crontab_remove_rc}\"\n"
                 "    ;;\n"
                 "  -)\n"
+                "    record_cronie_backup || exit $?\n"
                 "    cat > \"${CRONTAB_WRITE_OUTPUT}\"\n"
                 "    exit \"${CRONTAB_WRITE_RC:-0}\"\n"
                 "    ;;\n"
@@ -474,6 +509,20 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 encoding="utf-8",
             )
             fake_cmp.chmod(0o700)
+            fake_mktemp = fake_bin / "mktemp"
+            real_mktemp = shutil.which("mktemp")
+            self.assertIsNotNone(real_mktemp)
+            fake_mktemp.write_text(
+                "#!/bin/sh\n"
+                "[ \"$#\" -eq 2 ] || exit 95\n"
+                "[ \"$1\" = -d ] || exit 95\n"
+                "[ \"$2\" = /var/tmp/syswarden-cron.XXXXXX ] || exit 95\n"
+                "[ -n \"${SYSWARDEN_TEST_MKTEMP_ROOT:-}\" ] || exit 94\n"
+                f'exec "{real_mktemp}" -d '
+                '"${SYSWARDEN_TEST_MKTEMP_ROOT}/syswarden-cron.XXXXXX"\n',
+                encoding="utf-8",
+            )
+            fake_mktemp.chmod(0o700)
             backup = root / "backup"
             error = root / "error"
             filtered = root / "filtered"
@@ -499,6 +548,8 @@ class PackageLifecycleContractTests(unittest.TestCase):
                     {
                         "PATH": f"{fake_bin}:{environment.get('PATH', '')}",
                         "CRONTAB_WRITE_OUTPUT": str(written),
+                        "CRONTAB_CACHE_PATH_OUTPUT": str(root / "cache-path"),
+                        "CRONTAB_CREATE_BACKUP": "0",
                         "CRONTAB_REMOVED_MARKER": str(removed),
                         "CRONTAB_READ_RC": "0",
                         "CRONTAB_WRITE_RC": "0",
@@ -511,6 +562,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                         "CRONTAB_VERIFY_STDERR": "no crontab for root\n",
                         "CMP_FORCE_RC": "",
                         "SYSWARDEN_CRON_ABSENCE_SPOOL": "",
+                        "SYSWARDEN_TEST_MKTEMP_ROOT": str(root),
                         **updates,
                     }
                 )
@@ -669,6 +721,74 @@ class PackageLifecycleContractTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertFalse(removed.exists())
 
+            cache_path_output = root / "cache-path"
+            prepared_command = [
+                "/bin/sh",
+                "-c",
+                reference
+                + "\numask 077\n"
+                + "SYSWARDEN_CRON_ABSENCE_SPOOL=\n"
+                + "cron_work=\n"
+                + "trap 'syswarden_cleanup_cron_work' 0\n"
+                + "trap 'syswarden_cleanup_cron_work; exit 129' 1\n"
+                + "trap 'syswarden_cleanup_cron_work; exit 130' 2\n"
+                + "trap 'syswarden_cleanup_cron_work; exit 143' 15\n"
+                + "syswarden_prepare_cron_work || exit 1\n"
+                + 'syswarden_cleanup_crontab "${cron_backup}" '
+                + '"${cron_error}" "${cron_filtered}" "$1" || exit 1\n'
+                + "syswarden_cleanup_cron_work || exit 1\n"
+                + "trap - 0 1 2 15\n",
+                "cronie-private-cache-contract",
+                "/opt/syswarden/bin/syswarden-cli",
+            ]
+            for write_rc in ("0", "23"):
+                with self.subTest(cronie_write_rc=write_rc):
+                    written.unlink(missing_ok=True)
+                    cache_path_output.unlink(missing_ok=True)
+                    environment = os.environ.copy()
+                    environment.update(
+                        {
+                            "PATH": f"{fake_bin}:{environment.get('PATH', '')}",
+                            "CRONTAB_WRITE_OUTPUT": str(written),
+                            "CRONTAB_CACHE_PATH_OUTPUT": str(cache_path_output),
+                            "CRONTAB_CREATE_BACKUP": "1",
+                            "CRONTAB_READ_RC": "0",
+                            "CRONTAB_STDOUT": managed + "\n" + operator,
+                            "CRONTAB_STDERR": "",
+                            "CRONTAB_WRITE_RC": write_rc,
+                            "SYSWARDEN_TEST_MKTEMP_ROOT": str(root),
+                        }
+                    )
+                    result = subprocess.run(
+                        prepared_command,
+                        check=False,
+                        capture_output=True,
+                        env=environment,
+                    )
+                    if write_rc == "0":
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual(written.read_bytes(), operator.encode("utf-8"))
+                    else:
+                        self.assertNotEqual(result.returncode, 0)
+                    self.assertTrue(
+                        cache_path_output.exists(),
+                        "private Cronie cache setup did not reach crontab: "
+                        + result.stderr.decode("utf-8", errors="replace"),
+                    )
+                    cache_path = Path(
+                        cache_path_output.read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(cache_path.name, "cache")
+                    self.assertTrue(cache_path.parent.name.startswith("syswarden-cron."))
+                    self.assertFalse(
+                        cache_path.parent.exists(),
+                        "private Cronie cache work directory remains",
+                    )
+                    self.assertFalse(
+                        (cache_path / "crontab" / "crontab.bak").exists(),
+                        "Cronie backup remains outside cleanup",
+                    )
+
     def test_active_local_package_builder_uses_exact_fail_closed_cron_cleanup(self) -> None:
         preremove = self.local_build_script("prerm.sh")
         self.assertIn("syswarden_cleanup_crontab", preremove)
@@ -699,7 +819,17 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 for handler in handlers:
                     self.assertIn(handler, script)
                 self.assertIn("mktemp -d", script)
+                self.assertIn("syswarden_prepare_cron_work", script)
                 self.assertIn('chmod 0700 "${cron_work}"', script)
+                self.assertIn('cron_cache="${cron_work}/cache"', script)
+                self.assertIn('chmod 0700 "${cron_cache}"', script)
+                self.assertIn('XDG_CACHE_HOME="${cron_cache}"', script)
+                self.assertIn("export XDG_CACHE_HOME", script)
+                self.assertIn("unset XDG_CACHE_HOME", script)
+                self.assertIn(
+                    "private cron work directory remains after cleanup",
+                    script,
+                )
                 self.assertIn('cron_backup="${cron_work}/backup"', script)
                 self.assertIn('cron_error="${cron_work}/error"', script)
                 self.assertIn('cron_filtered="${cron_work}/filtered"', script)
@@ -774,12 +904,39 @@ class PackageLifecycleContractTests(unittest.TestCase):
             )
         for dependency in ("checkpolicy", "policycoreutils-python-utils"):
             self.assertEqual(self.workflow.count(f'-d "{dependency}"'), 2)
-        for dependency in ("wireguard-tools", "libqrencode-tools", "jq"):
+        for dependency in ("wireguard-tools", "libqrencode-tools", "jq", "openrc"):
             self.assertGreaterEqual(
                 self.workflow.count(f"            - {dependency}\n"),
                 2,
                 dependency,
             )
+
+    def test_apk_fresh_and_upgrade_hooks_share_the_exact_postinstall_contract(self) -> None:
+        workflow_postinstall = 'postinstall: "${PACKAGE_SCRIPTS}/postinst.sh"'
+        workflow_postupgrade = 'postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"'
+        workflow_apk_hook = (
+            "          apk:\n"
+            "            scripts:\n"
+            '              postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"\n'
+        )
+        self.assertEqual(self.workflow.count(workflow_postinstall), 2)
+        self.assertEqual(self.workflow.count(workflow_postupgrade), 2)
+        self.assertEqual(self.workflow.count(workflow_apk_hook), 2)
+        self.assertEqual(self.workflow.count("            - openrc\n"), 2)
+        self.assertIn(".post-install$/", self.workflow)
+        self.assertIn(".post-upgrade$/", self.workflow)
+        self.assertIn("^depend = openrc$", self.workflow)
+        self.assertIn('"${postinstall_members[0]}"', self.workflow)
+        self.assertIn('"${postupgrade_members[0]}"', self.workflow)
+
+        local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
+        self.assertEqual(local.count('postinstall: "./postinst.sh"'), 1)
+        self.assertEqual(local.count('postupgrade: "./postinst.sh"'), 1)
+        self.assertEqual(
+            local.count('apk:\n  scripts:\n    postupgrade: "./postinst.sh"\n'),
+            1,
+        )
+        self.assertEqual(local.count("  - openrc\n"), 1)
 
     def test_freebsd_package_lifecycle_contract(self) -> None:
         preinstall = self.script("preinst_fbsd.sh")

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -131,7 +131,7 @@ RPM_BOOTSTRAP = (
     "policycoreutils-python-utils binutils cpio diffutils file && dnf clean all"
 )
 APK_BOOTSTRAP = (
-    "apk add --no-cache nftables curl wget rsyslog rsyslog-uxsock "
+    "apk add --no-cache nftables openrc curl wget rsyslog rsyslog-uxsock "
     "bash-completion wireguard-tools libqrencode-tools jq binutils file"
 )
 DEB_PURGE_SEMANTICS = (
@@ -342,6 +342,35 @@ PACKAGE_COORDINATE_PATTERNS = {
     for spec in DEFAULT_PLATFORMS
 }
 REQUIRED_FAMILIES = ("deb", "rpm", "apk")
+NATIVE_AGGREGATE_HOST = "native-shards:amd64,arm64"
+QUALIFICATION_BINDING_KEYS = frozenset(
+    {
+        "schema_version",
+        "repository",
+        "release_sha",
+        "release_tag",
+        "previous_tag",
+        "workflow_run_id",
+        "workflow_run_attempt",
+        "candidate_run_id",
+        "candidate_artifact_id",
+        "candidate_artifact_name",
+        "previous_release_id",
+        "candidate_manifest_sha256",
+        "previous_manifest_sha256",
+    }
+)
+NATIVE_SHARD_KEYS = frozenset({"schema_version", "architecture"})
+NATIVE_SHARDS_KEYS = frozenset({"schema_version", "mode", "reports"})
+NATIVE_SHARD_RECORD_KEYS = frozenset(
+    {
+        "architecture",
+        "host_architecture",
+        "report_sha256",
+        "engine_name",
+        "engine_version",
+    }
+)
 
 OPERATOR_STATE_KEYS = (
     "config",
@@ -360,7 +389,7 @@ PACKAGE_PAYLOAD_PATHS = (
     "/usr/local/bin/syswarden",
     "/usr/local/bin/syswarden-tui",
 )
-FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.12"
+FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.13"
 FORWARD_ONLY_APK_PREVIOUS_VERSION = "4.02.8"
 FORWARD_ONLY_APK_PREVIOUS = {
     "x86_64": {
@@ -571,7 +600,7 @@ def validate_forward_only_apk_pair(spec: PlatformSpec, pair: PackagePair) -> boo
     if historical_binding_touched and not forward_only:
         raise LifecycleLabError(
             "historical APK transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.12 contract for "
+            "v4.02.8 -> v4.02.13 contract for "
             f"{spec.package_architecture}"
         )
     return forward_only
@@ -1260,7 +1289,7 @@ expected_runtime_dependencies() {
             printf '%s\n' bash-completion checkpolicy cronie curl ipset jq nftables policycoreutils-python-utils qrencode rsyslog wget wireguard-tools
             ;;
         apk)
-            printf '%s\n' bash-completion curl jq libqrencode-tools nftables rsyslog rsyslog-uxsock wget wireguard-tools
+            printf '%s\n' bash-completion curl jq libqrencode-tools nftables openrc rsyslog rsyslog-uxsock wget wireguard-tools
             ;;
         *)
             return 2
@@ -2672,6 +2701,20 @@ def normalize_host_architecture(value: str) -> str | None:
     return None
 
 
+def required_coordinates_for_architecture(
+    architecture: str,
+) -> frozenset[tuple[str, str]]:
+    if architecture not in ARCHITECTURE_LABELS:
+        raise LifecycleLabError(
+            f"unsupported package lifecycle architecture shard {architecture!r}"
+        )
+    return frozenset(
+        coordinate
+        for coordinate in REQUIRED_PLATFORM_COORDINATES
+        if coordinate[1] == architecture
+    )
+
+
 def probe_platform_execution(
     runner: CommandRunner,
     podman: str,
@@ -3126,8 +3169,16 @@ def validate_forward_only_apk_events(
 
 def classify_lifecycle_evidence(
     results: Sequence[dict[str, object]],
+    *,
+    required_platform_coordinates: frozenset[tuple[str, str]] = REQUIRED_PLATFORM_COORDINATES,
 ) -> dict[str, object]:
     """Recompute release readiness without a generic product waiver."""
+
+    if (
+        not required_platform_coordinates
+        or not required_platform_coordinates.issubset(REQUIRED_PLATFORM_COORDINATES)
+    ):
+        raise LifecycleLabError("required platform coordinate contract is invalid")
 
     structural_failures: list[str] = []
     results_by_coordinate = {
@@ -3137,7 +3188,7 @@ def classify_lifecycle_evidence(
     if len(results_by_coordinate) != len(results):
         structural_failures.append("matrix:duplicate-platform-coordinate")
     for distribution, architecture in sorted(
-        set(results_by_coordinate) - REQUIRED_PLATFORM_COORDINATES
+        set(results_by_coordinate) - required_platform_coordinates
     ):
         structural_failures.append(
             f"matrix:unexpected-platform-coordinate:{distribution}/{architecture}"
@@ -3145,7 +3196,7 @@ def classify_lifecycle_evidence(
     observed_failures: dict[str, str] = {}
     coordinate_classification: list[dict[str, object]] = []
 
-    for distribution, architecture in sorted(REQUIRED_PLATFORM_COORDINATES):
+    for distribution, architecture in sorted(required_platform_coordinates):
         coordinate_name = f"{distribution}/{architecture}"
         platform_result = results_by_coordinate.get((distribution, architecture))
         coordinate_structural: list[str] = []
@@ -3289,7 +3340,7 @@ def classify_lifecycle_evidence(
     every_check_passed = not unexpected_failed_checks and not observed_failures
     harness_complete = (
         every_check_passed
-        and len(results_by_coordinate) == len(REQUIRED_PLATFORM_COORDINATES)
+        and len(results_by_coordinate) == len(required_platform_coordinates)
     )
     release_ready = harness_complete and every_check_passed
     return {
@@ -3301,7 +3352,11 @@ def classify_lifecycle_evidence(
     }
 
 
-def validate_report_version_contract(report: dict[str, object]) -> None:
+def validate_report_version_contract(
+    report: dict[str, object],
+    *,
+    required_platform_coordinates: frozenset[tuple[str, str]] = REQUIRED_PLATFORM_COORDINATES,
+) -> None:
     """Reject a report whose artifact-version evidence is incomplete or mutable."""
 
     schema_version = report.get("schema_version")
@@ -3539,7 +3594,10 @@ def validate_report_version_contract(report: dict[str, object]) -> None:
         raise LifecycleLabError(
             "package lifecycle report version coordinates do not cover its platforms"
         )
-    classification = classify_lifecycle_evidence(platforms)
+    classification = classify_lifecycle_evidence(
+        platforms,
+        required_platform_coordinates=required_platform_coordinates,
+    )
     for key in (
         "harness_complete",
         "release_ready",
@@ -3567,6 +3625,132 @@ def validate_report_version_contract(report: dict[str, object]) -> None:
         )
 
 
+def _positive_identifier(value: object, label: str) -> int:
+    if type(value) is int and value > 0:
+        return value
+    if isinstance(value, str) and re.fullmatch(r"[1-9][0-9]*", value):
+        return int(value)
+    raise LifecycleLabError(f"{label} must be a positive canonical integer")
+
+
+def _manifest_sha256(root: Path, label: str) -> str:
+    path = root / "SHA256SUMS.txt"
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise LifecycleLabError(f"cannot inspect {label}: {exc}") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise LifecycleLabError(f"{label} must be a regular non-symlink file")
+    return sha256_file(path)
+
+
+def validate_qualification_binding(
+    value: object,
+    *,
+    expected: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if not isinstance(value, dict) or set(value) != QUALIFICATION_BINDING_KEYS:
+        raise LifecycleLabError("qualification binding schema is not exact")
+    binding = dict(value)
+    if type(binding["schema_version"]) is not int or binding["schema_version"] != 1:
+        raise LifecycleLabError("qualification binding schema version must be 1")
+    repository = binding["repository"]
+    if not isinstance(repository, str) or re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ) is None:
+        raise LifecycleLabError("qualification repository is not canonical")
+    release_sha = binding["release_sha"]
+    if not isinstance(release_sha, str) or re.fullmatch(
+        r"[0-9a-f]{40}", release_sha
+    ) is None:
+        raise LifecycleLabError("qualification release SHA is not canonical")
+    for key in ("release_tag", "previous_tag"):
+        tag = binding[key]
+        if not isinstance(tag, str) or re.fullmatch(
+            r"v[0-9]+\.[0-9]{2}\.[0-9]+", tag
+        ) is None:
+            raise LifecycleLabError(f"qualification {key} is not canonical")
+    if binding["release_tag"] == binding["previous_tag"]:
+        raise LifecycleLabError("qualification release and previous tags must differ")
+    artifact_name = binding["candidate_artifact_name"]
+    if not isinstance(artifact_name, str) or artifact_name != (
+        "syswarden-packages-" + str(binding["release_tag"]).removeprefix("v")
+    ):
+        raise LifecycleLabError("qualification candidate artifact name is invalid")
+    for key in (
+        "workflow_run_id",
+        "workflow_run_attempt",
+        "candidate_run_id",
+        "candidate_artifact_id",
+        "previous_release_id",
+    ):
+        if type(binding[key]) is not int or binding[key] <= 0:
+            raise LifecycleLabError(
+                f"qualification {key} must be a positive JSON integer"
+            )
+    for key in ("candidate_manifest_sha256", "previous_manifest_sha256"):
+        digest = binding[key]
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise LifecycleLabError(f"qualification {key} is not a SHA-256 digest")
+    if expected is not None and binding != expected:
+        raise LifecycleLabError("qualification binding differs from the expected inputs")
+    return binding
+
+
+def build_qualification_binding(
+    args: argparse.Namespace,
+    candidate_root: Path,
+    previous_root: Path,
+    version_contract: dict[str, object],
+) -> dict[str, object]:
+    binding = {
+        "schema_version": 1,
+        "repository": getattr(args, "qualification_repository", None),
+        "release_sha": getattr(args, "qualification_release_sha", None),
+        "release_tag": getattr(args, "qualification_release_tag", None),
+        "previous_tag": getattr(args, "qualification_previous_tag", None),
+        "workflow_run_id": _positive_identifier(
+            getattr(args, "qualification_workflow_run_id", None),
+            "qualification workflow_run_id",
+        ),
+        "workflow_run_attempt": _positive_identifier(
+            getattr(args, "qualification_workflow_run_attempt", None),
+            "qualification workflow_run_attempt",
+        ),
+        "candidate_run_id": _positive_identifier(
+            getattr(args, "qualification_candidate_run_id", None),
+            "qualification candidate_run_id",
+        ),
+        "candidate_artifact_id": _positive_identifier(
+            getattr(args, "qualification_candidate_artifact_id", None),
+            "qualification candidate_artifact_id",
+        ),
+        "candidate_artifact_name": getattr(
+            args, "qualification_candidate_artifact_name", None
+        ),
+        "previous_release_id": _positive_identifier(
+            getattr(args, "qualification_previous_release_id", None),
+            "qualification previous_release_id",
+        ),
+        "candidate_manifest_sha256": _manifest_sha256(
+            candidate_root, "candidate checksum manifest"
+        ),
+        "previous_manifest_sha256": _manifest_sha256(
+            previous_root, "previous checksum manifest"
+        ),
+    }
+    validated = validate_qualification_binding(binding)
+    if validated["release_tag"] != "v" + str(version_contract["candidate_version"]):
+        raise LifecycleLabError(
+            "qualification release tag differs from candidate package versions"
+        )
+    if validated["previous_tag"] != "v" + str(version_contract["previous_version"]):
+        raise LifecycleLabError(
+            "qualification previous tag differs from previous package versions"
+        )
+    return validated
+
+
 def run_lab(
     args: argparse.Namespace,
     *,
@@ -3575,10 +3759,33 @@ def run_lab(
     host_architecture: str | None = None,
 ) -> dict[str, object]:
     active_runner = runner or CommandRunner()
+    architecture_shard = getattr(args, "architecture_shard", None)
+    required_platform_coordinates = (
+        required_coordinates_for_architecture(architecture_shard)
+        if architecture_shard is not None
+        else REQUIRED_PLATFORM_COORDINATES
+    )
+    observed_platform_coordinates = frozenset(
+        platform_coordinate(spec) for spec in platforms
+    )
+    if architecture_shard is not None and (
+        observed_platform_coordinates != required_platform_coordinates
+        or len(platforms) != len(required_platform_coordinates)
+    ):
+        raise LifecycleLabError(
+            f"{architecture_shard} shard must contain its exact five platform coordinates"
+        )
     candidate_root, previous_root, pairs = validate_inputs(
         args.packages_dir, args.previous_packages_dir, platforms
     )
     actual_host_architecture = host_architecture or platform.machine()
+    normalized_host = normalize_host_architecture(actual_host_architecture)
+    if architecture_shard is not None and normalized_host != architecture_shard:
+        raise LifecycleLabError(
+            f"{architecture_shard} shard requires a native {architecture_shard} host"
+        )
+    if architecture_shard is not None and getattr(args, "arm64_emulator", None) is not None:
+        raise LifecycleLabError("native architecture shards forbid ARM64 emulation")
     arm64_emulator = validate_arm64_emulator(
         getattr(args, "arm64_emulator", None)
     )
@@ -3645,13 +3852,13 @@ def run_lab(
         for result in platform_results
     }
     missing_coordinates = sorted(
-        REQUIRED_PLATFORM_COORDINATES - set(results_by_coordinate)
+        required_platform_coordinates - set(results_by_coordinate)
     )
     architecture_coverage: list[dict[str, object]] = []
-    for architecture in ARCHITECTURE_LABELS:
+    for architecture in sorted({item[1] for item in required_platform_coordinates}):
         expected = sorted(
             coordinate
-            for coordinate in REQUIRED_PLATFORM_COORDINATES
+            for coordinate in required_platform_coordinates
             if coordinate[1] == architecture
         )
         present = [
@@ -3680,12 +3887,14 @@ def run_lab(
         )
 
     family_architecture_coverage: list[dict[str, object]] = []
-    for architecture in ARCHITECTURE_LABELS:
+    for architecture in sorted({item[1] for item in required_platform_coordinates}):
         for family in REQUIRED_FAMILIES:
             expected_specs = [
                 spec
                 for spec in DEFAULT_PLATFORMS
-                if spec.architecture == architecture and spec.family == family
+                if spec.architecture == architecture
+                and spec.family == family
+                and platform_coordinate(spec) in required_platform_coordinates
             ]
             present = [
                 results_by_coordinate[platform_coordinate(spec)]
@@ -3715,7 +3924,7 @@ def run_lab(
         result["status"] == "incomplete" for result in platform_results
     ):
         container_status = "incomplete"
-    elif set(results_by_coordinate) != REQUIRED_PLATFORM_COORDINATES:
+    elif set(results_by_coordinate) != required_platform_coordinates:
         container_status = "incomplete"
     elif platform_results and all(
         result["status"] == "pass" for result in platform_results
@@ -3738,7 +3947,11 @@ def run_lab(
         for item in architecture_coverage
         if item["status"] != "pass"
     ]
-    classification = classify_lifecycle_evidence(platform_results)
+    classification = classify_lifecycle_evidence(
+        platform_results,
+        required_platform_coordinates=required_platform_coordinates,
+    )
+    version_contract = build_package_version_contract(pairs)
     report: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "generated_at": datetime.now(UTC).isoformat(),
@@ -3749,7 +3962,7 @@ def run_lab(
         "unexpected_failed_checks": classification[
             "unexpected_failed_checks"
         ],
-        "package_version_contract": build_package_version_contract(pairs),
+        "package_version_contract": version_contract,
         "scope": {
             "container_lab_complete": container_status == "pass",
             "coordinate_classification": classification[
@@ -3765,17 +3978,22 @@ def run_lab(
             "family_architecture_coverage": family_architecture_coverage,
             "required_platform_coordinates": [
                 {"distribution": distribution, "architecture": architecture}
-                for distribution, architecture in sorted(REQUIRED_PLATFORM_COORDINATES)
+                for distribution, architecture in sorted(required_platform_coordinates)
             ],
             "missing_platform_coordinates": [
                 {"distribution": distribution, "architecture": architecture}
                 for distribution, architecture in missing_coordinates
             ],
             "arm64_coverage_policy": (
-                "arm64/aarch64 is complete only after each DEB, RPM, and APK "
-                "distribution variant executes natively or through a validated "
-                "persistent host binfmt registration whose interpreter exactly "
-                "matches the checksum-recorded --arm64-emulator"
+                "qualification shards require native execution on matching amd64 "
+                "and arm64 hosts and forbid emulation"
+                if architecture_shard is not None
+                else (
+                    "arm64/aarch64 is complete only after each DEB, RPM, and APK "
+                    "distribution variant executes natively or through a validated "
+                    "persistent host binfmt registration whose interpreter exactly "
+                    "matches the checksum-recorded --arm64-emulator"
+                )
             ),
             "rollback_model": (
                 "external package-manager downgrade to the separately supplied, "
@@ -3824,6 +4042,524 @@ def run_lab(
         },
         "platforms": platform_results,
     }
+    if architecture_shard is not None:
+        report["qualification_binding"] = build_qualification_binding(
+            args,
+            candidate_root,
+            previous_root,
+            version_contract,
+        )
+        report["native_shard"] = {
+            "schema_version": 1,
+            "architecture": architecture_shard,
+        }
+    validate_report_version_contract(
+        report,
+        required_platform_coordinates=required_platform_coordinates,
+    )
+    return report
+
+
+def validate_native_shard_report(
+    report: dict[str, object],
+    *,
+    architecture: str,
+    expected_binding: dict[str, object],
+) -> None:
+    expected_top_keys = {
+        "schema_version",
+        "generated_at",
+        "status",
+        "harness_complete",
+        "release_ready",
+        "blocker_ids",
+        "unexpected_failed_checks",
+        "package_version_contract",
+        "scope",
+        "engine",
+        "package_roots",
+        "platforms",
+        "qualification_binding",
+        "native_shard",
+    }
+    if set(report) != expected_top_keys:
+        raise LifecycleLabError("native shard report top-level schema is not exact")
+    required_coordinates = required_coordinates_for_architecture(architecture)
+    validate_qualification_binding(
+        report.get("qualification_binding"), expected=expected_binding
+    )
+    native_shard = report.get("native_shard")
+    if (
+        not isinstance(native_shard, dict)
+        or set(native_shard) != NATIVE_SHARD_KEYS
+        or type(native_shard.get("schema_version")) is not int
+        or native_shard.get("schema_version") != 1
+        or native_shard.get("architecture") != architecture
+    ):
+        raise LifecycleLabError("native shard identity is invalid")
+    scope = report.get("scope")
+    if not isinstance(scope, dict) or normalize_host_architecture(
+        str(scope.get("host_architecture", ""))
+    ) != architecture:
+        raise LifecycleLabError("native shard host architecture is inconsistent")
+    expected_coordinates_json = [
+        {"distribution": distribution, "architecture": item_architecture}
+        for distribution, item_architecture in sorted(required_coordinates)
+    ]
+    if (
+        scope.get("required_platform_coordinates") != expected_coordinates_json
+        or scope.get("missing_platform_coordinates") != []
+    ):
+        raise LifecycleLabError("native shard platform coordinate scope is not exact")
+    architecture_coverage = scope.get("architecture_coverage")
+    family_coverage = scope.get("family_architecture_coverage")
+    if (
+        not isinstance(architecture_coverage, list)
+        or len(architecture_coverage) != 1
+        or not isinstance(architecture_coverage[0], dict)
+        or architecture_coverage[0].get("architecture_id") != architecture
+        or not isinstance(family_coverage, list)
+        or len(family_coverage) != len(REQUIRED_FAMILIES)
+        or {
+            (item.get("family"), item.get("architecture_id"))
+            for item in family_coverage
+            if isinstance(item, dict)
+        }
+        != {(family, architecture) for family in REQUIRED_FAMILIES}
+    ):
+        raise LifecycleLabError("native shard coverage summary is not exact")
+    engine = report.get("engine")
+    if (
+        not isinstance(engine, dict)
+        or set(engine)
+        != {"name", "version", "rootless", "arm64_emulator", "arm64_binfmt"}
+        or engine.get("name") != "podman"
+        or not isinstance(engine.get("version"), str)
+        or not engine.get("version")
+        or engine.get("rootless") is not True
+        or engine.get("arm64_emulator") is not None
+        or engine.get("arm64_binfmt") is not None
+    ):
+        raise LifecycleLabError("native shard engine evidence is invalid")
+    roots = report.get("package_roots")
+    if (
+        not isinstance(roots, dict)
+        or set(roots) != {"candidate", "previous", "mount_mode"}
+        or roots.get("mount_mode") != "read-only"
+        or not isinstance(roots.get("candidate"), str)
+        or not Path(roots["candidate"]).is_absolute()
+        or not isinstance(roots.get("previous"), str)
+        or not Path(roots["previous"]).is_absolute()
+        or roots["candidate"] == roots["previous"]
+    ):
+        raise LifecycleLabError("native shard package roots are invalid")
+    platforms = report.get("platforms")
+    if not isinstance(platforms, list) or len(platforms) != len(required_coordinates):
+        raise LifecycleLabError("native shard platform inventory is incomplete")
+    specs = {
+        platform_coordinate(spec): spec
+        for spec in DEFAULT_PLATFORMS
+        if spec.architecture == architecture
+    }
+    seen: set[tuple[str, str]] = set()
+    observed_order: list[tuple[str, str]] = []
+    for platform_result in platforms:
+        if not isinstance(platform_result, dict):
+            raise LifecycleLabError("native shard platform result is invalid")
+        coordinate = (
+            str(platform_result.get("distribution")),
+            str(platform_result.get("architecture_id")),
+        )
+        if coordinate in seen or coordinate not in required_coordinates:
+            raise LifecycleLabError(
+                "native shard platform coordinate is duplicate or unsupported"
+            )
+        seen.add(coordinate)
+        observed_order.append(coordinate)
+        spec = specs[coordinate]
+        expected_platform_metadata = {
+            "family": spec.family,
+            "architecture": ARCHITECTURE_LABELS[spec.architecture],
+            "package_architecture": spec.package_architecture,
+            "podman_platform": spec.podman_platform,
+            "image": spec.image,
+            "lifecycle_network": "disabled",
+            "bootstrap_execution": "native_container_build",
+        }
+        if any(
+            platform_result.get(key) != value
+            for key, value in expected_platform_metadata.items()
+        ):
+            raise LifecycleLabError(
+                f"native shard platform metadata is invalid at {coordinate}"
+            )
+        probe = platform_result.get("architecture_probe")
+        if (
+            not isinstance(probe, dict)
+            or set(probe)
+            != {
+                "status",
+                "execution_mode",
+                "podman_platform",
+                "expected_uname",
+                "actual_uname",
+                "container_exit_code",
+                "network",
+                "filesystem",
+                "emulator",
+                "binfmt",
+            }
+            or probe.get("status") != "available"
+            or probe.get("execution_mode") != "native"
+            or probe.get("podman_platform") != spec.podman_platform
+            or probe.get("expected_uname") != spec.uname_architecture
+            or probe.get("actual_uname") != spec.uname_architecture
+            or type(probe.get("container_exit_code")) is not int
+            or probe.get("container_exit_code") != 0
+            or probe.get("network") != "disabled"
+            or probe.get("filesystem") != "read-only with bounded /tmp tmpfs"
+            or probe.get("emulator") is not None
+            or probe.get("binfmt") is not None
+        ):
+            raise LifecycleLabError(
+                f"native shard execution evidence is invalid at {coordinate}"
+            )
+    if seen != required_coordinates:
+        raise LifecycleLabError("native shard platform coordinate set is incomplete")
+    expected_order = [
+        platform_coordinate(spec)
+        for spec in DEFAULT_PLATFORMS
+        if spec.architecture == architecture
+    ]
+    if observed_order != expected_order:
+        raise LifecycleLabError("native shard platform coordinate order is not canonical")
+    validate_report_version_contract(
+        report,
+        required_platform_coordinates=required_coordinates,
+    )
+
+
+def _read_native_shard(
+    path: Path,
+    label: str,
+) -> tuple[dict[str, object], str, tuple[int, int]]:
+    absolute = path.expanduser().absolute()
+    try:
+        before = absolute.lstat()
+    except OSError as exc:
+        raise LifecycleLabError(f"cannot inspect {label}: {exc}") from exc
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise LifecycleLabError(f"{label} must be a regular non-symlink file")
+    if before.st_size <= 0 or before.st_size > 64 * 1024 * 1024:
+        raise LifecycleLabError(f"{label} size is invalid")
+    try:
+        payload = absolute.read_bytes()
+        after = absolute.lstat()
+    except OSError as exc:
+        raise LifecycleLabError(f"cannot read {label}: {exc}") from exc
+    if (
+        (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+        != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        or len(payload) != before.st_size
+    ):
+        raise LifecycleLabError(f"{label} changed while it was read")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise LifecycleLabError(f"{label} contains duplicate JSON key {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        report = json.loads(payload, object_pairs_hook=reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise LifecycleLabError(f"{label} is not strict UTF-8 JSON: {exc}") from exc
+    if not isinstance(report, dict):
+        raise LifecycleLabError(f"{label} root must be an object")
+    return (
+        report,
+        hashlib.sha256(payload).hexdigest(),
+        (before.st_dev, before.st_ino),
+    )
+
+
+def _aggregate_matrix_summary(
+    platform_results: Sequence[dict[str, object]],
+) -> tuple[str, dict[str, object], dict[str, object]]:
+    results_by_coordinate = {
+        (str(result.get("distribution")), str(result.get("architecture_id"))): result
+        for result in platform_results
+    }
+    if len(results_by_coordinate) != len(platform_results):
+        raise LifecycleLabError("native shard aggregate contains duplicate coordinates")
+    if set(results_by_coordinate) != REQUIRED_PLATFORM_COORDINATES:
+        raise LifecycleLabError("native shard aggregate platform matrix is not exact")
+    architecture_coverage: list[dict[str, object]] = []
+    family_architecture_coverage: list[dict[str, object]] = []
+    for architecture in ARCHITECTURE_LABELS:
+        expected = sorted(
+            coordinate
+            for coordinate in REQUIRED_PLATFORM_COORDINATES
+            if coordinate[1] == architecture
+        )
+        present = [results_by_coordinate[coordinate] for coordinate in expected]
+        architecture_coverage.append(
+            {
+                "architecture": ARCHITECTURE_LABELS[architecture],
+                "architecture_id": architecture,
+                "status": coverage_status(present, len(expected)),
+                "required_distributions": [item[0] for item in expected],
+                "completed_distributions": sorted(
+                    str(result["distribution"])
+                    for result in present
+                    if result["status"] == "pass"
+                ),
+                "incomplete_or_failed_distributions": sorted(
+                    str(result["distribution"])
+                    for result in present
+                    if result["status"] != "pass"
+                ),
+            }
+        )
+        for family in REQUIRED_FAMILIES:
+            specs = [
+                spec
+                for spec in DEFAULT_PLATFORMS
+                if spec.architecture == architecture and spec.family == family
+            ]
+            family_results = [
+                results_by_coordinate[platform_coordinate(spec)] for spec in specs
+            ]
+            family_architecture_coverage.append(
+                {
+                    "family": family,
+                    "architecture": ARCHITECTURE_LABELS[architecture],
+                    "architecture_id": architecture,
+                    "status": coverage_status(family_results, len(specs)),
+                    "required_distributions": [spec.distribution for spec in specs],
+                    "completed_distributions": sorted(
+                        str(result["distribution"])
+                        for result in family_results
+                        if result["status"] == "pass"
+                    ),
+                }
+            )
+    if any(result.get("status") == "fail" for result in platform_results):
+        status = "fail"
+    elif any(result.get("status") != "pass" for result in platform_results):
+        status = "incomplete"
+    else:
+        status = "pass"
+    classification = classify_lifecycle_evidence(platform_results)
+    scope = {
+        "container_lab_complete": status == "pass",
+        "coordinate_classification": classification["coordinate_classification"],
+        "host_architecture": NATIVE_AGGREGATE_HOST,
+        "network_during_image_bootstrap": (
+            "rootless Podman default on each native architecture shard"
+        ),
+        "network_during_package_operations": "disabled",
+        "host_mutation": (
+            "bounded to rootless Podman storage and temporary workdirs on each "
+            "native architecture runner"
+        ),
+        "architectures_completed": [
+            item["architecture"]
+            for item in architecture_coverage
+            if item["status"] == "pass"
+        ],
+        "architectures_incomplete_or_failed": [
+            {
+                "architecture": item["architecture"],
+                "status": item["status"],
+                "reason": (
+                    "not every required distribution completed every lifecycle scenario"
+                ),
+            }
+            for item in architecture_coverage
+            if item["status"] != "pass"
+        ],
+        "architecture_coverage": architecture_coverage,
+        "family_architecture_coverage": family_architecture_coverage,
+        "required_platform_coordinates": [
+            {"distribution": distribution, "architecture": architecture}
+            for distribution, architecture in sorted(REQUIRED_PLATFORM_COORDINATES)
+        ],
+        "missing_platform_coordinates": [],
+        "arm64_coverage_policy": (
+            "arm64/aarch64 qualification requires the native ubuntu-24.04-arm "
+            "shard; emulation and binfmt execution are forbidden"
+        ),
+        "rollback_model": (
+            "external package-manager downgrade to the separately supplied, "
+            "checksum-verified previous artifact; this is not a SysWarden "
+            "product rollback feature"
+        ),
+        "freebsd": {
+            "status": "vm_required",
+            "reason": (
+                "A real FreeBSD VM is required for pkg, rc.d, PF, service "
+                "startup, signature loading, and runtime-path validation."
+            ),
+        },
+    }
+    return status, classification, scope
+
+
+def aggregate_native_shard_reports(args: argparse.Namespace) -> dict[str, object]:
+    candidate_root, previous_root, pairs = validate_inputs(
+        args.packages_dir,
+        args.previous_packages_dir,
+        DEFAULT_PLATFORMS,
+    )
+    version_contract = build_package_version_contract(pairs)
+    expected_binding = build_qualification_binding(
+        args,
+        candidate_root,
+        previous_root,
+        version_contract,
+    )
+    paths = {
+        "amd64": args.aggregate_amd64_report,
+        "arm64": args.aggregate_arm64_report,
+    }
+    shard_reports: dict[str, dict[str, object]] = {}
+    shard_digests: dict[str, str] = {}
+    identities: set[tuple[int, int]] = set()
+    for architecture in ("amd64", "arm64"):
+        report, digest, identity = _read_native_shard(
+            paths[architecture], f"{architecture} native shard report"
+        )
+        if identity in identities:
+            raise LifecycleLabError("native shard reports must have distinct inodes")
+        identities.add(identity)
+        validate_native_shard_report(
+            report,
+            architecture=architecture,
+            expected_binding=expected_binding,
+        )
+        shard_reports[architecture] = report
+        shard_digests[architecture] = digest
+
+    expected_contract_coordinates = {
+        str(item["coordinate"]): item
+        for item in version_contract["coordinates"]
+        if isinstance(item, dict)
+    }
+    platform_results: list[dict[str, object]] = []
+    observed_package_coordinates: set[str] = set()
+    for architecture in ("amd64", "arm64"):
+        shard = shard_reports[architecture]
+        shard_contract = shard["package_version_contract"]
+        if not isinstance(shard_contract, dict):
+            raise LifecycleLabError("native shard version contract is invalid")
+        for key in (
+            "scheme",
+            "relation",
+            "previous_version",
+            "candidate_version",
+            "previous_numeric",
+            "candidate_numeric",
+        ):
+            if shard_contract.get(key) != version_contract[key]:
+                raise LifecycleLabError(
+                    f"{architecture} shard version contract differs at {key}"
+                )
+        coordinates = shard_contract.get("coordinates")
+        if not isinstance(coordinates, list):
+            raise LifecycleLabError("native shard package coordinates are invalid")
+        for item in coordinates:
+            if not isinstance(item, dict):
+                raise LifecycleLabError("native shard package coordinate is invalid")
+            coordinate = str(item.get("coordinate"))
+            if (
+                coordinate in observed_package_coordinates
+                or expected_contract_coordinates.get(coordinate) != item
+            ):
+                raise LifecycleLabError(
+                    "native shard package coordinate is duplicate or mismatched"
+                )
+            observed_package_coordinates.add(coordinate)
+        platforms = shard.get("platforms")
+        if not isinstance(platforms, list):
+            raise LifecycleLabError("native shard platform list is invalid")
+        for platform_result in platforms:
+            if not isinstance(platform_result, dict):
+                raise LifecycleLabError("native shard platform result is invalid")
+            coordinate = f"{platform_result.get('family')}:{platform_result.get('package_architecture')}"
+            pair = pairs.get(coordinate)
+            if pair is None:
+                raise LifecycleLabError("native shard references an unknown package coordinate")
+            if platform_result.get("candidate") != {
+                "filename": pair.candidate.path.name,
+                "version": pair.candidate.version,
+                "sha256": pair.candidate.sha256,
+            } or platform_result.get("previous") != {
+                "filename": pair.previous.path.name,
+                "version": pair.previous.version,
+                "sha256": pair.previous.sha256,
+            }:
+                raise LifecycleLabError(
+                    "native shard artifact evidence differs from current package bytes"
+                )
+            platform_results.append(platform_result)
+    if observed_package_coordinates != set(expected_contract_coordinates):
+        raise LifecycleLabError("native shard package coordinate union is incomplete")
+
+    status, classification, scope = _aggregate_matrix_summary(platform_results)
+    native_records = []
+    for architecture in ("amd64", "arm64"):
+        shard = shard_reports[architecture]
+        shard_scope = shard["scope"]
+        shard_engine = shard["engine"]
+        if not isinstance(shard_scope, dict) or not isinstance(shard_engine, dict):
+            raise LifecycleLabError("native shard metadata is invalid")
+        native_records.append(
+            {
+                "architecture": architecture,
+                "host_architecture": normalize_host_architecture(
+                    str(shard_scope["host_architecture"])
+                ),
+                "report_sha256": shard_digests[architecture],
+                "engine_name": shard_engine["name"],
+                "engine_version": shard_engine["version"],
+            }
+        )
+    report: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "status": status,
+        "harness_complete": classification["harness_complete"],
+        "release_ready": classification["release_ready"],
+        "blocker_ids": classification["blocker_ids"],
+        "unexpected_failed_checks": classification["unexpected_failed_checks"],
+        "package_version_contract": version_contract,
+        "scope": scope,
+        "engine": {
+            "name": "podman",
+            "version": ";".join(
+                f"{item['architecture']}={item['engine_version']}"
+                for item in native_records
+            ),
+            "rootless": True,
+            "arm64_emulator": None,
+            "arm64_binfmt": None,
+        },
+        "package_roots": {
+            "candidate": str(candidate_root),
+            "previous": str(previous_root),
+            "mount_mode": "read-only",
+        },
+        "platforms": platform_results,
+        "qualification_binding": expected_binding,
+        "native_shards": {
+            "schema_version": 1,
+            "mode": "native_architecture_shards_v1",
+            "reports": native_records,
+        },
+    }
     validate_report_version_contract(report)
     return report
 
@@ -3864,6 +4600,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--pretty", action="store_true")
     parser.add_argument("--podman", default="podman")
+    parser.add_argument("--architecture-shard", choices=("amd64", "arm64"))
+    parser.add_argument("--aggregate-amd64-report", type=Path)
+    parser.add_argument("--aggregate-arm64-report", type=Path)
+    parser.add_argument("--qualification-repository")
+    parser.add_argument("--qualification-release-sha")
+    parser.add_argument("--qualification-release-tag")
+    parser.add_argument("--qualification-previous-tag")
+    parser.add_argument("--qualification-workflow-run-id")
+    parser.add_argument("--qualification-workflow-run-attempt")
+    parser.add_argument("--qualification-candidate-run-id")
+    parser.add_argument("--qualification-candidate-artifact-id")
+    parser.add_argument("--qualification-candidate-artifact-name")
+    parser.add_argument("--qualification-previous-release-id")
     parser.add_argument(
         "--arm64-emulator",
         type=Path,
@@ -3942,6 +4691,8 @@ def configured_platforms(args: argparse.Namespace) -> tuple[PlatformSpec, ...]:
             }
         )
         for spec in DEFAULT_PLATFORMS
+        if args.architecture_shard is None
+        or spec.architecture == args.architecture_shard
     )
 
 
@@ -3961,13 +4712,31 @@ def error_report(exc: Exception) -> dict[str, object]:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.scenario_timeout < 30:
+    aggregate_requested = (
+        args.aggregate_amd64_report is not None
+        or args.aggregate_arm64_report is not None
+    )
+    if aggregate_requested and (
+        args.aggregate_amd64_report is None
+        or args.aggregate_arm64_report is None
+        or args.architecture_shard is not None
+        or args.arm64_emulator is not None
+    ):
+        report = error_report(
+            LifecycleLabError(
+                "aggregation requires exactly both shard reports and forbids shard/emulator options"
+            )
+        )
+    elif args.scenario_timeout < 30:
         report = error_report(
             LifecycleLabError("--scenario-timeout must be at least 30 seconds")
         )
     else:
         try:
-            report = run_lab(args, platforms=configured_platforms(args))
+            if aggregate_requested:
+                report = aggregate_native_shard_reports(args)
+            else:
+                report = run_lab(args, platforms=configured_platforms(args))
         except (LifecycleLabError, OSError) as exc:
             report = error_report(exc)
 

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -308,6 +308,60 @@ class PackageLifecycleLabTests(unittest.TestCase):
         values.update(overrides)
         return argparse.Namespace(**values)
 
+    def qualification_args(self, architecture: str, **overrides: object) -> argparse.Namespace:
+        values: dict[str, object] = {
+            **vars(self.args()),
+            "architecture_shard": architecture,
+            "arm64_emulator": None,
+            "qualification_repository": "duggytuxy/syswarden",
+            "qualification_release_sha": "a" * 40,
+            "qualification_release_tag": "v4.02.8",
+            "qualification_previous_tag": "v4.02.7",
+            "qualification_workflow_run_id": "1001",
+            "qualification_workflow_run_attempt": "1",
+            "qualification_candidate_run_id": "900",
+            "qualification_candidate_artifact_id": "901",
+            "qualification_candidate_artifact_name": "syswarden-packages-4.02.8",
+            "qualification_previous_release_id": "800",
+            "aggregate_amd64_report": None,
+            "aggregate_arm64_report": None,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def native_shard_reports(self) -> tuple[dict[str, object], dict[str, object]]:
+        reports = []
+        for architecture, host in (("amd64", "x86_64"), ("arm64", "aarch64")):
+            platforms = tuple(
+                spec
+                for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+                if spec.architecture == architecture
+            )
+            reports.append(
+                package_lifecycle_lab.run_lab(
+                    self.qualification_args(architecture),
+                    runner=FakePodmanRunner(),
+                    platforms=platforms,
+                    host_architecture=host,
+                )
+            )
+        return reports[0], reports[1]
+
+    def aggregate_args(
+        self,
+        amd64_path: Path,
+        arm64_path: Path,
+        **overrides: object,
+    ) -> argparse.Namespace:
+        values = {
+            **vars(self.qualification_args("amd64")),
+            "architecture_shard": None,
+            "aggregate_amd64_report": amd64_path,
+            "aggregate_arm64_report": arm64_path,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
     def run_embedded_inventory_contract(
         self,
         family: str,
@@ -393,8 +447,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             pair = package_lifecycle_lab.PackagePair(
                 candidate=package_lifecycle_lab.PackageArtifact(
                     self.candidate
-                    / f"syswarden_4.02.12_{spec.package_architecture}.apk",
-                    "4.02.12",
+                    / f"syswarden_4.02.13_{spec.package_architecture}.apk",
+                    "4.02.13",
                     "a" * 64,
                 ),
                 previous=package_lifecycle_lab.PackageArtifact(
@@ -1050,7 +1104,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         previous_path = self.root / "syswarden_4.02.8_x86_64.apk"
         previous_path.write_bytes(b"exact historical APK fixture")
         previous = str(previous_path)
-        candidate_path = self.root / "syswarden_4.02.12_x86_64.apk"
+        candidate_path = self.root / "syswarden_4.02.13_x86_64.apk"
         candidate_path.write_bytes(b"candidate APK fixture")
         candidate = str(candidate_path)
         previous_sha256 = hashlib.sha256(previous_path.read_bytes()).hexdigest()
@@ -1144,11 +1198,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
             f'CALLS="{calls}"\n'
             f'RESTART_STATE_FILE="{restart}"\n'
             'PREVIOUS_PACKAGE="/previous/exact-v4.02.8.apk"\n'
-            'CANDIDATE_PACKAGE="/candidate/v4.02.12.apk"\n'
+            'CANDIDATE_PACKAGE="/candidate/v4.02.13.apk"\n'
             'PREVIOUS_VERSION="4.02.8"\n'
-            'CANDIDATE_VERSION="4.02.12"\n'
+            'CANDIDATE_VERSION="4.02.13"\n'
             'EXPECTED_PREVIOUS_VERSION="4.02.8"\n'
-            'EXPECTED_CANDIDATE_VERSION="4.02.12"\n'
+            'EXPECTED_CANDIDATE_VERSION="4.02.13"\n'
             'FORWARD_ONLY_APK_TRANSITION="1"\n'
             "prepare_expected_payloads() { return 0; }\n"
             "seed_state() { :; }\n"
@@ -1506,6 +1560,248 @@ class PackageLifecycleLabTests(unittest.TestCase):
         self.assertTrue(all("--platform" in call for call in build_calls))
         self.assertTrue(all("--network=host" not in call for call in build_calls))
 
+    def test_native_shards_cover_exact_architecture_without_emulation(self) -> None:
+        amd64, arm64 = self.native_shard_reports()
+        for architecture, report in (("amd64", amd64), ("arm64", arm64)):
+            with self.subTest(architecture=architecture):
+                self.assertEqual(report["status"], "pass")
+                self.assertEqual(
+                    report["native_shard"],
+                    {"schema_version": 1, "architecture": architecture},
+                )
+                self.assertEqual(
+                    {item["architecture_id"] for item in report["platforms"]},
+                    {architecture},
+                )
+                self.assertEqual(len(report["platforms"]), 5)
+                self.assertIsNone(report["engine"]["arm64_emulator"])
+                self.assertIsNone(report["engine"]["arm64_binfmt"])
+                self.assertTrue(
+                    all(
+                        item["architecture_probe"]["execution_mode"] == "native"
+                        and item["architecture_probe"]["emulator"] is None
+                        and item["architecture_probe"]["binfmt"] is None
+                        for item in report["platforms"]
+                    )
+                )
+
+    def test_native_shard_rejects_wrong_host_and_any_emulator(self) -> None:
+        amd64_platforms = tuple(
+            spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if spec.architecture == "amd64"
+        )
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "requires a native amd64 host",
+        ):
+            package_lifecycle_lab.run_lab(
+                self.qualification_args("amd64"),
+                runner=FakePodmanRunner(),
+                platforms=amd64_platforms,
+                host_architecture="aarch64",
+            )
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "forbid ARM64 emulation",
+        ):
+            package_lifecycle_lab.run_lab(
+                self.qualification_args("amd64", arm64_emulator=self.emulator),
+                runner=FakePodmanRunner(),
+                platforms=amd64_platforms,
+                host_architecture="x86_64",
+            )
+
+    def test_native_shard_aggregate_is_exact_digest_bound_and_adapter_compatible(self) -> None:
+        amd64, arm64 = self.native_shard_reports()
+        amd64_path = self.root / "package-lifecycle-amd64.json"
+        arm64_path = self.root / "package-lifecycle-arm64.json"
+        for path, report in ((amd64_path, amd64), (arm64_path, arm64)):
+            path.write_text(
+                json.dumps(report, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        aggregate = package_lifecycle_lab.aggregate_native_shard_reports(
+            self.aggregate_args(amd64_path, arm64_path)
+        )
+        self.assertEqual(aggregate["status"], "pass")
+        self.assertTrue(aggregate["harness_complete"])
+        self.assertTrue(aggregate["release_ready"])
+        self.assertEqual(
+            aggregate["scope"]["host_architecture"],
+            package_lifecycle_lab.NATIVE_AGGREGATE_HOST,
+        )
+        self.assertEqual(len(aggregate["platforms"]), 10)
+        self.assertEqual(
+            [item["architecture"] for item in aggregate["native_shards"]["reports"]],
+            ["amd64", "arm64"],
+        )
+        for path, record in zip(
+            (amd64_path, arm64_path),
+            aggregate["native_shards"]["reports"],
+            strict=True,
+        ):
+            self.assertEqual(
+                record["report_sha256"],
+                hashlib.sha256(path.read_bytes()).hexdigest(),
+            )
+        package_lifecycle_lab.validate_report_version_contract(aggregate)
+
+    def test_native_shard_aggregate_propagates_product_failure(self) -> None:
+        amd64, arm64 = self.native_shard_reports()
+        arm64_platforms = tuple(
+            spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if spec.architecture == "arm64"
+        )
+        arm64 = package_lifecycle_lab.run_lab(
+            self.qualification_args("arm64"),
+            runner=FakePodmanRunner(event_status="fail"),
+            platforms=arm64_platforms,
+            host_architecture="aarch64",
+        )
+        amd64_path = self.root / "failed-aggregate-amd64.json"
+        arm64_path = self.root / "failed-aggregate-arm64.json"
+        amd64_path.write_text(json.dumps(amd64) + "\n", encoding="utf-8")
+        arm64_path.write_text(json.dumps(arm64) + "\n", encoding="utf-8")
+
+        aggregate = package_lifecycle_lab.aggregate_native_shard_reports(
+            self.aggregate_args(amd64_path, arm64_path)
+        )
+        self.assertEqual(aggregate["status"], "fail")
+        self.assertFalse(aggregate["harness_complete"])
+        self.assertFalse(aggregate["release_ready"])
+        self.assertTrue(aggregate["unexpected_failed_checks"])
+
+    def test_native_shard_aggregate_rejects_mutated_binding_matrix_and_execution(self) -> None:
+        baseline_amd64, baseline_arm64 = self.native_shard_reports()
+        mutations = {
+            "run mismatch": lambda report: report["qualification_binding"].__setitem__(
+                "workflow_run_id", 1002
+            ),
+            "manifest mismatch": lambda report: report[
+                "qualification_binding"
+            ].__setitem__("candidate_manifest_sha256", "0" * 64),
+            "binding missing": lambda report: report[
+                "qualification_binding"
+            ].pop("workflow_run_id"),
+            "binding null": lambda report: report[
+                "qualification_binding"
+            ].__setitem__("workflow_run_id", None),
+            "binding string": lambda report: report[
+                "qualification_binding"
+            ].__setitem__("workflow_run_id", "1001"),
+            "emulated arm64": lambda report: report["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("execution_mode", "host_binfmt_qemu_aarch64"),
+            "wrong native uname": lambda report: report["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("actual_uname", "x86_64"),
+            "missing coordinate": lambda report: report["platforms"].pop(),
+            "duplicate coordinate": lambda report: report["platforms"].__setitem__(
+                -1, dict(report["platforms"][0])
+            ),
+            "reordered coordinates": lambda report: report["platforms"].reverse(),
+            "package contract mismatch": lambda report: report[
+                "package_version_contract"
+            ]["coordinates"][0].__setitem__("candidate_version", "4.02.9"),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                amd64 = json.loads(json.dumps(baseline_amd64))
+                arm64 = json.loads(json.dumps(baseline_arm64))
+                target = arm64 if name in {
+                    "emulated arm64",
+                    "wrong native uname",
+                    "missing coordinate",
+                    "duplicate coordinate",
+                    "reordered coordinates",
+                } else amd64
+                mutate(target)
+                amd64_path = self.root / f"{name}-amd64.json"
+                arm64_path = self.root / f"{name}-arm64.json"
+                amd64_path.write_text(json.dumps(amd64) + "\n", encoding="utf-8")
+                arm64_path.write_text(json.dumps(arm64) + "\n", encoding="utf-8")
+                with self.assertRaises(package_lifecycle_lab.LifecycleLabError):
+                    package_lifecycle_lab.aggregate_native_shard_reports(
+                        self.aggregate_args(amd64_path, arm64_path)
+                    )
+
+        single = self.root / "same-shard.json"
+        single.write_text(json.dumps(baseline_amd64) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "distinct inodes",
+        ):
+            package_lifecycle_lab.aggregate_native_shard_reports(
+                self.aggregate_args(single, single)
+            )
+
+    def test_native_shard_reader_rejects_duplicate_json_keys(self) -> None:
+        amd64, arm64 = self.native_shard_reports()
+        amd64_path = self.root / "duplicate-amd64.json"
+        arm64_path = self.root / "duplicate-arm64.json"
+        payload = json.dumps(amd64)
+        amd64_path.write_text(
+            payload.replace("{", '{"schema_version":3,', 1) + "\n",
+            encoding="utf-8",
+        )
+        arm64_path.write_text(json.dumps(arm64) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "duplicate JSON key",
+        ):
+            package_lifecycle_lab.aggregate_native_shard_reports(
+                self.aggregate_args(amd64_path, arm64_path)
+            )
+
+    def test_native_shard_aggregate_cli_writes_exact_report(self) -> None:
+        amd64, arm64 = self.native_shard_reports()
+        amd64_path = self.root / "cli-amd64.json"
+        arm64_path = self.root / "cli-arm64.json"
+        output = self.root / "cli-aggregate.json"
+        amd64_path.write_text(json.dumps(amd64) + "\n", encoding="utf-8")
+        arm64_path.write_text(json.dumps(arm64) + "\n", encoding="utf-8")
+        arguments = (
+            "--packages-dir",
+            str(self.candidate),
+            "--previous-packages-dir",
+            str(self.previous),
+            "--aggregate-amd64-report",
+            str(amd64_path),
+            "--aggregate-arm64-report",
+            str(arm64_path),
+            "--qualification-repository",
+            "duggytuxy/syswarden",
+            "--qualification-release-sha",
+            "a" * 40,
+            "--qualification-release-tag",
+            "v4.02.8",
+            "--qualification-previous-tag",
+            "v4.02.7",
+            "--qualification-workflow-run-id",
+            "1001",
+            "--qualification-workflow-run-attempt",
+            "1",
+            "--qualification-candidate-run-id",
+            "900",
+            "--qualification-candidate-artifact-id",
+            "901",
+            "--qualification-candidate-artifact-name",
+            "syswarden-packages-4.02.8",
+            "--qualification-previous-release-id",
+            "800",
+            "--output",
+            str(output),
+            "--pretty",
+        )
+        with mock.patch("sys.stdout") as stdout:
+            self.assertEqual(package_lifecycle_lab.main(arguments), 0)
+        written = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(written["status"], "pass")
+        self.assertEqual(len(written["platforms"]), 10)
+        stdout.write.assert_called_once()
+
     def test_report_version_contract_rejects_schema_order_and_platform_tampering(
         self,
     ) -> None:
@@ -1653,11 +1949,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 architecture
             ]
             platform_result.update(
-                candidate_version="4.02.12",
+                candidate_version="4.02.13",
                 previous_version="4.02.8",
                 candidate={
-                    "filename": f"syswarden_4.02.12_{architecture}.apk",
-                    "version": "4.02.12",
+                    "filename": f"syswarden_4.02.13_{architecture}.apk",
+                    "version": "4.02.13",
                     "sha256": "c" * 64,
                 },
                 previous={
@@ -1947,6 +2243,21 @@ class PackageLifecycleLabTests(unittest.TestCase):
                             f"{scenario}.{label}.postinstall_contract", checks
                         )
 
+    def test_apk_postinstall_contract_covers_fresh_upgrade_reinstall_and_recovery(self) -> None:
+        upgrade_checks = package_lifecycle_lab.expected_event_checks(
+            "apk", "upgrade-rollback"
+        )
+        for label in ("candidate", "reinstall", "recovery"):
+            self.assertIn(
+                f"upgrade-rollback.{label}.postinstall_contract",
+                upgrade_checks,
+            )
+        for scenario in ("remove", "purge"):
+            self.assertIn(
+                f"{scenario}.fresh.postinstall_contract",
+                package_lifecycle_lab.expected_event_checks("apk", scenario),
+            )
+
     def test_bootstrap_preinstalls_every_declared_runtime_dependency(self) -> None:
         expected = {
             "deb": (
@@ -1969,6 +2280,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 {
                     "nftables", "curl", "wget", "rsyslog", "rsyslog-uxsock",
                     "bash-completion", "wireguard-tools", "libqrencode-tools", "jq",
+                    "openrc",
                 },
             ),
         }
@@ -2221,6 +2533,23 @@ class PackageLifecycleLabTests(unittest.TestCase):
             package_lifecycle_lab.REQUIRED_PLATFORM_COORDINATES,
         )
         self.assertTrue(all("@sha256:" in spec.image for spec in configured))
+
+        arm_shard = parser.parse_args(
+            (
+                "--packages-dir",
+                str(self.candidate),
+                "--previous-packages-dir",
+                str(self.previous),
+                "--architecture-shard",
+                "arm64",
+            )
+        )
+        arm_configured = package_lifecycle_lab.configured_platforms(arm_shard)
+        self.assertEqual(len(arm_configured), 5)
+        self.assertEqual(
+            {spec.architecture for spec in arm_configured},
+            {"arm64"},
+        )
 
         replacement_image = (
             "docker.io/library/ubuntu:24.04@sha256:" + "f" * 64

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -823,15 +823,31 @@ printf 'gh\\n' >> "${FAKE_LOG}"
             1,
         )
         for section in (validate, privileged):
+            for argument in (
+                "--package-amd64-shard",
+                "--package-arm64-shard",
+                "--expected-repository",
+                "--expected-workflow-run-id",
+                "--expected-workflow-run-attempt 1",
+                "--expected-candidate-run-id",
+                "--expected-candidate-artifact-id",
+                "--expected-candidate-artifact-name",
+                "--expected-previous-release-id",
+            ):
+                self.assertIn(argument, section)
             self.assertIn("EVIDENCE_SHA256SUMS.txt qualification-context.json", section)
             self.assertIn("aggregate bound packages raw status", section)
             self.assertIn("qualification_root_directories+=(tools update)", section)
             self.assertIn("qualification_all_directories+=(tools update)", section)
             self.assertIn("qualification_raw_files+=(freebsd-updater-raw.json)", section)
-            self.assertIn(
-                "freebsd-vm-raw.json nftables-raw.json package-lifecycle-raw.json",
-                section,
-            )
+            for raw_name in (
+                "freebsd-vm-raw.json",
+                "nftables-raw.json",
+                "package-lifecycle-amd64.json",
+                "package-lifecycle-arm64.json",
+                "package-lifecycle-raw.json",
+            ):
+                self.assertIn(raw_name, section)
             self.assertIn(
                 "freebsd-vm-bound.json nftables-bound.json package-lifecycle-bound.json",
                 section,
@@ -990,6 +1006,7 @@ printf 'gh\\n' >> "${FAKE_LOG}"
             workflow, "Require Protected Maintainer Release Environment"
         )
         self.assertIn("required_environment_boolean()", environment_script)
+        self.assertIn("required_top_level_environment_boolean()", environment_script)
         self.assertIn('if type == "boolean" then', environment_script)
         self.assertIn("tostring", environment_script)
         self.assertNotIn('// "missing"', environment_script)
@@ -1003,6 +1020,7 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         )
         valid = {
             "name": "syswarden-release-production",
+            "can_admins_bypass": False,
             "protection_rules": [
                 {
                     "type": "required_reviewers",
@@ -1042,8 +1060,16 @@ printf 'gh\\n' >> "${FAKE_LOG}"
                 self.assertNotEqual(result.returncode, 0, diagnostic)
                 self.assertNotIn("must be boolean", diagnostic)
                 self.assertIn(
-                    "must require exactly one approval", diagnostic
+                    "must forbid administrator bypass", diagnostic
                 )
+
+        mutated = json.loads(json.dumps(valid))
+        mutated["can_admins_bypass"] = True
+        result = run_environment_gate(script, mutated, policies)
+        diagnostic = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0, diagnostic)
+        self.assertNotIn("must be boolean", diagnostic)
+        self.assertIn("must forbid administrator bypass", diagnostic)
 
         for name, field, value, missing in (
             ("protected missing", "protected_branches", None, True),
@@ -1066,6 +1092,22 @@ printf 'gh\\n' >> "${FAKE_LOG}"
                     f"deployment_branch_policy.{field} must be boolean",
                     diagnostic,
                 )
+
+        for name, value, missing in (
+            ("admin bypass missing", None, True),
+            ("admin bypass null", None, False),
+            ("admin bypass string", "false", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                if missing:
+                    del mutated["can_admins_bypass"]
+                else:
+                    mutated["can_admins_bypass"] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertIn("can_admins_bypass must be boolean", diagnostic)
 
     def test_privileged_publisher_requires_exact_immutable_tag_ruleset(self) -> None:
         workflow = (

--- a/scripts/ci/release_qualification_adapter.py
+++ b/scripts/ci/release_qualification_adapter.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Strictly bind raw SysWarden runtime-lab reports to release evidence.
 
-The laboratory reports deliberately contain no Git or release-package binding.
-This adapter validates their exact schemas, independently re-verifies the Git
-checkout and both package sets, derives all qualification decisions from nested
-evidence, and emits the three canonical envelopes consumed by
-``release_qualification_gate.py``.
+The native package shards carry an explicit qualification-run binding so their
+cross-run aggregation is independently reproducible. This adapter validates all
+exact schemas and shard digests, independently re-verifies the Git checkout and
+both package sets, derives decisions from nested evidence, and emits the three
+canonical envelopes consumed by ``release_qualification_gate.py``.
 """
 
 from __future__ import annotations
@@ -72,6 +72,8 @@ RAW_TOP_KEYS = {
             "engine",
             "package_roots",
             "platforms",
+            "qualification_binding",
+            "native_shards",
         }
     ),
     "freebsd": frozenset(
@@ -113,6 +115,7 @@ class ValidatedInputs:
     candidate: gate.PackageManifest
     previous: gate.PackageManifest
     raws: dict[str, RawReport]
+    package_shards: dict[str, RawReport]
     envelopes: dict[str, dict[str, Any]]
 
 
@@ -364,6 +367,38 @@ PACKAGE_SCOPE_KEYS = frozenset(
         "freebsd",
     }
 )
+PACKAGE_QUALIFICATION_BINDING_KEYS = frozenset(
+    {
+        "schema_version",
+        "repository",
+        "release_sha",
+        "release_tag",
+        "previous_tag",
+        "workflow_run_id",
+        "workflow_run_attempt",
+        "candidate_run_id",
+        "candidate_artifact_id",
+        "candidate_artifact_name",
+        "previous_release_id",
+        "candidate_manifest_sha256",
+        "previous_manifest_sha256",
+    }
+)
+PACKAGE_NATIVE_SHARDS_KEYS = frozenset({"schema_version", "mode", "reports"})
+PACKAGE_NATIVE_SHARD_RECORD_KEYS = frozenset(
+    {
+        "architecture",
+        "host_architecture",
+        "report_sha256",
+        "engine_name",
+        "engine_version",
+    }
+)
+PACKAGE_NATIVE_SHARD_NAMES = {
+    "amd64": "package-lifecycle-amd64.json",
+    "arm64": "package-lifecycle-arm64.json",
+}
+PACKAGE_NATIVE_AGGREGATE_HOST = "native-shards:amd64,arm64"
 PACKAGE_PLATFORM_KEYS = frozenset(
     {
         "name",
@@ -409,7 +444,201 @@ def _package_versions(document: dict[str, Any], expected_version: str) -> tuple[
     return previous, candidate
 
 
+def _validate_package_qualification_binding(
+    value: Any,
+) -> dict[str, Any]:
+    binding = _exact_keys(
+        value,
+        PACKAGE_QUALIFICATION_BINDING_KEYS,
+        "package.qualification_binding",
+    )
+    if _integer(binding["schema_version"], "package.qualification_binding.schema_version") != 1:
+        _fail("package qualification binding schema version must be 1")
+    for key in (
+        "repository",
+        "release_sha",
+        "release_tag",
+        "previous_tag",
+        "candidate_artifact_name",
+    ):
+        _string(binding[key], f"package.qualification_binding.{key}")
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", binding["repository"]) is None:
+        _fail("package qualification repository is not canonical")
+    if gate.SHA_RE.fullmatch(binding["release_sha"]) is None:
+        _fail("package qualification release SHA is not canonical")
+    for key in ("release_tag", "previous_tag"):
+        if gate.VERSION_RE.fullmatch(binding[key]) is None:
+            _fail(f"package qualification {key} is not canonical")
+    if binding["release_tag"] == binding["previous_tag"]:
+        _fail("package qualification release and previous tags must differ")
+    for key in (
+        "workflow_run_id",
+        "workflow_run_attempt",
+        "candidate_run_id",
+        "candidate_artifact_id",
+        "previous_release_id",
+    ):
+        if _integer(binding[key], f"package.qualification_binding.{key}") <= 0:
+            _fail(f"package qualification {key} must be positive")
+    for key in ("candidate_manifest_sha256", "previous_manifest_sha256"):
+        _sha256(binding[key], f"package.qualification_binding.{key}")
+    return binding
+
+
+def _validate_package_native_shards(value: Any) -> dict[str, dict[str, Any]]:
+    native_shards = _exact_keys(
+        value,
+        PACKAGE_NATIVE_SHARDS_KEYS,
+        "package.native_shards",
+    )
+    if _integer(native_shards["schema_version"], "package.native_shards.schema_version") != 1:
+        _fail("package native shard schema version must be 1")
+    if native_shards["mode"] != "native_architecture_shards_v1":
+        _fail("package native shard mode is invalid")
+    reports = _list(native_shards["reports"], "package.native_shards.reports")
+    if len(reports) != 2:
+        _fail("package native shard inventory must contain exactly two reports")
+    by_architecture: dict[str, dict[str, Any]] = {}
+    architecture_order: list[str] = []
+    for index, value in enumerate(reports):
+        report = _exact_keys(
+            value,
+            PACKAGE_NATIVE_SHARD_RECORD_KEYS,
+            f"package.native_shards.reports[{index}]",
+        )
+        architecture = _string(
+            report["architecture"],
+            f"package.native_shards.reports[{index}].architecture",
+        )
+        for key in ("host_architecture", "engine_name", "engine_version"):
+            _string(
+                report[key],
+                f"package.native_shards.reports[{index}].{key}",
+            )
+        _sha256(
+            report["report_sha256"],
+            f"package.native_shards.reports[{index}].report_sha256",
+        )
+        if architecture in by_architecture or architecture not in {"amd64", "arm64"}:
+            _fail("package native shard architecture is duplicate or unsupported")
+        if report["host_architecture"] != architecture or report["engine_name"] != "podman":
+            _fail("package native shard host or engine identity is invalid")
+        by_architecture[architecture] = report
+        architecture_order.append(architecture)
+    if set(by_architecture) != {"amd64", "arm64"}:
+        _fail("package native shard architecture inventory is incomplete")
+    if architecture_order != ["amd64", "arm64"]:
+        _fail("package native shard inventory order must be amd64 then arm64")
+    return by_architecture
+
+
+def _validate_package_shard_binding(
+    document: dict[str, Any],
+    package_shards: dict[str, RawReport],
+    expected_binding: dict[str, Any],
+) -> None:
+    binding = _validate_package_qualification_binding(
+        document["qualification_binding"]
+    )
+    if binding != expected_binding:
+        _fail("package qualification binding differs from the exact workflow inputs")
+    records = _validate_package_native_shards(document["native_shards"])
+    if set(package_shards) != {"amd64", "arm64"}:
+        _fail("package native shard file inventory is incomplete")
+    for architecture in ("amd64", "arm64"):
+        raw = package_shards[architecture]
+        record = records[architecture]
+        if raw.snapshot.path.name != PACKAGE_NATIVE_SHARD_NAMES[architecture]:
+            _fail(f"package {architecture} shard basename is invalid")
+        if raw.snapshot.sha256 != record["report_sha256"]:
+            _fail(f"package {architecture} shard digest differs from the aggregate")
+        try:
+            package_lab.validate_native_shard_report(
+                raw.document,
+                architecture=architecture,
+                expected_binding=expected_binding,
+            )
+        except (package_lab.LifecycleLabError, KeyError, TypeError, ValueError) as exc:
+            raise AdapterError(
+                f"invalid package {architecture} native shard evidence: {exc}"
+            ) from exc
+        engine = raw.document["engine"]
+        scope = raw.document["scope"]
+        if record != {
+            "architecture": architecture,
+            "host_architecture": package_lab.normalize_host_architecture(
+                scope["host_architecture"]
+            ),
+            "report_sha256": raw.snapshot.sha256,
+            "engine_name": engine["name"],
+            "engine_version": engine["version"],
+        }:
+            _fail(f"package {architecture} shard metadata differs from its report")
+    shard_platforms = [
+        platform
+        for architecture in ("amd64", "arm64")
+        for platform in package_shards[architecture].document["platforms"]
+    ]
+    if document.get("platforms") != shard_platforms:
+        _fail("package aggregate platform evidence differs from its native shards")
+    try:
+        aggregate_status, aggregate_classification, aggregate_scope = (
+            package_lab._aggregate_matrix_summary(shard_platforms)
+        )
+    except (package_lab.LifecycleLabError, KeyError, TypeError, ValueError) as exc:
+        raise AdapterError(
+            f"invalid package native shard aggregate evidence: {exc}"
+        ) from exc
+    if (
+        document.get("status") != aggregate_status
+        or document.get("harness_complete")
+        != aggregate_classification["harness_complete"]
+        or document.get("release_ready")
+        != aggregate_classification["release_ready"]
+        or document.get("blocker_ids") != aggregate_classification["blocker_ids"]
+        or document.get("unexpected_failed_checks")
+        != aggregate_classification["unexpected_failed_checks"]
+        or document.get("scope") != aggregate_scope
+    ):
+        _fail("package aggregate summary differs from its native shards")
+
+    shard_contracts = [
+        package_shards[architecture].document["package_version_contract"]
+        for architecture in ("amd64", "arm64")
+    ]
+    expected_contract = {
+        key: shard_contracts[0][key]
+        for key in (
+            "scheme",
+            "relation",
+            "previous_version",
+            "candidate_version",
+            "previous_numeric",
+            "candidate_numeric",
+        )
+    }
+    expected_contract["coordinates"] = sorted(
+        [
+            coordinate
+            for contract in shard_contracts
+            for coordinate in contract["coordinates"]
+        ],
+        key=lambda coordinate: coordinate["coordinate"],
+    )
+    if document.get("package_version_contract") != expected_contract:
+        _fail("package aggregate version contract differs from its native shards")
+    expected_engine_version = ";".join(
+        f"{architecture}={records[architecture]['engine_version']}"
+        for architecture in ("amd64", "arm64")
+    )
+    engine = document.get("engine")
+    if not isinstance(engine, dict) or engine.get("version") != expected_engine_version:
+        _fail("package aggregate engine version differs from native shard reports")
+
+
 def _validate_package_schema(document: dict[str, Any]) -> None:
+    _validate_package_qualification_binding(document["qualification_binding"])
+    _validate_package_native_shards(document["native_shards"])
     contract = _exact_keys(
         document["package_version_contract"], PACKAGE_CONTRACT_KEYS, "package.version_contract"
     )
@@ -447,8 +676,9 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
     normalized_host_architecture = package_lab.normalize_host_architecture(
         scope["host_architecture"]
     )
-    if normalized_host_architecture is None:
-        _fail("package host architecture is unsupported or ambiguous")
+    native_aggregate = scope["host_architecture"] == PACKAGE_NATIVE_AGGREGATE_HOST
+    if not native_aggregate or normalized_host_architecture is not None:
+        _fail("package report must identify the exact amd64 plus arm64 native shard model")
     if scope["network_during_package_operations"] != "disabled":
         _fail("package operations were not network-isolated")
     classification = _list(scope["coordinate_classification"], "package.scope.coordinate_classification")
@@ -522,6 +752,8 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
             _fail("package ARM64 binfmt evidence lacks the fix-binary flag")
         if emulator is None or binfmt["interpreter"] != emulator["path"]:
             _fail("package ARM64 binfmt interpreter does not match the emulator")
+    if emulator is not None or binfmt is not None:
+        _fail("package native shard qualification forbids ARM64 emulation")
 
     roots = _exact_keys(document["package_roots"], {"candidate", "previous", "mount_mode"}, "package.package_roots")
     _string(roots["candidate"], "package.package_roots.candidate")
@@ -596,7 +828,7 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
             _string(probe_binfmt["interpreter"], "package probe binfmt interpreter")
             if "F" not in _string(probe_binfmt["flags"], "package probe binfmt flags"):
                 _fail("package probe binfmt flags are invalid")
-        native_coordinate = spec.architecture == normalized_host_architecture
+        native_coordinate = native_aggregate
         cross_arm64_coordinate = (
             spec.architecture == "arm64"
             and normalized_host_architecture != "arm64"
@@ -679,8 +911,15 @@ def _validate_package(
     binding: gate.RepositoryBinding,
     candidate: gate.PackageManifest,
     previous: gate.PackageManifest,
+    package_shards: dict[str, RawReport],
+    expected_qualification_binding: dict[str, Any],
 ) -> dict[str, Any]:
     _validate_package_schema(document)
+    _validate_package_shard_binding(
+        document,
+        package_shards,
+        expected_qualification_binding,
+    )
     try:
         package_lab.validate_report_version_contract(document)
         classification = package_lab.classify_lifecycle_evidence(document["platforms"])
@@ -1123,8 +1362,8 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
         _string(item["version"], f"freebsd.inputs.{side}.version")
         _sha256(item["sha256"], f"freebsd.inputs.{side}.sha256")
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.12.txz"
-        and inputs["candidate"]["version"] == "4.02.12"
+        inputs["candidate"]["package"] == "syswarden-4.02.13.txz"
+        and inputs["candidate"]["version"] == "4.02.13"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]
@@ -1143,7 +1382,7 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
     if historical_binding_touched and not forward_only:
         _fail(
             "FreeBSD historical transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.12 contract"
+            "v4.02.8 -> v4.02.13 contract"
         )
     _string(inputs["pf_fixture"], "freebsd.inputs.pf_fixture")
     _sha256(inputs["pf_fixture_sha256"], "freebsd.inputs.pf_fixture_sha256")
@@ -1365,8 +1604,8 @@ def _validate_freebsd(
     derived_product = "pass"
     inputs = document["inputs"]
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.12.txz"
-        and inputs["candidate"]["version"] == "4.02.12"
+        inputs["candidate"]["package"] == "syswarden-4.02.13.txz"
+        and inputs["candidate"]["version"] == "4.02.13"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]
@@ -1505,8 +1744,9 @@ def _revalidate_all(
     candidate: gate.PackageManifest,
     previous: gate.PackageManifest,
     raws: dict[str, RawReport],
+    package_shards: dict[str, RawReport],
 ) -> None:
-    for raw in raws.values():
+    for raw in (*raws.values(), *package_shards.values()):
         gate.revalidate(raw.snapshot, f"{raw.label} raw report")
     for manifest, label in ((candidate, "candidate package evidence"), (previous, "previous package evidence")):
         for snapshot in manifest.snapshots:
@@ -1544,11 +1784,30 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
     candidate = gate.verify_packages(args.candidate_packages_dir, binding)
     raw_paths = {"nft": args.nft_raw, "package": args.package_raw, "freebsd": args.freebsd_raw}
     raws = {key: _load_raw(path, key, binding.root, current, args.max_age_seconds) for key, path in raw_paths.items()}
+    package_shard_paths = {
+        "amd64": args.package_amd64_shard,
+        "arm64": args.package_arm64_shard,
+    }
+    package_shards = {
+        architecture: _load_raw(
+            path,
+            f"package-{architecture}-shard",
+            binding.root,
+            current,
+            args.max_age_seconds,
+        )
+        for architecture, path in package_shard_paths.items()
+    }
     for key, raw in raws.items():
         if raw.snapshot.path.name != RAW_NAMES[key]:
             _fail(f"{key} raw basename must be exactly {RAW_NAMES[key]!r}")
-    if len({(item.snapshot.device, item.snapshot.inode) for item in raws.values()}) != 3 or len({item.snapshot.path for item in raws.values()}) != 3 or len({item.snapshot.path.name for item in raws.values()}) != 3:
-        _fail("the three raw reports must have distinct files, inodes, paths, and basenames")
+    all_raws = [*raws.values(), *package_shards.values()]
+    if (
+        len({(item.snapshot.device, item.snapshot.inode) for item in all_raws}) != 5
+        or len({item.snapshot.path for item in all_raws}) != 5
+        or len({item.snapshot.path.name for item in all_raws}) != 5
+    ):
+        _fail("the raw reports and native shards must have distinct files, inodes, paths, and basenames")
     timestamps = [item.generated_at for item in raws.values()]
     if max(timestamps) - min(timestamps) > timedelta(seconds=RAW_REPORT_MAX_SKEW_SECONDS):
         _fail("raw report timestamps exceed the bounded laboratory collection window")
@@ -1558,6 +1817,26 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         _fail("Linux and FreeBSD raw reports do not bind the same previous version")
     previous_binding = gate.RepositoryBinding(binding.root, binding.commit_sha, binding.tree_sha, "v" + previous_version)
     previous = gate.verify_packages(args.previous_packages_dir, previous_binding)
+    expected_qualification_binding = {
+        "schema_version": 1,
+        "repository": args.expected_repository,
+        "release_sha": binding.commit_sha,
+        "release_tag": binding.version,
+        "previous_tag": previous_binding.version,
+        "workflow_run_id": args.expected_workflow_run_id,
+        "workflow_run_attempt": args.expected_workflow_run_attempt,
+        "candidate_run_id": args.expected_candidate_run_id,
+        "candidate_artifact_id": args.expected_candidate_artifact_id,
+        "candidate_artifact_name": args.expected_candidate_artifact_name,
+        "previous_release_id": args.expected_previous_release_id,
+        "candidate_manifest_sha256": candidate.sha256,
+        "previous_manifest_sha256": previous.sha256,
+    }
+    _validate_package_qualification_binding(expected_qualification_binding)
+    if args.expected_candidate_artifact_name != (
+        "syswarden-packages-" + binding.version.removeprefix("v")
+    ):
+        _fail("candidate package artifact name does not match the release version")
     candidate_dir_stat = candidate.directory.stat()
     previous_dir_stat = previous.directory.stat()
     if candidate.directory == previous.directory or (
@@ -1569,7 +1848,7 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
     if len(identities) != len(candidate.snapshots) + len(previous.snapshots):
         _fail("candidate and previous package evidence must not share files/inodes")
     raw_identities = {
-        (item.snapshot.device, item.snapshot.inode) for item in raws.values()
+        (item.snapshot.device, item.snapshot.inode) for item in all_raws
     }
     if raw_identities & identities:
         _fail("raw reports must not alias candidate or previous package evidence")
@@ -1584,14 +1863,21 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
     if any(
         raw.snapshot.path.parent.name != "raw"
         or raw.snapshot.path.parent.parent != artifact_root
-        for raw in raws.values()
+        for raw in all_raws
     ):
         _fail("raw reports and package directories do not share the exact artifact layout")
     for old_name, new_name in zip(gate.package_names("v" + previous_version), gate.package_names(binding.version)):
         if previous.checksums[old_name] == candidate.checksums[new_name]:
             _fail(f"previous and candidate package bytes are identical: {old_name}/{new_name}")
     nft = _validate_nft(raws["nft"].document, binding)
-    package = _validate_package(raws["package"].document, binding, candidate, previous)
+    package = _validate_package(
+        raws["package"].document,
+        binding,
+        candidate,
+        previous,
+        package_shards,
+        expected_qualification_binding,
+    )
     freebsd = _validate_freebsd(raws["freebsd"].document, binding, candidate, previous)
     if package["lifecycle"]["previous_version"] != freebsd["lifecycle"]["previous_version"]:
         _fail("Linux and FreeBSD lifecycle evidence disagrees on the previous version")
@@ -1609,8 +1895,15 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         "package": gate.build_bound_report(kind="linux_package_lifecycle", generated_at=generated_at, raw_report_sha256=raws["package"].snapshot.sha256, bindings=bindings, real_freebsd_vm=False, **package),
         "freebsd": gate.build_bound_report(kind="freebsd_vm", generated_at=generated_at, raw_report_sha256=raws["freebsd"].snapshot.sha256, bindings=bindings, real_freebsd_vm=True, **freebsd),
     }
-    _revalidate_all(binding, candidate, previous, raws)
-    return ValidatedInputs(binding, candidate, previous, raws, envelopes)
+    _revalidate_all(binding, candidate, previous, raws, package_shards)
+    return ValidatedInputs(
+        binding,
+        candidate,
+        previous,
+        raws,
+        package_shards,
+        envelopes,
+    )
 
 
 def _destination_paths(args: argparse.Namespace) -> dict[str, Path]:
@@ -1621,7 +1914,10 @@ def _destination_paths(args: argparse.Namespace) -> dict[str, Path]:
 
 def _validate_destinations(paths: dict[str, Path], state: ValidatedInputs, *, must_exist: bool) -> dict[str, Path]:
     resolved: dict[str, Path] = {}
-    protected = {(item.snapshot.device, item.snapshot.inode) for item in state.raws.values()} | _package_identity_set(state.candidate, state.previous)
+    protected = {
+        (item.snapshot.device, item.snapshot.inode)
+        for item in (*state.raws.values(), *state.package_shards.values())
+    } | _package_identity_set(state.candidate, state.previous)
     existing: set[tuple[int, int]] = set()
     for key, path in paths.items():
         if path.name != OUTPUT_NAMES[key]:
@@ -1659,7 +1955,13 @@ def run_build(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
     for key, snapshot in snapshots.items():
         if snapshot.payload != _canonical(state.envelopes[key]):
             _fail(f"{key} envelope atomic write was not byte-exact")
-    _revalidate_all(state.binding, state.candidate, state.previous, state.raws)
+    _revalidate_all(
+        state.binding,
+        state.candidate,
+        state.previous,
+        state.raws,
+        state.package_shards,
+    )
     return state.envelopes
 
 
@@ -1675,7 +1977,13 @@ def run_verify(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
             _fail(f"{key} envelope is not the byte-exact canonical recomputation")
     for key, snapshot in snapshots.items():
         gate.revalidate(snapshot, f"{key} envelope")
-    _revalidate_all(state.binding, state.candidate, state.previous, state.raws)
+    _revalidate_all(
+        state.binding,
+        state.candidate,
+        state.previous,
+        state.raws,
+        state.package_shards,
+    )
     return state.envelopes
 
 
@@ -1687,7 +1995,16 @@ def _common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--previous-packages-dir", type=Path, required=True)
     parser.add_argument("--nft-raw", type=Path, required=True)
     parser.add_argument("--package-raw", type=Path, required=True)
+    parser.add_argument("--package-amd64-shard", type=Path, required=True)
+    parser.add_argument("--package-arm64-shard", type=Path, required=True)
     parser.add_argument("--freebsd-raw", type=Path, required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--expected-workflow-run-id", type=int, required=True)
+    parser.add_argument("--expected-workflow-run-attempt", type=int, required=True)
+    parser.add_argument("--expected-candidate-run-id", type=int, required=True)
+    parser.add_argument("--expected-candidate-artifact-id", type=int, required=True)
+    parser.add_argument("--expected-candidate-artifact-name", required=True)
+    parser.add_argument("--expected-previous-release-id", type=int, required=True)
     parser.add_argument("--max-age-seconds", type=int, required=True)
     parser.add_argument("--max-report-skew-seconds", type=int, default=300)
 

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -35,6 +35,13 @@ ACT_IMAGE = (
 class AdapterFixture:
     version = "v4.02.8"
     previous_version = "v4.02.7"
+    repository = "duggytuxy/syswarden"
+    workflow_run_id = 1001
+    workflow_run_attempt = 1
+    candidate_run_id = 900
+    candidate_artifact_id = 901
+    candidate_artifact_name = "syswarden-packages-4.02.8"
+    previous_release_id = 800
 
     def __init__(self, root: Path) -> None:
         self.root = root
@@ -159,19 +166,65 @@ class AdapterFixture:
         return hashlib.sha256(path.read_bytes()).hexdigest()
 
     def _make_raw_reports(self) -> None:
-        package_args = argparse.Namespace(
-            packages_dir=self.candidate,
-            previous_packages_dir=self.previous,
-            podman="podman",
-            pull_policy="never",
-            scenario_timeout=60,
-            arm64_emulator=self.emulator,
-            _arm64_binfmt_registration=self.binfmt,
+        common_package_args = {
+            "packages_dir": self.candidate,
+            "previous_packages_dir": self.previous,
+            "podman": "podman",
+            "pull_policy": "never",
+            "scenario_timeout": 60,
+            "arm64_emulator": None,
+            "qualification_repository": self.repository,
+            "qualification_release_sha": self.commit,
+            "qualification_release_tag": self.version,
+            "qualification_previous_tag": self.previous_version,
+            "qualification_workflow_run_id": str(self.workflow_run_id),
+            "qualification_workflow_run_attempt": str(self.workflow_run_attempt),
+            "qualification_candidate_run_id": str(self.candidate_run_id),
+            "qualification_candidate_artifact_id": str(self.candidate_artifact_id),
+            "qualification_candidate_artifact_name": self.candidate_artifact_name,
+            "qualification_previous_release_id": str(self.previous_release_id),
+            "aggregate_amd64_report": None,
+            "aggregate_arm64_report": None,
+        }
+        shard_paths: dict[str, Path] = {}
+        for offset, (architecture, host) in enumerate(
+            (("amd64", "x86_64"), ("arm64", "aarch64")),
+            1,
+        ):
+            package_args = argparse.Namespace(
+                **common_package_args,
+                architecture_shard=architecture,
+            )
+            platforms = tuple(
+                spec
+                for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+                if spec.architecture == architecture
+            )
+            shard = package_lifecycle_lab.run_lab(
+                package_args,
+                runner=FakePodmanRunner(),
+                platforms=platforms,
+                host_architecture=host,
+            )
+            shard["generated_at"] = (
+                self.now + timedelta(seconds=offset)
+            ).isoformat()
+            shard_path = self.raw / f"package-lifecycle-{architecture}.json"
+            shard_path.write_text(
+                json.dumps(shard, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            shard_paths[architecture] = shard_path
+        aggregate_args = argparse.Namespace(
+            **{
+                **common_package_args,
+                "architecture_shard": None,
+                "aggregate_amd64_report": shard_paths["amd64"],
+                "aggregate_arm64_report": shard_paths["arm64"],
+            }
         )
-        package_report = package_lifecycle_lab.run_lab(
-            package_args,
-            runner=FakePodmanRunner(),
-            host_architecture="x86_64",
+        package_report = package_lifecycle_lab.aggregate_native_shard_reports(
+            aggregate_args
         )
         package_report["generated_at"] = (self.now + timedelta(seconds=11)).isoformat()
 
@@ -278,7 +331,16 @@ class AdapterFixture:
             "previous_packages_dir": self.previous,
             "nft_raw": self.raw / "nftables-raw.json",
             "package_raw": self.raw / "package-lifecycle-raw.json",
+            "package_amd64_shard": self.raw / "package-lifecycle-amd64.json",
+            "package_arm64_shard": self.raw / "package-lifecycle-arm64.json",
             "freebsd_raw": self.raw / "freebsd-vm-raw.json",
+            "expected_repository": self.repository,
+            "expected_workflow_run_id": self.workflow_run_id,
+            "expected_workflow_run_attempt": self.workflow_run_attempt,
+            "expected_candidate_run_id": self.candidate_run_id,
+            "expected_candidate_artifact_id": self.candidate_artifact_id,
+            "expected_candidate_artifact_name": self.candidate_artifact_name,
+            "expected_previous_release_id": self.previous_release_id,
             "max_age_seconds": 172800,
             "max_report_skew_seconds": 0,
             "nft_output": self.bound / "nftables-bound.json",
@@ -334,6 +396,8 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             previous_packages_dir=relocated / "packages/previous",
             nft_raw=relocated / "raw/nftables-raw.json",
             package_raw=relocated / "raw/package-lifecycle-raw.json",
+            package_amd64_shard=relocated / "raw/package-lifecycle-amd64.json",
+            package_arm64_shard=relocated / "raw/package-lifecycle-arm64.json",
             freebsd_raw=relocated / "raw/freebsd-vm-raw.json",
             nft_envelope=relocated / "bound/nftables-bound.json",
             package_envelope=relocated / "bound/package-lifecycle-bound.json",
@@ -494,7 +558,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture.save_raw("freebsd-vm-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 
-    def test_freebsd_forward_only_v40212_contract_is_exercised(self) -> None:
+    def test_freebsd_forward_only_v40213_contract_is_exercised(self) -> None:
         evidence = passing_evidence()
         evidence["PF_SNAPSHOT_PROVENANCE"] = "legacy_derived"
         evidence["PREVIOUS_PACKAGE_SHA256"] = (
@@ -505,7 +569,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             "CANDIDATE_REINSTALL",
             "CANDIDATE_RESTART_IDEMPOTENCE",
         ):
-            evidence[f"{phase}_PKG_VERSION"] = "4.02.12"
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.13"
         for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
             evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
             evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"
@@ -521,8 +585,8 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         report = freebsd_vm_lab.build_report(
             evidence,
             freebsd_vm_lab.PackageArtifact(
-                self.fixture.root / "syswarden-4.02.12.txz",
-                "4.02.12",
+                self.fixture.root / "syswarden-4.02.13.txz",
+                "4.02.13",
                 evidence["CANDIDATE_PACKAGE_SHA256"],
             ),
             freebsd_vm_lab.PackageArtifact(
@@ -574,7 +638,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture.save_raw("package-lifecycle-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 
-    def test_arm64_probe_cannot_claim_native_or_report_the_host_uname(self) -> None:
+    def test_arm64_probe_must_be_native_and_report_the_native_uname(self) -> None:
         report = self.fixture.load_raw("package-lifecycle-raw.json")
         arm64 = next(
             item
@@ -585,6 +649,39 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture.save_raw("package-lifecycle-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 
+    def test_native_shard_files_and_workflow_binding_are_independently_revalidated(self) -> None:
+        arm_path = self.fixture.raw / "package-lifecycle-arm64.json"
+        arm = self.fixture.load_raw("package-lifecycle-arm64.json")
+        arm["qualification_binding"]["workflow_run_id"] += 1
+        self.fixture.save_raw("package-lifecycle-arm64.json", arm)
+        aggregate = self.fixture.load_raw("package-lifecycle-raw.json")
+        record = next(
+            item
+            for item in aggregate["native_shards"]["reports"]
+            if item["architecture"] == "arm64"
+        )
+        record["report_sha256"] = hashlib.sha256(arm_path.read_bytes()).hexdigest()
+        self.fixture.save_raw("package-lifecycle-raw.json", aggregate)
+        self.assertAdapterError(self.fixture.args())
+
+        self.fixture._make_raw_reports()
+        self.assertAdapterError(
+            self.fixture.args(expected_workflow_run_id=self.fixture.workflow_run_id + 1)
+        )
+
+        self.fixture._make_raw_reports()
+        self.assertAdapterError(
+            self.fixture.args(
+                package_arm64_shard=self.fixture.raw / "package-lifecycle-amd64.json"
+            )
+        )
+
+        self.fixture._make_raw_reports()
+        aggregate = self.fixture.load_raw("package-lifecycle-raw.json")
+        aggregate["native_shards"]["reports"].reverse()
+        self.fixture.save_raw("package-lifecycle-raw.json", aggregate)
+        self.assertAdapterError(self.fixture.args())
+
         self.fixture._make_raw_reports()
         report = self.fixture.load_raw("package-lifecycle-raw.json")
         arm64 = next(
@@ -593,16 +690,30 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             if item["architecture_id"] == "arm64"
         )
         arm64["architecture_probe"].update(
-            execution_mode="native",
-            emulator=None,
-            binfmt=None,
+            execution_mode="host_binfmt_qemu_aarch64",
         )
-        arm64["bootstrap_execution"] = "native_container_build"
+        arm64["bootstrap_execution"] = "podman_platform_with_validated_host_binfmt"
         self.fixture.save_raw("package-lifecycle-raw.json", report)
         self.assertAdapterError(self.fixture.args())
         self.fixture._make_raw_reports()
         report = self.fixture.load_raw("package-lifecycle-raw.json")
         report["platforms"][0]["scenarios"][0]["events"][0]["status"] = "fail"
+        self.fixture.save_raw("package-lifecycle-raw.json", report)
+        self.assertAdapterError(self.fixture.args())
+
+        self.fixture._make_raw_reports()
+        report = self.fixture.load_raw("package-lifecycle-raw.json")
+        report["platforms"][0]["scenarios"][0]["events"][0]["detail"] = (
+            "aggregate-only forged detail"
+        )
+        self.fixture.save_raw("package-lifecycle-raw.json", report)
+        self.assertAdapterError(self.fixture.args())
+
+        self.fixture._make_raw_reports()
+        report = self.fixture.load_raw("package-lifecycle-raw.json")
+        report["scope"]["architecture_coverage"][0][
+            "completed_distributions"
+        ].reverse()
         self.fixture.save_raw("package-lifecycle-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -148,6 +148,10 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertEqual(
             self.workflow.count("name: syswarden-release-qualification"), 2
         )
+        self.assertEqual(self.workflow.count("runs-on: ubuntu-24.04-arm"), 1)
+        self.assertEqual(self.workflow.count("- self-hosted"), 1)
+        self.assertIn("needs: package-lifecycle-arm64", self.workflow)
+        self.assertIn('test "$(uname -m)" = "aarch64"', self.workflow)
 
     def test_environment_api_enforces_automatic_qualification_and_main_only(self) -> None:
         required = (
@@ -160,6 +164,9 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "must require no reviewer or wait gate",
             ".deployment_branch_policy[$field]",
             "required_environment_boolean",
+            "required_top_level_environment_boolean",
+            '"${can_admins_bypass}" != "false"',
+            "forbid administrator bypass",
             "deployment-branch-policies",
             '.name == "main" and .type == "branch"',
             '"${policy_count}" != "1"',
@@ -183,6 +190,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
 
         valid = {
             "name": "syswarden-release-qualification",
+            "can_admins_bypass": False,
             "protection_rules": [{"type": "branch_policy"}],
             "deployment_branch_policy": {
                 "protected_branches": False,
@@ -210,6 +218,29 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0, diagnostic)
                 self.assertNotIn("must be boolean", diagnostic)
                 self.assertIn("must require no reviewer or wait gate", diagnostic)
+
+        mutated = json.loads(json.dumps(valid))
+        mutated["can_admins_bypass"] = True
+        result = run_environment_gate(script, mutated, policies)
+        diagnostic = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0, diagnostic)
+        self.assertIn("forbid administrator bypass", diagnostic)
+
+        for name, value, missing in (
+            ("bypass missing", None, True),
+            ("bypass null", None, False),
+            ("bypass string", "false", False),
+        ):
+            with self.subTest(name=name):
+                mutated = json.loads(json.dumps(valid))
+                if missing:
+                    del mutated["can_admins_bypass"]
+                else:
+                    mutated["can_admins_bypass"] = value
+                result = run_environment_gate(script, mutated, policies)
+                diagnostic = result.stdout + result.stderr
+                self.assertNotEqual(result.returncode, 0, diagnostic)
+                self.assertIn("can_admins_bypass must be boolean", diagnostic)
 
         for name, field, value, missing in (
             ("protected missing", "protected_branches", None, True),
@@ -294,28 +325,73 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertGreaterEqual(
             self.workflow.count("gh api --paginate --slurp --method GET"), 4
         )
-        self.assertEqual(self.workflow.count("verify-packages"), 2)
+        self.assertEqual(self.workflow.count("verify-packages"), 4)
 
-    def test_arm64_requires_exact_enabled_fix_binary_binfmt(self) -> None:
+    def test_arm64_is_native_and_emulation_is_forbidden(self) -> None:
         required = (
-            "SYSWARDEN_QEMU_AARCH64_STATIC",
-            "/proc/sys/fs/binfmt_misc/qemu-aarch64",
-            "sed -n 's/^interpreter //p'",
-            '"${binfmt_interpreters[0]}" != "${QEMU_AARCH64_STATIC}"',
-            '"${binfmt_flags}" != *F*',
-            "--arm64-emulator \"${QEMU_AARCH64_STATIC}\"",
+            "runs-on: ubuntu-24.04-arm",
+            "--architecture-shard arm64",
+            "--architecture-shard amd64",
+            "package-lifecycle-arm64.json",
+            "package-lifecycle-amd64.json",
+            "--aggregate-amd64-report",
+            "--aggregate-arm64-report",
         )
         for contract in required:
             self.assertIn(contract, self.workflow)
+        for forbidden in (
+            "SYSWARDEN_QEMU_AARCH64_STATIC",
+            "/proc/sys/fs/binfmt_misc/qemu-aarch64",
+            "--arm64-emulator",
+            "host_binfmt_qemu_aarch64",
+        ):
+            self.assertNotIn(forbidden, self.workflow)
+
+    def test_native_shards_are_bound_to_one_run_sha_and_package_source(self) -> None:
+        for argument in (
+            "--qualification-repository",
+            "--qualification-release-sha",
+            "--qualification-release-tag",
+            "--qualification-previous-tag",
+            "--qualification-workflow-run-id",
+            "--qualification-workflow-run-attempt",
+            "--qualification-candidate-run-id",
+            "--qualification-candidate-artifact-id",
+            "--qualification-candidate-artifact-name",
+            "--qualification-previous-release-id",
+        ):
+            self.assertEqual(self.workflow.count(argument), 2)
+        for argument in (
+            "--package-amd64-shard",
+            "--package-arm64-shard",
+            "--expected-repository",
+            "--expected-workflow-run-id",
+            "--expected-workflow-run-attempt",
+            "--expected-candidate-run-id",
+            "--expected-candidate-artifact-id",
+            "--expected-candidate-artifact-name",
+            "--expected-previous-release-id",
+        ):
+            self.assertEqual(self.workflow.count(argument), 2)
+        self.assertIn("sha256sum --check --strict SHA256SUMS.txt", self.workflow)
+        self.assertIn('test "${actual_arm_sha256}" = "${ARM_REPORT_SHA256}"', self.workflow)
+        self.assertIn(
+            '"${ARM_CANDIDATE_RUN_ID}" != "${CANDIDATE_RUN_ID}"',
+            self.workflow,
+        )
+        self.assertIn(
+            "a native shard returned nonzero while the aggregate claimed success",
+            self.workflow,
+        )
 
     def test_all_real_labs_are_fail_closed_and_never_pull_images(self) -> None:
-        for script in (
-            "scripts/ci/package_lifecycle_lab.py",
-            "scripts/ci/freebsd_vm_lab.py",
-            "scripts/ci/nftables_kernel_lab.py",
-        ):
+        self.assertEqual(
+            self.workflow.count("scripts/ci/package_lifecycle_lab.py"), 3
+        )
+        for script in ("scripts/ci/freebsd_vm_lab.py", "scripts/ci/nftables_kernel_lab.py"):
             self.assertEqual(self.workflow.count(script), 1)
         self.assertEqual(self.workflow.count("--pull-policy never"), 2)
+        self.assertEqual(self.workflow.count("--pull-policy always"), 1)
         for status in (
             "package-lab.rc",
             "freebsd-lab.rc",
@@ -445,6 +521,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "raw/freebsd-vm-raw.json",
             "raw/freebsd-updater-raw.json",
             "raw/nftables-raw.json",
+            "raw/package-lifecycle-amd64.json",
+            "raw/package-lifecycle-arm64.json",
             "raw/package-lifecycle-raw.json",
             "packages/candidate/SHA256SUMS.txt",
             "packages/previous/SHA256SUMS.txt",

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -122,7 +122,7 @@ var installCmd = &cobra.Command{
 		fmt.Printf("    Password: %s\n", token)
 		fmt.Printf("======================================================\n\n")
 
-		fmt.Println("[SYSWARDEN] v4.02.12 Native Installation Complete.")
+		fmt.Println("[SYSWARDEN] v4.02.13 Native Installation Complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/cmd/manual.go
+++ b/src/core/syswarden-cli/cmd/manual.go
@@ -92,10 +92,10 @@ var manualCmd = &cobra.Command{
 
 		fmt.Printf("%s--- 5. SAFETY LIMITS ---%s\n", ansiYellow, ansiReset)
 		fmt.Printf("  %sRELOAD:%s the Linux nftables candidate is committed atomically and verified; compatibility-wrapper failure leaves nftables authoritative and returns an error. The core normally restarts, so keep console access and a ruleset backup.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.12. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
+		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.13. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sUNINSTALL:%s configuration, data, logs, services and firewall tables are deleted; it is not a rollback. On FreeBSD, use this command instead of raw pkg delete.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sALPINE:%s dedicated CGO-free static APK binaries are built for x86_64 and aarch64; install only an exact release-qualified artifact.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sFREEBSD:%s v4.02.12 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
+		fmt.Printf("  %sFREEBSD:%s v4.02.13 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
 
 		fmt.Printf("%s================================================================================%s\n", ansiCyan, ansiReset)
 		fmt.Printf("%sRead README.md and the command-specific --help output before a host-mutating action.%s\n", ansiWhite, ansiReset)

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.02.12
+# Version=v4.02.13
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.02.12", Inline: true},
+						{Name: "Version", Value: "v4.02.13", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/cron_contract.go
+++ b/src/core/syswarden-cli/pkg/system/cron_contract.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"syswarden-cli/pkg/platformpaths"
@@ -51,6 +52,67 @@ func writeRootCrontab(command *exec.Cmd, content string) error {
 		return fmt.Errorf("failed to write root crontab: %w", err)
 	}
 	return nil
+}
+
+func setPrivateCronCache(command *exec.Cmd, cacheDirectory string) {
+	environment := command.Environ()
+	filteredEnvironment := make([]string, 0, len(environment)+1)
+	for _, variable := range environment {
+		if !strings.HasPrefix(variable, "XDG_CACHE_HOME=") {
+			filteredEnvironment = append(filteredEnvironment, variable)
+		}
+	}
+	command.Env = append(filteredEnvironment, "XDG_CACHE_HOME="+cacheDirectory)
+}
+
+func removePrivateCronWork(workDirectory string) error {
+	if err := os.RemoveAll(workDirectory); err != nil {
+		return fmt.Errorf("remove private cron work directory: %w", err)
+	}
+	if _, err := os.Lstat(workDirectory); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("verify private cron work directory removal: %w", err)
+	}
+	return fmt.Errorf("private cron work directory remains after removal")
+}
+
+func verifyPrivateCronDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect private cron directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("private cron path is not a non-symlink directory")
+	}
+	if info.Mode().Perm() != 0700 {
+		return fmt.Errorf("private cron directory mode is %04o, want 0700", info.Mode().Perm())
+	}
+	return nil
+}
+
+func preparePrivateCronWork(commands ...*exec.Cmd) (string, error) {
+	workDirectory, err := os.MkdirTemp("/var/tmp", "syswarden-cron.")
+	if err != nil {
+		return "", fmt.Errorf("create private cron work directory: %w", err)
+	}
+	if err := verifyPrivateCronDirectory(workDirectory); err != nil {
+		return "", errors.Join(err, removePrivateCronWork(workDirectory))
+	}
+	cacheDirectory := filepath.Join(workDirectory, "cache")
+	if err := os.Mkdir(cacheDirectory, 0700); err != nil {
+		return "", errors.Join(
+			fmt.Errorf("create private cron cache directory: %w", err),
+			removePrivateCronWork(workDirectory),
+		)
+	}
+	if err := verifyPrivateCronDirectory(cacheDirectory); err != nil {
+		return "", errors.Join(err, removePrivateCronWork(workDirectory))
+	}
+	for _, command := range commands {
+		setPrivateCronCache(command, cacheDirectory)
+	}
+	return workDirectory, nil
 }
 
 // filterManagedRootCrontab removes only canonical SysWarden entries. Every
@@ -119,7 +181,22 @@ func removeManagedRootCronContent(
 	return false, writeRootCrontab(writeCommand, filtered)
 }
 
-func removeManagedRootCron(readCommand, writeCommand *exec.Cmd) error {
+func removeManagedRootCron(readCommand, writeCommand *exec.Cmd) (result error) {
+	removeCommand := exec.Command("crontab", "-r")
+	verifyCommand := exec.Command("crontab", "-l")
+	workDirectory, err := preparePrivateCronWork(
+		readCommand,
+		writeCommand,
+		removeCommand,
+		verifyCommand,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		result = errors.Join(result, removePrivateCronWork(workDirectory))
+	}()
+
 	existing, present, err := readRootCrontab(readCommand)
 	if err != nil {
 		return err
@@ -128,8 +205,8 @@ func removeManagedRootCron(readCommand, writeCommand *exec.Cmd) error {
 		existing,
 		present,
 		writeCommand,
-		exec.Command("crontab", "-r"),
-		exec.Command("crontab", "-l"),
+		removeCommand,
+		verifyCommand,
 	)
 	return err
 }

--- a/src/core/syswarden-cli/pkg/system/cron_contract_test.go
+++ b/src/core/syswarden-cli/pkg/system/cron_contract_test.go
@@ -1,6 +1,9 @@
 package system
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -190,6 +193,159 @@ func TestManagedRootCronRemovalFailsClosed(t *testing.T) {
 			t.Fatal("crontab write failure was accepted")
 		}
 	})
+}
+
+func TestPrivateCronWorkIsModeLockedAndIgnoresHostileTMPDIR(t *testing.T) {
+	hostileTmp := filepath.Join(t.TempDir(), "attacker-controlled-tmp")
+	if err := os.Mkdir(hostileTmp, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", hostileTmp)
+	command := exec.Command("/bin/sh", "-c", "exit 0")
+	workPath, err := preparePrivateCronWork(command)
+	if err != nil {
+		t.Fatalf("prepare private cron work: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := removePrivateCronWork(workPath); err != nil {
+			t.Errorf("cleanup private cron work: %v", err)
+		}
+	})
+	if filepath.Dir(workPath) != "/var/tmp" ||
+		!strings.HasPrefix(filepath.Base(workPath), "syswarden-cron.") {
+		t.Fatalf("unexpected private cron work path: %q", workPath)
+	}
+	if strings.HasPrefix(workPath, hostileTmp+string(os.PathSeparator)) {
+		t.Fatalf("hostile TMPDIR controlled cron work path: %q", workPath)
+	}
+	cachePath := filepath.Join(workPath, "cache")
+	for _, path := range []string{workPath, cachePath} {
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			t.Fatalf("inspect private cron directory %q: %v", path, statErr)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0700 {
+			t.Fatalf("private cron directory %q has type/mode %v", path, info.Mode())
+		}
+	}
+	xdgCount := 0
+	for _, variable := range command.Environ() {
+		if strings.HasPrefix(variable, "XDG_CACHE_HOME=") {
+			xdgCount++
+			if variable != "XDG_CACHE_HOME="+cachePath {
+				t.Fatalf("unexpected private cron cache environment: %q", variable)
+			}
+		}
+	}
+	if xdgCount != 1 {
+		t.Fatalf("private cron cache environment count = %d, want 1", xdgCount)
+	}
+	backup := filepath.Join(cachePath, "crontab", "crontab.bak")
+	if err := os.Mkdir(filepath.Dir(backup), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backup, []byte("previous cron\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removePrivateCronWork(workPath); err != nil {
+		t.Fatalf("remove private cron work: %v", err)
+	}
+	if _, statErr := os.Lstat(workPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("private cron work remains: %v", statErr)
+	}
+	if _, statErr := os.Lstat(backup); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Cronie backup remains: %v", statErr)
+	}
+}
+
+func TestManagedRootCronUsesPrivateCronieCacheWithoutResidue(t *testing.T) {
+	managed := "17 * * * * " + platformpaths.CLI + " update-feeds >/dev/null 2>&1"
+	operator := "19 4 * * * /usr/local/bin/operator"
+
+	for _, writeExit := range []int{0, 23} {
+		name := "successful write"
+		if writeExit != 0 {
+			name = "failed write"
+		}
+		t.Run(name, func(t *testing.T) {
+			hostileTmp := filepath.Join(t.TempDir(), "attacker-controlled-tmp")
+			if err := os.Mkdir(hostileTmp, 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("TMPDIR", hostileTmp)
+			cacheReader, cacheWriter, pipeErr := os.Pipe()
+			if pipeErr != nil {
+				t.Fatalf("create private cache path pipe: %v", pipeErr)
+			}
+			defer cacheReader.Close()
+			defer cacheWriter.Close()
+			readCommand := exec.Command(
+				"/bin/sh",
+				"-c",
+				`printf '%s\n' "${SYSWARDEN_TEST_MANAGED}" "${SYSWARDEN_TEST_OPERATOR}"`,
+			)
+			readCommand.Env = append(
+				os.Environ(),
+				"SYSWARDEN_TEST_MANAGED="+managed,
+				"SYSWARDEN_TEST_OPERATOR="+operator,
+			)
+			writeCommand := exec.Command(
+				"/bin/sh",
+				"-c",
+				`set -eu
+test -n "${XDG_CACHE_HOME:-}"
+test -d "${XDG_CACHE_HOME}"
+test ! -L "${XDG_CACHE_HOME}"
+mkdir -p "${XDG_CACHE_HOME}/crontab"
+printf 'previous cron\n' > "${XDG_CACHE_HOME}/crontab/crontab.bak"
+printf '%s' "${XDG_CACHE_HOME}" >&3
+cat >/dev/null
+exit "${SYSWARDEN_TEST_WRITE_EXIT}"`,
+			)
+			writeCommand.Env = append(
+				os.Environ(),
+				fmt.Sprintf("SYSWARDEN_TEST_WRITE_EXIT=%d", writeExit),
+			)
+			writeCommand.ExtraFiles = []*os.File{cacheWriter}
+
+			err := removeManagedRootCron(readCommand, writeCommand)
+			if writeExit == 0 && err != nil {
+				t.Fatalf("cron cleanup failed: %v", err)
+			}
+			if writeExit != 0 && err == nil {
+				t.Fatal("cron write failure was accepted")
+			}
+			if closeErr := cacheWriter.Close(); closeErr != nil {
+				t.Fatalf("close private cache path writer: %v", closeErr)
+			}
+			cachePathBytes, readErr := io.ReadAll(cacheReader)
+			if readErr != nil {
+				t.Fatalf("read private cache marker: %v", readErr)
+			}
+			cachePath := string(cachePathBytes)
+			workPath := filepath.Dir(cachePath)
+			if filepath.Dir(workPath) != "/var/tmp" ||
+				!strings.HasPrefix(filepath.Base(workPath), "syswarden-cron.") {
+				t.Fatalf("unexpected private cron work path: %q", cachePath)
+			}
+			if strings.HasPrefix(workPath, hostileTmp+string(os.PathSeparator)) {
+				t.Fatalf("hostile TMPDIR controlled cron work path: %q", workPath)
+			}
+			varTmp, openErr := os.OpenRoot("/var/tmp")
+			if openErr != nil {
+				t.Fatalf("open bounded cron work root: %v", openErr)
+			}
+			defer varTmp.Close()
+			relativeWork := filepath.Base(workPath)
+			if _, statErr := varTmp.Stat(relativeWork); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("private cron work remains: %v", statErr)
+			}
+			backup := filepath.Join(relativeWork, "cache", "crontab", "crontab.bak")
+			if _, statErr := varTmp.Stat(backup); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("Cronie backup remains: %v", statErr)
+			}
+		})
+	}
 }
 
 func TestManagedOnlyRootCrontabIsRemovedAndAbsenceVerified(t *testing.T) {

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var Version = "v4.02.12"
+var Version = "v4.02.13"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -79,7 +79,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.12 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -147,7 +147,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.12 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -359,7 +359,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.12 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.02.12"
+const SysWardenVersion = "v4.02.13"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary

- fixes Alpine OpenRC packaging, APK post-upgrade hooks, and Cronie cleanup
- replaces ARM64 user-mode emulation with native ARM64 qualification shards
- binds qualification, publisher, documentation, and forward-only v4.02.8 -> v4.02.13 evidence
- keeps GitHub shell payloads below the enforced 21,000-character limit
- updates the complete v4.02.13 changelog, README, manual, and public report

## Validation

- 252 targeted Python tests passed
- Linux Go suites and FreeBSD/amd64 cross-build suites passed
- gosec Linux/FreeBSD CLI scans passed with zero findings
- release workflows passed strict YAML, ShellCheck, and act validation
- documentation truth gate and exact 14-asset contract passed
- Gitleaks found no leak in the exact staged index
- signed commit and versioning transition v4.02.12 -> v4.02.13 verified

The protected qualification remains fail-closed and must pass from public v4.02.8 before the immutable tag and Release are created.
