### PR TITLE
Patch : qualify v4.02.14

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -484,7 +484,7 @@ jobs:
           syswarden_managed_cron_line() {
               syswarden_cron_candidate="$1"
               shift
-              syswarden_cron_minute="${syswarden_cron_candidate%% *}"
+              syswarden_cron_minute="$(printf '%s\n' "${syswarden_cron_candidate}" | awk 'NR == 1 { print $1; exit }')"
               for syswarden_cron_cli do
                   if [ "${syswarden_cron_candidate}" = "*/30 * * * * ${syswarden_cron_cli} ha-sync >/dev/null 2>&1" ]; then
                       return 0
@@ -665,7 +665,7 @@ jobs:
           syswarden_managed_cron_line() {
               syswarden_cron_candidate="$1"
               shift
-              syswarden_cron_minute="${syswarden_cron_candidate%% *}"
+              syswarden_cron_minute="$(printf '%s\n' "${syswarden_cron_candidate}" | awk 'NR == 1 { print $1; exit }')"
               for syswarden_cron_cli do
                   if [ "${syswarden_cron_candidate}" = "*/30 * * * * ${syswarden_cron_cli} ha-sync >/dev/null 2>&1" ]; then
                       return 0
@@ -953,6 +953,7 @@ jobs:
             postremove: "${PACKAGE_SCRIPTS}/postrm.sh"
           apk:
             scripts:
+              preupgrade: "${PACKAGE_SCRIPTS}/preinst.sh"
               postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"
           EOF
 
@@ -988,6 +989,7 @@ jobs:
             postremove: "${PACKAGE_SCRIPTS}/postrm.sh"
           apk:
             scripts:
+              preupgrade: "${PACKAGE_SCRIPTS}/preinst.sh"
               postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"
           EOF
 
@@ -1155,7 +1157,7 @@ jobs:
           syswarden_managed_cron_line() {
               syswarden_cron_candidate="$1"
               shift
-              syswarden_cron_minute="${syswarden_cron_candidate%% *}"
+              syswarden_cron_minute="$(printf '%s\n' "${syswarden_cron_candidate}" | awk 'NR == 1 { print $1; exit }')"
               for syswarden_cron_cli do
                   if [ "${syswarden_cron_candidate}" = "*/30 * * * * ${syswarden_cron_cli} ha-sync >/dev/null 2>&1" ]; then
                       return 0
@@ -1376,8 +1378,16 @@ jobs:
           validate_rpm() {
             local path="$1"
             local architecture="$2"
+            local scriptlets
+            local expected_cron_extraction
             [[ "$(rpm --query --package --queryformat '%{VERSION}' "${path}")" == "${VERSION}" ]]
             [[ "$(rpm --query --package --queryformat '%{ARCH}' "${path}")" == "${architecture}" ]]
+            scriptlets="$(rpm --query --package --scripts "${path}")"
+            expected_cron_extraction="syswarden_cron_minute=\"\$(printf '%s\\n' \"\${syswarden_cron_candidate}\" | awk 'NR == 1 { print \$1; exit }')\""
+            [[ "$(grep --fixed-strings --count "${expected_cron_extraction}" <<< "${scriptlets}")" -eq 2 ]]
+            if grep --fixed-strings --quiet '${syswarden_cron_candidate%' <<< "${scriptlets}"; then
+              return 1
+            fi
           }
 
           validate_apk() {
@@ -1387,6 +1397,8 @@ jobs:
             local metadata
             local package_version
             local package_architecture
+            local -a preinstall_members=()
+            local -a preupgrade_members=()
             local -a postinstall_members=()
             local -a postupgrade_members=()
             member="$(tar --list --file "${path}" | awk '/(^|\/)\.PKGINFO$/ { print }')"
@@ -1395,14 +1407,25 @@ jobs:
             [[ "$(grep --count '^pkgver = ' <<< "${metadata}")" -eq 1 ]]
             [[ "$(grep --count '^arch = ' <<< "${metadata}")" -eq 1 ]]
             [[ "$(grep --count '^depend = openrc$' <<< "${metadata}")" -eq 1 ]]
+            mapfile -t preinstall_members < <(
+              tar --list --file "${path}" | awk '/(^|\/)\.pre-install$/ { print }'
+            )
+            mapfile -t preupgrade_members < <(
+              tar --list --file "${path}" | awk '/(^|\/)\.pre-upgrade$/ { print }'
+            )
             mapfile -t postinstall_members < <(
               tar --list --file "${path}" | awk '/(^|\/)\.post-install$/ { print }'
             )
             mapfile -t postupgrade_members < <(
               tar --list --file "${path}" | awk '/(^|\/)\.post-upgrade$/ { print }'
             )
+            [[ "${#preinstall_members[@]}" -eq 1 ]]
+            [[ "${#preupgrade_members[@]}" -eq 1 ]]
             [[ "${#postinstall_members[@]}" -eq 1 ]]
             [[ "${#postupgrade_members[@]}" -eq 1 ]]
+            cmp -s \
+              <(tar --extract --to-stdout --file "${path}" "${preinstall_members[0]}") \
+              <(tar --extract --to-stdout --file "${path}" "${preupgrade_members[0]}")
             cmp -s \
               <(tar --extract --to-stdout --file "${path}" "${postinstall_members[0]}") \
               <(tar --extract --to-stdout --file "${path}" "${postupgrade_members[0]}")
@@ -1423,12 +1446,33 @@ jobs:
             [[ "${package_architecture}" == "${architecture}" ]]
           }
 
+          compare_apk_hook_parity() {
+            local left="$1"
+            local right="$2"
+            local hook="$3"
+            local left_member
+            local right_member
+            left_member="$(tar --list --file "${left}" | awk -F / -v hook="${hook}" '$NF == hook { print }')"
+            right_member="$(tar --list --file "${right}" | awk -F / -v hook="${hook}" '$NF == hook { print }')"
+            [[ -n "${left_member}" && "${left_member}" != *$'\n'* ]]
+            [[ -n "${right_member}" && "${right_member}" != *$'\n'* ]]
+            cmp -s \
+              <(tar --extract --to-stdout --file "${left}" "${left_member}") \
+              <(tar --extract --to-stdout --file "${right}" "${right_member}")
+          }
+
           validate_deb "${PACKAGE_ASSETS}/syswarden_${VERSION}_amd64.deb" amd64
           validate_deb "${PACKAGE_ASSETS}/syswarden_${VERSION}_arm64.deb" arm64
           validate_rpm "${PACKAGE_ASSETS}/syswarden-${VERSION}-1.x86_64.rpm" x86_64
           validate_rpm "${PACKAGE_ASSETS}/syswarden-${VERSION}-1.aarch64.rpm" aarch64
           validate_apk "${PACKAGE_ASSETS}/syswarden_${VERSION}_x86_64.apk" x86_64
           validate_apk "${PACKAGE_ASSETS}/syswarden_${VERSION}_aarch64.apk" aarch64
+          for hook in .pre-install .pre-upgrade .post-install .post-upgrade; do
+            compare_apk_hook_parity \
+              "${PACKAGE_ASSETS}/syswarden_${VERSION}_x86_64.apk" \
+              "${PACKAGE_ASSETS}/syswarden_${VERSION}_aarch64.apk" \
+              "${hook}"
+          done
 
           freebsd_manifest="$(tar --extract --to-stdout \
             --file "${PACKAGE_ASSETS}/syswarden-${VERSION}.txz" \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 # SysWarden v4
 
-Current source version: **v4.02.13**.
+Current source version: **v4.02.14**.
 
 > **Active Defense and HIDS/HIPS/WAAP Out-of-Band Orchestration for Critical Linux Infrastructure**
 
@@ -50,9 +50,10 @@ published release. Until the protected qualification passes for the exact
 commit and artifacts, use SysWarden only in an isolated laboratory with console
 access and a tested host snapshot or rollback path.
 
-The historical v4.02.12 source candidate failed protected qualification before
-signing and was never tagged or published. v4.02.13 supersedes it and remains
-NO-GO until protected qualification passes on the exact candidate commit.
+The historical v4.02.13 source candidate failed protected qualification before
+signing, tagging or release publication and was never tagged or published.
+v4.02.14 supersedes it and remains NO-GO until protected qualification passes
+on the exact candidate commit.
 
 ## Components and data flow
 
@@ -115,7 +116,7 @@ parameter. Restrict the listener with `--bind`, protect the port with a trusted
 network control, and do not place tokens in URLs or logs.
 
 A package-level `[webtui] enabled = false` switch and conditional ownership of
-TCP 62027 are not part of v4.02.13. They remain a separate Lot 2 change. The
+TCP 62027 are not part of v4.02.14. They remain a separate Lot 2 change. The
 current package behavior must therefore be treated as Web-TUI enabled.
 
 ### High availability
@@ -322,7 +323,7 @@ default HTTP client without an explicit timeout.
 | Package and PF recovery state | `/var/db/syswarden` |
 | rc.d services | `/usr/local/etc/rc.d/syswarden`, `/usr/local/etc/rc.d/syswardenwebtui` |
 
-The v4.02.13 PF contract is intentionally bounded. A fresh installation
+The v4.02.14 PF contract is intentionally bounded. A fresh installation
 requires PF to be disabled with an empty live ruleset before SysWarden first
 mutates it. The separately byte-bound historical v4.02.8 transition is also covered. This
 does not claim safe coexistence with an arbitrary pre-existing operator PF
@@ -374,10 +375,10 @@ selected release.
 
 The historical v4.02.8 binary predates the signed updater and cannot perform
 the first signed hop. Linux hosts must install the separately verified
-v4.02.13 package with their native package manager. FreeBSD hosts must first
+v4.02.14 package with their native package manager. FreeBSD hosts must first
 install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then use
-`pkg add -f` on the checksum-verified v4.02.13 TXZ. Starting from an installed
-v4.02.13, the signed updater supports the six Linux package targets and
+`pkg add -f` on the checksum-verified v4.02.14 TXZ. Starting from an installed
+v4.02.14, the signed updater supports the six Linux package targets and
 FreeBSD amd64.
 
 ### Install the latest verified Release
@@ -386,7 +387,7 @@ The procedure below downloads exactly one package for the detected operating
 system and architecture. Use it only after that tag is visible in GitHub
 Releases and the release qualification is complete. For the first hop from
 historical v4.02.8, run it as
-`VERSION=v4.02.13 sh ./install-release.sh` after saving the block as
+`VERSION=v4.02.14 sh ./install-release.sh` after saving the block as
 `install-release.sh`; leaving `VERSION` unset selects the latest published
 Release automatically.
 
@@ -621,8 +622,8 @@ access recovery.
   verifies the selected OS/architecture filename, size and SHA-256 again
   immediately before invoking the package manager, and uses a private temporary
   workspace. The historical v4.02.8 binary predates this trust root, so its
-  first upgrade to v4.02.13 must be a separately verified manual package
-  upgrade. From v4.02.13 onward, FreeBSD amd64 uses the same signed contract and
+  first upgrade to v4.02.14 must be a separately verified manual package
+  upgrade. From v4.02.14 onward, FreeBSD amd64 uses the same signed contract and
   invokes native `pkg add -f` only after all verification succeeds.
 - `syswarden uninstall` is destructive. It deletes SysWarden configuration,
   data, logs, services and firewall tables. It does not restore every previous
@@ -668,8 +669,8 @@ maintainer-controlled publication gate; a wiki page may lag the source until
 that gate is completed. When the wiki and this README disagree, prefer tested
 behavior in the source candidate and report the inconsistency.
 
-The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md)
-records the v4.02.13 source scope, evidence, platform boundaries and current
+The version-specific [Lot 1 public security delivery report](docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.14.md)
+records the v4.02.14 source scope, evidence, platform boundaries and current
 release decision.
 
 ## Target and support

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -176,7 +176,7 @@ cat << 'EOF' > prerm.sh
 syswarden_managed_cron_line() {
     syswarden_cron_candidate="$1"
     shift
-    syswarden_cron_minute="${syswarden_cron_candidate%% *}"
+    syswarden_cron_minute="$(printf '%s\n' "${syswarden_cron_candidate}" | awk 'NR == 1 { print $1; exit }')"
     for syswarden_cron_cli do
         if [ "${syswarden_cron_candidate}" = "*/30 * * * * ${syswarden_cron_cli} ha-sync >/dev/null 2>&1" ]; then
             return 0
@@ -405,6 +405,7 @@ scripts:
   postremove: "./postrm.sh"
 apk:
   scripts:
+    preupgrade: "./preinst.sh"
     postupgrade: "./postinst.sh"
 EOF
 "$(go env GOPATH)/bin/nfpm" pkg --config nfpm_alpine_amd64.yaml --packager apk --target .

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,34 @@
+# Release v4.02.14
+
+### FIXED 🐛
+- **Alpine upgrades:** Run the same fail-closed directory and legacy-configuration preparation before APK upgrades that already protects fresh installs, so the exact v4.02.8 to v4.02.14 hop repairs historical directory modes before configuration preflight.
+- **Alpine reloads:** Restart `syswarden-core` with OpenRC on Alpine Linux while retaining systemd on the other Linux package targets.
+- **RPM cron cleanup:** Extract the managed cron minute without RPM-sensitive percent expansion, so the packaged pre-remove and post-remove scriptlets delete the exact SysWarden `update-feeds` entry while preserving every operator-owned lookalike byte-for-byte.
+- **RPM inventory evidence:** Accept three exact build-id links whose parent directories are their unique prefix set, including the valid case where two binaries share one prefix, while continuing to reject every missing, orphaned or unexpected package path.
+
+### SECURITY 🔒
+- **APK hook parity:** Require both architectures to contain the expected pre-upgrade, post-upgrade, fresh-install and removal hooks, and verify those hooks from the generated APK archives rather than from source text alone.
+- **Cron transformation proof:** Inspect the generated RPM scriptlets and prove that packaging cannot rewrite the minute parser or leave a canonical SysWarden cron reference behind.
+- **Native lifecycle proof:** Keep amd64 and ARM64 package lifecycles on native hosts, bind both shards to the same exact package artifact and merged SHA, and forbid QEMU user-mode evidence for nftables behavior.
+- **Fail-closed release path:** Keep evidence signing, immutable tagging and publication unreachable unless all native Linux lifecycles, the FreeBSD VM, the signed updater, nftables and both evidence adapters pass on the exact merged commit.
+
+### RELEASE STATUS 📦
+- v4.02.13 was merged as a source candidate but was never tagged or published. Protected qualification run `31972963066` stopped before signing after the native package laboratory detected the Alpine upgrade pre-hook omission, the Alpine systemd-only reload path, an RPM-sensitive cron parser and an overly rigid RPM build-id inventory assertion. No sealed qualification artifact, release signature, tag, public Release or Release asset was created.
+- The native ARM64 shard, real FreeBSD VM laboratory and isolated nftables laboratory passed in that run, but their v4.02.13 evidence is SHA-bound and is not reused as final v4.02.14 evidence.
+- v4.02.14 supersedes the unpublished v4.02.13 candidate. The last public Release remains v4.02.8 until v4.02.14 passes protected qualification on its exact merged SHA and the immutable tag publisher verifies the complete inventory.
+- The expected Release inventory is seven native packages plus `SHA256SUMS.txt`, `RELEASE_SHA256SUMS.txt`, `syswarden-release.tar.gz`, `syswarden-sbom.spdx.json`, `plumber-report.zip`, `syswarden-update-manifest-v1.json` and `syswarden-update-manifest-v1.json.sig`, exactly 14 assets.
+
+### UPGRADE NOTES 📦
+- The immutable v4.02.8 binary predates the signed updater. Do not use `syswarden update` for its first hop. Download exactly one v4.02.14 package matching the host plus `SHA256SUMS.txt`, verify that exact package, then install it with the native package manager.
+- **Debian or Ubuntu:** after checksum verification, run `sudo apt-get install -y ./syswarden_4.02.14_amd64.deb` or use the `arm64` filename on an ARM64 host.
+- **RHEL, AlmaLinux or Rocky Linux:** after checksum verification, run `sudo dnf install -y ./syswarden-4.02.14-1.x86_64.rpm` or use the `aarch64` filename on an ARM64 host.
+- **Alpine Linux:** after checksum verification, run `sudo apk add --allow-untrusted ./syswarden_4.02.14_x86_64.apk` or use the `aarch64` filename on an ARM64 host. Never use `--allow-untrusted` before the SHA-256 check succeeds.
+- **FreeBSD 14 amd64:** install `curl`, `jq`, `libqrencode`, `rsyslog` and `wireguard-tools`, then run `sudo pkg add -f ./syswarden-4.02.14.txz` after checksum verification. Use `syswarden uninstall` rather than raw `pkg delete`, whose script-failure behavior cannot guarantee PF recovery.
+- Starting from an installed v4.02.14, `syswarden update` verifies the signed Ed25519 manifest for the six Linux targets and FreeBSD amd64 before installing future published versions.
+- Review the package post-install result with `sudo syswarden manual` and `sudo syswarden config`. The complete architecture-selecting procedure remains in the README section [Install the latest verified Release](README.md#install-the-latest-verified-release).
+
+---
+
 # Release v4.02.13
 
 ### FIXED 🐛

--- a/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.14.md
+++ b/docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.14.md
@@ -1,0 +1,153 @@
+# SysWarden Lot 1 Public Security Delivery Report
+
+| Field | Value |
+| :--- | :--- |
+| Lot 1 source status | CANDIDATE |
+| Product release decision | NO-GO until protected qualification |
+| Candidate | v4.02.14 |
+| Historical public baseline | v4.02.8 |
+| Prior source candidate | v4.02.13, merged but never tagged or published |
+| Report date | 17 August 2026 |
+| Scope | Lot 1 source, package and release-qualification closure |
+| Audience | Public, anonymized |
+
+## 1. Executive outcome
+
+This report describes the v4.02.14 repository candidate. It does not claim
+that an untagged build is a public release, that every environment is
+supported, or that a package is safe merely because a workflow produced it.
+
+The v4.02.13 source candidate was merged, but it was never tagged or published.
+Protected qualification run `31972963066` stopped before signing after the
+native package laboratory detected the Alpine upgrade pre-hook omission, the
+Alpine systemd-only reload path, an RPM-sensitive cron parser and an overly
+rigid RPM build-id inventory assertion. No sealed v4.02.13 qualification
+artifact, release signature, tag, public Release or Release asset was created.
+
+v4.02.14 supersedes that unpublished candidate. It remains NO-GO until
+protected qualification passes on its exact commit and produces byte-bound
+evidence. No v4.02.14 tag or public Release is authorized before that result.
+
+## 2. Candidate corrections and delivered controls
+
+The v4.02.14 source candidate runs fail-closed Alpine preparation before both
+fresh installation and upgrade, selects OpenRC for the Alpine service reload,
+extracts the managed RPM cron minute without RPM-sensitive percent expansion,
+and accepts exactly three RPM build-id links whose directory set equals their
+unique parent set. Missing, orphaned and unexpected package paths still fail
+closed. Qualification keeps separate native amd64 and ARM64 shards bound to
+the same candidate bytes.
+
+| Area | Candidate behavior | Security boundary |
+| :--- | :--- | :--- |
+| Configuration | Transactional migration, strict validation, durable recovery phases, concurrency controls and preservation of operator overrides | Mutating commands stop when the active configuration is unavailable or degraded |
+| Linux firewall | Validated nftables candidate, shared lock, atomic commit, post-commit verification, TTL preservation and bounded compatibility wrappers | A policy change can still interrupt remote access; console recovery remains mandatory |
+| Scheduling | Feed and HA cron entries are reconciled independently; exact managed entries are removed without RPM-sensitive parsing; operator lines are preserved | The exact package lifecycle must still prove these properties on every release coordinate |
+| Alpine packages | OpenRC is a declared runtime dependency; preparation and installation hooks cover fresh installation and upgrades; reload uses OpenRC | Exact native x86_64 and ARM64 lifecycle evidence remains mandatory |
+| RPM package evidence | Exact payload and metadata checks accept three build-id links and exactly their unique parent directories | Missing, orphaned, additional or unsafe paths remain rejected |
+| Native Linux evidence | Independent native amd64 and ARM64 shards cover the exact DEB, RPM and APK coordinate sets and reject emulation, duplicates, omissions and binding mismatches | Both shards must originate from the same protected workflow run and exact candidate bytes |
+| High availability | TLS 1.3, bearer authentication, bounded payloads, canonical peer scope, durable ledgers and bidirectional persistent-ban exchange | CIDRs authorize inbound peers only and are never dialed as outbound destinations |
+| BunkerWeb integration | Additive TTL, provenance and batch extensions behind an explicit gate | Durable node-to-node L7 and WAAP ban exchange remains active with the partner gate false or true |
+| Signed updates | Canonical manifest, detached Ed25519 signature, exact platform binding, private staging and final size and SHA-256 verification before installation | The historical v4.02.8 binary predates this trust root and requires one separately verified manual first hop |
+| FreeBSD package | ABI 14 amd64 TXZ, native `/usr/local` layout, rc.d services, PF recovery contract, host-state restoration and native signed updater support | Fresh installation requires PF disabled with an empty live ruleset; arbitrary pre-existing PF coexistence is not claimed |
+| Release governance | Exact tag ruleset, non-bypassable protected environments, byte-bound qualification evidence and independent publisher revalidation | A public tag and Release remain blocked until protected qualification succeeds |
+
+## 3. Upgrade contract
+
+The signed update protocol applies to v4.02.9 and later candidates. A qualified
+v4.02.14 manifest must bind seven package identities: two DEB, two RPM, two APK
+and one FreeBSD TXZ. A package is selected by exact operating system,
+architecture, name, size and SHA-256, then rehashed immediately before its
+package manager is invoked.
+
+The immutable v4.02.8 binary has no embedded signed-manifest verifier. Its first
+hop to v4.02.14 must therefore use a separately verified package and the native
+package manager. On FreeBSD, the standalone TXZ also requires `curl`, `jq`,
+`libqrencode`, `rsyslog` and `wireguard-tools` to be installed first. Once
+v4.02.14 is installed from a qualified Release, signed updates support the six
+Linux targets and FreeBSD amd64.
+
+## 4. Package and platform boundaries
+
+| Platform | Candidate evidence | Remaining release gate |
+| :--- | :--- | :--- |
+| DEB amd64 and arm64 | Contents, dependencies, maintainer scripts and lifecycle contracts | Protected native amd64 and ARM64 lifecycle |
+| RPM x86_64 and aarch64 | Exact payload, scriptlet, build-id and lifecycle contracts | Protected native amd64 and ARM64 lifecycle |
+| APK x86_64 and aarch64 | Static package executables, OpenRC dependency, preparation and fresh/upgrade hooks | Protected native x86_64 and ARM64 lifecycle |
+| FreeBSD amd64 | Cross-build, ABI, inventory, native paths, rc.d, PF, uninstall and updater contracts | Disposable VM lifecycle and signed updater transition |
+
+Raw `pkg delete` is not the supported FreeBSD cleanup path because the package
+manager does not guarantee that a failing pre-deinstall script aborts payload
+removal, and its no-script mode bypasses recovery hooks. Operators must use
+`syswarden uninstall` with backups and console access.
+
+The Web-TUI is enabled by the current package path. A package-level disabled
+default and conditional TCP 62027 ownership remain Lot 2 work.
+
+## 5. Qualification state
+
+The failed v4.02.13 protected attempt is diagnostic evidence only. It is not
+release evidence for v4.02.14, and none of its SHA-bound outputs may be reused
+to authorize a tag.
+
+The v4.02.14 candidate must pass all source and governance checks on its exact
+merged commit. The protected run must then verify package install, upgrade,
+reinstall, restart, rollback, recovery, removal and purge lifecycles on native
+amd64 and ARM64 hosts; independent IPv4 and IPv6 preservation; FreeBSD PF and
+package lifecycle; the signed FreeBSD updater transition; isolated nftables
+behavior; staged artifact integrity; and publisher revalidation. Any failed
+coordinate keeps the release closed.
+
+## 6. Expected public Release inventory
+
+A qualified v4.02.14 Release must contain exactly these 14 public assets:
+
+1. `syswarden_4.02.14_amd64.deb`;
+2. `syswarden_4.02.14_arm64.deb`;
+3. `syswarden-4.02.14-1.x86_64.rpm`;
+4. `syswarden-4.02.14-1.aarch64.rpm`;
+5. `syswarden_4.02.14_x86_64.apk`;
+6. `syswarden_4.02.14_aarch64.apk`;
+7. `syswarden-4.02.14.txz`;
+8. `SHA256SUMS.txt`;
+9. `RELEASE_SHA256SUMS.txt`;
+10. `syswarden-release.tar.gz`;
+11. `syswarden-sbom.spdx.json`;
+12. `plumber-report.zip`;
+13. `syswarden-update-manifest-v1.json`;
+14. `syswarden-update-manifest-v1.json.sig`.
+
+This inventory contains seven packages plus seven evidence and update assets.
+A successful source merge alone does not create the tag or these Release
+assets.
+
+## 7. Release notes contract
+
+The public v4.02.14 Release notes must come from the complete v4.02.14 changelog
+section. They must retain the fixes, security properties, release status and
+upgrade notes, including the manual v4.02.8 first hop, exact native package
+commands, the FreeBSD dependency and cleanup limits, and the 14-asset inventory.
+Publisher revalidation must bind those notes and every public asset to the
+qualified commit without rewriting the failed v4.02.13 history.
+
+## 8. Deferred Lot 2 work
+
+The following items remain outside this Lot 1 closure:
+
+- a package-level `[webtui] enabled = false` default and conditional TCP 62027
+  ownership;
+- an external BunkerWeb plugin, UI and end-to-end partner qualification;
+- per-client HA tokens and remote whitelist mutation privileges;
+- FreeBSD jails and coexistence with arbitrary pre-existing PF policy;
+- a public FreeBSD package repository instead of standalone TXZ installation;
+- additional product UX and policy controls that do not alter the v4.02.14
+  upgrade safety boundary.
+
+## 9. Final decision rule
+
+v4.02.14 remains NO-GO. The tag may be created only after protected
+qualification binds the exact release commit and passes the native amd64 and
+ARM64 package, FreeBSD, PF, nftables, signed-updater and release-governance
+gates. The publisher must then revalidate the qualified evidence, complete
+Release notes and exact asset inventory before it can publish the GitHub
+Release. Any failed coordinate keeps the public Release closed.

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -412,9 +412,9 @@
     {
       "case": "root",
       "stream": "stdout",
-      "reason": "Advance the Patch version to v4.02.13 while preserving the bounded built-in operator reference introduced after v4.02.8.",
+      "reason": "Advance the Patch version to v4.02.14 while preserving the bounded built-in operator reference introduced after v4.02.8.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.02.13 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.02.14 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     }
   ],
   "product_command_count": 24,
@@ -470,12 +470,12 @@
     "If no token is configured, `syswarden web-token` generates and persists one even without `--rotate`",
     "If that restart fails, the command returns nonzero and reports partial state",
     "`syswarden uninstall` is destructive",
-    "The historical v4.02.12 source candidate failed protected qualification before signing and was never tagged or published.",
-    "v4.02.13 supersedes it and remains NO-GO",
+    "The historical v4.02.13 source candidate failed protected qualification before signing, tagging or release publication and was never tagged or published.",
+    "v4.02.14 supersedes it and remains NO-GO",
     "The procedure below downloads exactly one package for the detected operating system and architecture.",
-    "VERSION=v4.02.13 sh ./install-release.sh",
+    "VERSION=v4.02.14 sh ./install-release.sh",
     "checksum manifest must contain exactly one entry for $PACKAGE",
-    "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md",
+    "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.14.md",
     "## Security posture and limitations",
     "Goal: 37% reached/year (Goal)"
   ],
@@ -483,7 +483,7 @@
     "it is not a compliance certification",
     "v4.02.9+ requires a trusted Ed25519 release manifest",
     "dedicated CGO-free static APK binaries are built for x86_64 and aarch64",
-    "v4.02.13 uses native /usr/local paths and rc.d on amd64",
+    "v4.02.14 uses native /usr/local paths and rc.d on amd64",
     "default bind 0.0.0.0:62027",
     "persistent self-signed TLS 1.3 identity",
     "/var/lib/syswarden/ha/server.crt and /var/lib/syswarden/ha/server.key",
@@ -507,7 +507,7 @@
     "configuration, data, logs, services and firewall tables are deleted"
   ],
   "public_report_contract": {
-    "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md",
+    "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.14.md",
     "preserved_reports": [
       {
         "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.11.md",
@@ -516,31 +516,35 @@
       {
         "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.12.md",
         "sha256": "eb920e37cc8b3700179149ee2ce14e13ab3221d3a622db39d41bdef81ab4285a"
+      },
+      {
+        "path": "docs/reports/LOT1_PUBLIC_SECURITY_REPORT_v4.02.13.md",
+        "sha256": "164130bc0cc338a79e79d2f09d6d6593b18e2e42ae941d4f4d8b0d577daed0f1"
       }
     ],
     "required_phrases": [
       "| Product release decision | NO-GO until protected qualification |",
-      "| Candidate | v4.02.13 |",
+      "| Candidate | v4.02.14 |",
       "| Historical public baseline | v4.02.8 |",
-      "| Prior source candidate | v4.02.12, merged but never tagged or published |",
-      "Protected qualification run `31965382720` stopped before signing",
-      "No v4.02.12 qualification artifact, signature, tag, public Release or Release asset was created.",
-      "v4.02.13 supersedes that unpublished candidate",
-      "hop to v4.02.13 must therefore use a separately verified package and the native package manager",
-      "A qualified v4.02.13 Release must contain exactly these 14 public assets:",
+      "| Prior source candidate | v4.02.13, merged but never tagged or published |",
+      "Protected qualification run `31972963066` stopped before signing",
+      "No sealed v4.02.13 qualification artifact, release signature, tag, public Release or Release asset was created.",
+      "v4.02.14 supersedes that unpublished candidate",
+      "hop to v4.02.14 must therefore use a separately verified package and the native package manager",
+      "A qualified v4.02.14 Release must contain exactly these 14 public assets:",
       "separate native amd64 and ARM64 shards",
       "Durable node-to-node L7 and WAAP ban exchange remains active with the partner gate false or true",
       "Raw `pkg delete` is not the supported FreeBSD cleanup path",
       "FreeBSD jails and coexistence with arbitrary pre-existing PF policy"
     ],
     "expected_assets": [
-      "syswarden_4.02.13_amd64.deb",
-      "syswarden_4.02.13_arm64.deb",
-      "syswarden-4.02.13-1.x86_64.rpm",
-      "syswarden-4.02.13-1.aarch64.rpm",
-      "syswarden_4.02.13_x86_64.apk",
-      "syswarden_4.02.13_aarch64.apk",
-      "syswarden-4.02.13.txz",
+      "syswarden_4.02.14_amd64.deb",
+      "syswarden_4.02.14_arm64.deb",
+      "syswarden-4.02.14-1.x86_64.rpm",
+      "syswarden-4.02.14-1.aarch64.rpm",
+      "syswarden_4.02.14_x86_64.apk",
+      "syswarden_4.02.14_aarch64.apk",
+      "syswarden-4.02.14.txz",
       "SHA256SUMS.txt",
       "RELEASE_SHA256SUMS.txt",
       "syswarden-release.tar.gz",
@@ -577,7 +581,7 @@
       "Disabling BunkerWeb leaves this authenticated node-to-node exchange available",
       "signed Ed25519 update manifest",
       "The procedure below downloads exactly one package for the detected operating system and architecture.",
-      "VERSION=v4.02.13 sh ./install-release.sh",
+      "VERSION=v4.02.14 sh ./install-release.sh",
       "checksum manifest must contain exactly one entry for $PACKAGE",
       "On FreeBSD, use `syswarden uninstall` rather than raw `pkg delete`."
     ],
@@ -588,7 +592,7 @@
       "A-to-B and B-to-A exchange",
       "through TLS 1.3 and bearer authentication",
       "removes partner TTL, batch and provenance capabilities",
-      "any package artifact that has not passed the exact protected v4.02.13 lifecycle",
+      "any package artifact that has not passed the exact protected v4.02.14 lifecycle",
       "FreeBSD coexistence with an arbitrary pre-existing PF policy"
     ],
     "BunkerWeb-Integration.md": [
@@ -613,7 +617,7 @@
       "Start with `SYSWARDEN_ENFORCEMENT=audit`",
       "An external-only row is never reported as a SysWarden test success.",
       "Never copy `server.key` to a client.",
-      "v4.02.13 does not expose remote whitelist writes or per-client scoped tokens."
+      "v4.02.14 does not expose remote whitelist writes or per-client scoped tokens."
     ]
   },
   "package_platform_contract": {
@@ -751,7 +755,7 @@
         "header": [
           "Package family",
           "Architectures produced by the workflow",
-          "Decision for v4.02.13"
+          "Decision for v4.02.14"
         ],
         "rows": [
           [

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -554,7 +554,7 @@ invented_key = true
         ]
         deployment = """## 1. Target decision
 
-| Package family | Architectures produced by the workflow | Decision for v4.02.13 |
+| Package family | Architectures produced by the workflow | Decision for v4.02.14 |
 | :--- | :--- | :--- |
 | DEB | amd64, arm64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |
 | RPM | x86_64, aarch64 | Package contents and lifecycle contracts validated; exact protected lifecycle still required before release |

--- a/scripts/ci/fixtures/package-forward-only-v4.02.8.json
+++ b/scripts/ci/fixtures/package-forward-only-v4.02.8.json
@@ -1,5 +1,5 @@
 {
-  "candidate_version": "4.02.13",
+  "candidate_version": "4.02.14",
   "previous_version": "4.02.8",
   "artifacts": {
     "aarch64": {

--- a/scripts/ci/freebsd_updater_vm_probe_test.py
+++ b/scripts/ci/freebsd_updater_vm_probe_test.py
@@ -44,7 +44,7 @@ def passing_evidence() -> dict[str, str]:
         "UPDATER_RESULT_SHA256": "a" * 64,
         "UPDATER_RESULT_EXACT": "1",
         "UPDATER_RESULT_LINE": f"--- PASS: {subject.TEST_NAME} (1.23s)",
-        "CANDIDATE_VERSION": "4.02.13",
+        "CANDIDATE_VERSION": "4.02.14",
         "CORE_ENABLED": "YES",
         "WEB_ENABLED": "YES",
         "CORE_STATUS_RC": "0",
@@ -80,13 +80,13 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
-        self.candidate_path = fixture(self.root / "syswarden-4.02.13.txz", b"candidate")
+        self.candidate_path = fixture(self.root / "syswarden-4.02.14.txz", b"candidate")
         self.previous_path = fixture(self.root / "syswarden-4.02.8.txz", b"previous")
         self.manifest = fixture(self.root / "syswarden-update-manifest-v1.json", b"{}\n")
         self.signature = fixture(self.root / "syswarden-update-manifest-v1.json.sig", b"signature\n")
         self.test_binary = fixture(self.root / subject.TEST_BINARY_NAME, b"ELF", 0o700)
         self.candidate = vm_lab.PackageArtifact(
-            self.candidate_path, "4.02.13", hashlib.sha256(b"candidate").hexdigest()
+            self.candidate_path, "4.02.14", hashlib.sha256(b"candidate").hexdigest()
         )
         self.previous = vm_lab.PackageArtifact(
             self.previous_path, "4.02.8", hashlib.sha256(b"previous").hexdigest()
@@ -116,7 +116,7 @@ class FreeBSDUpdaterVMProbeTests(unittest.TestCase):
         report = self.report()
         self.assertTrue(report["release_ready"])
         self.assertEqual(report["blocker_ids"], [])
-        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.13")
+        self.assertEqual(report["inputs"]["candidate"]["version"], "4.02.14")
         self.assertEqual(report["inputs"]["previous"]["version"], "4.02.8")
 
     def test_each_material_observation_is_fail_closed(self) -> None:

--- a/scripts/ci/freebsd_vm_lab.py
+++ b/scripts/ci/freebsd_vm_lab.py
@@ -547,10 +547,10 @@ def version_tuple(version: str) -> tuple[int, int, int]:
 def is_forward_only_transition(
     candidate: PackageArtifact, previous: PackageArtifact
 ) -> bool:
-    """Recognize only the immutable v4.02.8 to v4.02.13 transition."""
+    """Recognize only the immutable v4.02.8 to v4.02.14 transition."""
 
     return (
-        candidate.version == "4.02.13"
+        candidate.version == "4.02.14"
         and previous.version == FORWARD_ONLY_PREVIOUS_VERSION
         and previous.path.name == FORWARD_ONLY_PREVIOUS_PACKAGE
         and previous.sha256 == FORWARD_ONLY_PREVIOUS_SHA256
@@ -570,7 +570,7 @@ def validate_forward_only_binding(
     ):
         raise FreeBSDVMLabError(
             "the historical FreeBSD transition is allowed only for the exact "
-            "v4.02.8 package bytes followed by candidate v4.02.13"
+            "v4.02.8 package bytes followed by candidate v4.02.14"
         )
 
 
@@ -1181,7 +1181,7 @@ fi
 if [ "$previous_expected_version" = "4.02.8" ]; then
     if [ "$previous_package_name" != "syswarden-4.02.8.txz" ] || \
        [ "$previous_expected_sha" != "8b3b489821450b3afd74548c6db5ad92001b8a69f923e2b9a99ce550353b6e37" ] || \
-       [ "$candidate_expected_version" != "4.02.13" ]; then
+       [ "$candidate_expected_version" != "4.02.14" ]; then
         exit 91
     fi
 fi

--- a/scripts/ci/freebsd_vm_lab_test.py
+++ b/scripts/ci/freebsd_vm_lab_test.py
@@ -344,7 +344,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
 
     def forward_candidate_artifact(self) -> freebsd_vm_lab.PackageArtifact:
         return freebsd_vm_lab.PackageArtifact(
-            self.root / "syswarden-4.02.13.txz", "4.02.13", self.package_sha
+            self.root / "syswarden-4.02.14.txz", "4.02.14", self.package_sha
         )
 
     def forward_previous_artifact(self) -> freebsd_vm_lab.PackageArtifact:
@@ -365,9 +365,9 @@ class FreeBSDVMLabTests(unittest.TestCase):
         self.assertEqual(candidate, self.artifact())
         self.assertEqual(previous, self.previous_artifact())
 
-    def test_candidate_v40213_requires_exact_dependency_manifest(self) -> None:
+    def test_candidate_v40214_requires_exact_dependency_manifest(self) -> None:
         self.package.unlink()
-        candidate = self.packages / "syswarden-4.02.13.txz"
+        candidate = self.packages / "syswarden-4.02.14.txz"
         candidate.write_bytes(b"candidate with dependency gate")
         digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
         (self.packages / "SHA256SUMS.txt").write_text(
@@ -775,7 +775,7 @@ class FreeBSDVMLabTests(unittest.TestCase):
             "CANDIDATE_REINSTALL",
             "CANDIDATE_RESTART_IDEMPOTENCE",
         ):
-            evidence[f"{phase}_PKG_VERSION"] = "4.02.13"
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.14"
         for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
             evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
             evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
 import shutil
 import signal
 import subprocess
+import tarfile
 import tempfile
 import textwrap
 import time
@@ -31,6 +33,33 @@ def workflow_step_script(workflow: str, step_name: str) -> str:
     if step.count(run_marker) != 1:
         raise AssertionError(f"expected one shell body for workflow step {step_name}")
     return textwrap.dedent(step.split(run_marker, 1)[1])
+
+
+def workflow_run_commands(workflow: str) -> tuple[tuple[str, str], ...]:
+    lines = workflow.splitlines()
+    commands: list[tuple[str, str]] = []
+    step_name = ""
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith("      - name: "):
+            step_name = line.removeprefix("      - name: ")
+        if line.startswith("        run: "):
+            value = line.removeprefix("        run: ")
+            if value == "|":
+                body: list[str] = []
+                index += 1
+                while index < len(lines):
+                    candidate = lines[index]
+                    if candidate and len(candidate) - len(candidate.lstrip()) <= 8:
+                        index -= 1
+                        break
+                    body.append(candidate)
+                    index += 1
+                value = textwrap.dedent("\n".join(body))
+            commands.append((step_name, value))
+        index += 1
+    return tuple(commands)
 
 
 class PackageLifecycleContractTests(unittest.TestCase):
@@ -66,13 +95,11 @@ class PackageLifecycleContractTests(unittest.TestCase):
         )
         return bodies[0]
 
-    def test_package_workflow_shell_steps_fit_github_limit(self) -> None:
-        for step_name in (
-            "Prepare Linux Maintainer Scripts",
-            "Build Debian Package (.deb)",
-        ):
+    def test_every_package_workflow_run_command_fits_github_limit(self) -> None:
+        commands = workflow_run_commands(self.workflow)
+        self.assertGreater(len(commands), 0)
+        for step_name, script in commands:
             with self.subTest(step=step_name):
-                script = workflow_step_script(self.workflow, step_name)
                 encoded_size = len(json.dumps(script, ensure_ascii=False))
                 self.assertLessEqual(
                     encoded_size,
@@ -376,6 +403,12 @@ class PackageLifecycleContractTests(unittest.TestCase):
     def test_package_cron_filters_are_exact_and_preserve_operator_bytes(self) -> None:
         for name, script, managed_paths in self.cron_script_matrix():
             functions = self.cron_functions(script)
+            self.assertNotIn("syswarden_cron_candidate%", functions)
+            self.assertIn(
+                'printf \'%s\\n\' "${syswarden_cron_candidate}" | '
+                "awk 'NR == 1 { print $1; exit }'",
+                functions,
+            )
             managed_lines = [
                 line
                 for path in managed_paths
@@ -403,45 +436,177 @@ class PackageLifecycleContractTests(unittest.TestCase):
             input_lines = [survivors[0], *managed_lines, *survivors[1:]]
             if alternate not in input_lines:
                 input_lines.append(alternate)
-            for final_lf in (False, True):
-                with self.subTest(script=name, final_lf=final_lf), tempfile.TemporaryDirectory() as temporary:
-                    root = Path(temporary)
-                    source = root / "input"
-                    destination = root / "output"
-                    source_bytes = "\n".join(input_lines).encode("utf-8")
-                    if final_lf:
-                        source_bytes += b"\n"
-                    managed_candidates = set(managed_lines)
-                    if "/usr/local/syswarden/bin/syswarden-cli" in managed_paths:
-                        managed_candidates.add(alternate)
-                    expected = b""
-                    for index, line in enumerate(input_lines):
-                        if line in managed_candidates:
-                            continue
-                        expected += line.encode("utf-8")
-                        if index < len(input_lines) - 1 or final_lf:
-                            expected += b"\n"
-                    source.write_bytes(source_bytes)
-                    result = subprocess.run(
-                        [
-                            "/bin/sh",
-                            "-c",
-                            functions
-                            + '\nsyswarden_cron_source="$1"\n'
-                            + 'syswarden_cron_destination="$2"\n'
-                            + "shift 2\n"
-                            + 'syswarden_filter_crontab "${syswarden_cron_source}" '
-                            + '"${syswarden_cron_destination}" "$@"',
-                            "cron-filter-contract",
-                            str(source),
-                            str(destination),
-                            *managed_paths,
-                        ],
-                        check=False,
-                        capture_output=True,
-                    )
-                    self.assertEqual(result.returncode, 0, result.stderr)
-                    self.assertEqual(destination.read_bytes(), expected)
+            variants = (
+                ("source", functions),
+                ("rpm-scriptlet", functions.replace("%%", "%")),
+            )
+            for variant, executable_functions in variants:
+                for final_lf in (False, True):
+                    with self.subTest(
+                        script=name,
+                        variant=variant,
+                        final_lf=final_lf,
+                    ), tempfile.TemporaryDirectory() as temporary:
+                        root = Path(temporary)
+                        source = root / "input"
+                        destination = root / "output"
+                        source_bytes = "\n".join(input_lines).encode("utf-8")
+                        if final_lf:
+                            source_bytes += b"\n"
+                        managed_candidates = set(managed_lines)
+                        if "/usr/local/syswarden/bin/syswarden-cli" in managed_paths:
+                            managed_candidates.add(alternate)
+                        expected = b""
+                        for index, line in enumerate(input_lines):
+                            if line in managed_candidates:
+                                continue
+                            expected += line.encode("utf-8")
+                            if index < len(input_lines) - 1 or final_lf:
+                                expected += b"\n"
+                        source.write_bytes(source_bytes)
+                        result = subprocess.run(
+                            [
+                                "/bin/sh",
+                                "-c",
+                                executable_functions
+                                + '\nsyswarden_cron_source="$1"\n'
+                                + 'syswarden_cron_destination="$2"\n'
+                                + "shift 2\n"
+                                + 'syswarden_filter_crontab "${syswarden_cron_source}" '
+                                + '"${syswarden_cron_destination}" "$@"',
+                                "cron-filter-contract",
+                                str(source),
+                                str(destination),
+                                *managed_paths,
+                            ],
+                            check=False,
+                            capture_output=True,
+                        )
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual(destination.read_bytes(), expected)
+
+    def test_rpm_scriptlet_transform_rejects_percent_and_awk_mutations(self) -> None:
+        functions = self.cron_functions(self.script("prerm.sh"))
+        extraction = (
+            'syswarden_cron_minute="$(printf \'%s\\n\' '
+            '"${syswarden_cron_candidate}" | '
+            "awk 'NR == 1 { print $1; exit }')\""
+        )
+        self.assertEqual(functions.count(extraction), 1)
+
+        managed = (
+            "17 * * * * /opt/syswarden/bin/syswarden-cli "
+            "update-feeds >/dev/null 2>&1\n"
+        )
+
+        def filtered_bytes(candidate_functions: str) -> bytes:
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                source = root / "input"
+                destination = root / "output"
+                source.write_bytes(managed.encode("utf-8"))
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        candidate_functions.replace("%%", "%")
+                        + '\nsyswarden_cron_source="$1"\n'
+                        + 'syswarden_cron_destination="$2"\n'
+                        + 'syswarden_filter_crontab "${syswarden_cron_source}" '
+                        + '"${syswarden_cron_destination}" '
+                        + '"/opt/syswarden/bin/syswarden-cli"',
+                        "rpm-scriptlet-contract",
+                        str(source),
+                        str(destination),
+                    ],
+                    check=False,
+                    capture_output=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                return destination.read_bytes()
+
+        self.assertEqual(filtered_bytes(functions), b"")
+        legacy_percent = functions.replace(
+            extraction,
+            'syswarden_cron_minute="${syswarden_cron_candidate%% *}"',
+        )
+        wrong_awk_field = functions.replace("print $1; exit", "print $2; exit")
+        self.assertEqual(filtered_bytes(legacy_percent), managed.encode("utf-8"))
+        self.assertEqual(filtered_bytes(wrong_awk_field), managed.encode("utf-8"))
+
+    def test_rpm_artifact_gate_rejects_transformed_scriptlet_mutations(self) -> None:
+        validation_step = workflow_step_script(
+            self.workflow, "Validate Package Metadata"
+        )
+        function_start = validation_step.index("validate_rpm() {")
+        function_end = validation_step.index("\nvalidate_apk() {", function_start)
+        validate_rpm = validation_step[function_start:function_end]
+        self.assertIn("rpm --query --package --scripts", validate_rpm)
+        self.assertIn("grep --fixed-strings --count", validate_rpm)
+        self.assertIn("'${syswarden_cron_candidate%'", validate_rpm)
+
+        expected = (
+            'syswarden_cron_minute="$(printf \'%s\\n\' '
+            '"${syswarden_cron_candidate}" | '
+            "awk 'NR == 1 { print $1; exit }')\""
+        )
+        legacy = 'syswarden_cron_minute="${syswarden_cron_candidate% *}"'
+        wrong_awk = expected.replace("print $1; exit", "print $2; exit")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            scriptlets = root / "scriptlets"
+            fake_rpm = fake_bin / "rpm"
+            fake_rpm.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$3\" = --scripts ]; then\n"
+                "  cat \"${RPM_SCRIPTLETS_FILE}\"\n"
+                "  exit 0\n"
+                "fi\n"
+                "[ \"$3\" = --queryformat ] || exit 90\n"
+                "case \"$4\" in\n"
+                "  '%{VERSION}') printf 4.02.14 ;;\n"
+                "  '%{ARCH}') printf x86_64 ;;\n"
+                "  *) exit 91 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            fake_rpm.chmod(0o700)
+            environment = {
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "RPM_SCRIPTLETS_FILE": str(scriptlets),
+            }
+
+            def validate(payload: str) -> subprocess.CompletedProcess[bytes]:
+                scriptlets.write_text(payload, encoding="utf-8")
+                return subprocess.run(
+                    [
+                        "/bin/bash",
+                        "-c",
+                        "set -euo pipefail\nVERSION=4.02.14\n"
+                        + validate_rpm
+                        + '\nvalidate_rpm "$1" x86_64',
+                        "rpm-artifact-contract",
+                        str(root / "candidate.rpm"),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    env=environment,
+                )
+
+            accepted = validate(f"{expected}\n{expected}\n")
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            for name, payload in (
+                ("single-helper", f"{expected}\n"),
+                ("legacy-percent", f"{legacy}\n{legacy}\n"),
+                ("wrong-awk-field", f"{wrong_awk}\n{wrong_awk}\n"),
+            ):
+                with self.subTest(mutation=name):
+                    rejected = validate(payload)
+                    self.assertNotEqual(rejected.returncode, 0, rejected)
 
     def test_package_cron_cleanup_distinguishes_absence_and_errors(self) -> None:
         matrix = self.cron_script_matrix()
@@ -911,32 +1076,180 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 dependency,
             )
 
-    def test_apk_fresh_and_upgrade_hooks_share_the_exact_postinstall_contract(self) -> None:
+    def test_apk_fresh_and_upgrade_hooks_share_exact_pre_and_post_contracts(self) -> None:
+        workflow_preinstall = 'preinstall: "${PACKAGE_SCRIPTS}/preinst.sh"'
+        workflow_preupgrade = 'preupgrade: "${PACKAGE_SCRIPTS}/preinst.sh"'
         workflow_postinstall = 'postinstall: "${PACKAGE_SCRIPTS}/postinst.sh"'
         workflow_postupgrade = 'postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"'
         workflow_apk_hook = (
             "          apk:\n"
             "            scripts:\n"
+            '              preupgrade: "${PACKAGE_SCRIPTS}/preinst.sh"\n'
             '              postupgrade: "${PACKAGE_SCRIPTS}/postinst.sh"\n'
         )
+        self.assertEqual(self.workflow.count(workflow_preinstall), 2)
+        self.assertEqual(self.workflow.count(workflow_preupgrade), 2)
         self.assertEqual(self.workflow.count(workflow_postinstall), 2)
         self.assertEqual(self.workflow.count(workflow_postupgrade), 2)
         self.assertEqual(self.workflow.count(workflow_apk_hook), 2)
         self.assertEqual(self.workflow.count("            - openrc\n"), 2)
+        self.assertIn(".pre-install$/", self.workflow)
+        self.assertIn(".pre-upgrade$/", self.workflow)
         self.assertIn(".post-install$/", self.workflow)
         self.assertIn(".post-upgrade$/", self.workflow)
         self.assertIn("^depend = openrc$", self.workflow)
+        self.assertIn('"${preinstall_members[0]}"', self.workflow)
+        self.assertIn('"${preupgrade_members[0]}"', self.workflow)
         self.assertIn('"${postinstall_members[0]}"', self.workflow)
         self.assertIn('"${postupgrade_members[0]}"', self.workflow)
+        self.assertIn("compare_apk_hook_parity", self.workflow)
+        self.assertIn(
+            "for hook in .pre-install .pre-upgrade .post-install .post-upgrade; do",
+            self.workflow,
+        )
 
         local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
+        self.assertEqual(local.count('preinstall: "./preinst.sh"'), 1)
+        self.assertEqual(local.count('preupgrade: "./preinst.sh"'), 1)
         self.assertEqual(local.count('postinstall: "./postinst.sh"'), 1)
         self.assertEqual(local.count('postupgrade: "./postinst.sh"'), 1)
         self.assertEqual(
-            local.count('apk:\n  scripts:\n    postupgrade: "./postinst.sh"\n'),
+            local.count(
+                'apk:\n  scripts:\n    preupgrade: "./preinst.sh"\n'
+                '    postupgrade: "./postinst.sh"\n'
+            ),
             1,
         )
         self.assertEqual(local.count("  - openrc\n"), 1)
+
+    def test_apk_archive_hook_validation_rejects_missing_drift_and_arch_mismatch(
+        self,
+    ) -> None:
+        validation_step = workflow_step_script(
+            self.workflow, "Validate Package Metadata"
+        )
+        validate_start = validation_step.index("validate_apk() {")
+        parity_start = validation_step.index("\ncompare_apk_hook_parity() {")
+        invocation_start = validation_step.index("\nvalidate_deb ", parity_start)
+        validate_function = validation_step[validate_start:parity_start]
+        parity_function = validation_step[parity_start + 1 : invocation_start]
+
+        hooks = {
+            ".pre-install": b"#!/bin/sh\nprintf pre\n",
+            ".pre-upgrade": b"#!/bin/sh\nprintf pre\n",
+            ".post-install": b"#!/bin/sh\nprintf post\n",
+            ".post-upgrade": b"#!/bin/sh\nprintf post\n",
+        }
+
+        def write_apk(
+            path: Path,
+            architecture: str,
+            archive_hooks: dict[str, bytes],
+        ) -> None:
+            members = {
+                ".PKGINFO": (
+                    "pkgname = syswarden\n"
+                    "pkgver = 4.02.14\n"
+                    f"arch = {architecture}\n"
+                    "depend = openrc\n"
+                ).encode("utf-8"),
+                **archive_hooks,
+            }
+            with tarfile.open(path, "w:gz") as archive:
+                for name, content in members.items():
+                    metadata = tarfile.TarInfo(name)
+                    metadata.mode = 0o755 if name != ".PKGINFO" else 0o600
+                    metadata.size = len(content)
+                    archive.addfile(metadata, io.BytesIO(content))
+
+        def validate(path: Path, architecture: str) -> subprocess.CompletedProcess[bytes]:
+            return subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    "set -euo pipefail\nVERSION=4.02.14\n"
+                    + validate_function
+                    + '\nvalidate_apk "$1" "$2"',
+                    "apk-archive-contract",
+                    str(path),
+                    architecture,
+                ],
+                check=False,
+                capture_output=True,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            x86 = root / "syswarden_4.02.14_x86_64.apk"
+            arm = root / "syswarden_4.02.14_aarch64.apk"
+            write_apk(x86, "x86_64", hooks)
+            write_apk(arm, "aarch64", hooks)
+            accepted = validate(x86, "x86_64")
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            parity = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    + parity_function
+                    + '\ncompare_apk_hook_parity "$1" "$2" .pre-upgrade',
+                    "apk-parity-contract",
+                    str(x86),
+                    str(arm),
+                ],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(parity.returncode, 0, parity.stderr)
+
+            mutations = {
+                "missing-preupgrade": {
+                    name: content
+                    for name, content in hooks.items()
+                    if name != ".pre-upgrade"
+                },
+                "drifted-preupgrade": {
+                    **hooks,
+                    ".pre-upgrade": b"#!/bin/sh\nprintf drift\n",
+                },
+                "missing-postupgrade": {
+                    name: content
+                    for name, content in hooks.items()
+                    if name != ".post-upgrade"
+                },
+            }
+            for name, mutated_hooks in mutations.items():
+                with self.subTest(mutation=name):
+                    mutated = root / f"{name}.apk"
+                    write_apk(mutated, "x86_64", mutated_hooks)
+                    rejected = validate(mutated, "x86_64")
+                    self.assertNotEqual(rejected.returncode, 0, rejected)
+
+            wrong_arch = validate(x86, "aarch64")
+            self.assertNotEqual(wrong_arch.returncode, 0, wrong_arch)
+
+            drifted_arm = root / "drifted-arm.apk"
+            write_apk(
+                drifted_arm,
+                "aarch64",
+                {**hooks, ".pre-upgrade": b"#!/bin/sh\nprintf drift\n"},
+            )
+            rejected_parity = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    + parity_function
+                    + '\ncompare_apk_hook_parity "$1" "$2" .pre-upgrade',
+                    "apk-parity-contract",
+                    str(x86),
+                    str(drifted_arm),
+                ],
+                check=False,
+                capture_output=True,
+            )
+            self.assertNotEqual(rejected_parity.returncode, 0, rejected_parity)
 
     def test_freebsd_package_lifecycle_contract(self) -> None:
         preinstall = self.script("preinst_fbsd.sh")

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -389,7 +389,7 @@ PACKAGE_PAYLOAD_PATHS = (
     "/usr/local/bin/syswarden",
     "/usr/local/bin/syswarden-tui",
 )
-FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.13"
+FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.02.14"
 FORWARD_ONLY_APK_PREVIOUS_VERSION = "4.02.8"
 FORWARD_ONLY_APK_PREVIOUS = {
     "x86_64": {
@@ -600,7 +600,7 @@ def validate_forward_only_apk_pair(spec: PlatformSpec, pair: PackagePair) -> boo
     if historical_binding_touched and not forward_only:
         raise LifecycleLabError(
             "historical APK transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.13 contract for "
+            "v4.02.8 -> v4.02.14 contract for "
             f"{spec.package_architecture}"
         )
     return forward_only
@@ -1598,10 +1598,36 @@ validate_manifest_contract() {
         rpm)
             allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
             grep -Ev "${allowed}" "${manifest}" | grep -q . && return 1
-            [ "$(grep -Ec '^/usr/lib/\.build-id/[0-9a-f]{2}$' "${manifest}" || true)" = "3" ] || return 1
-            [ "$(grep -Ec '^/usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38}$' "${manifest}" || true)" = "3" ] || return 1
             required_manifest_path "${manifest}" /usr/lib/.build-id || return 1
-            [ "$(wc -l < "${manifest}" | tr -d ' ')" = "13" ] || return 1
+            awk '
+                /^\/usr\/lib\/\.build-id\/[0-9a-f]{2}$/ {
+                    directories[$0]++
+                    next
+                }
+                /^\/usr\/lib\/\.build-id\/[0-9a-f]{2}\/[0-9a-f]{38}$/ {
+                    links++
+                    parent = $0
+                    sub(/\/[0-9a-f]{38}$/, "", parent)
+                    required_directories[parent] = 1
+                    next
+                }
+                END {
+                    if (links != 3) {
+                        exit 1
+                    }
+                    for (directory in directories) {
+                        if (directories[directory] != 1 ||
+                            !(directory in required_directories)) {
+                            exit 1
+                        }
+                    }
+                    for (directory in required_directories) {
+                        if (directories[directory] != 1) {
+                            exit 1
+                        }
+                    }
+                }
+            ' "${manifest}" || return 1
             ;;
     esac
     return 0
@@ -2340,17 +2366,19 @@ def _validate_manager_paths(family: str, paths: list[str]) -> None:
     build_links = {
         path for path in paths if RPM_BUILD_ID_LINK_PATTERN.fullmatch(path)
     }
+    required_build_directories = {
+        path.rsplit("/", 1)[0] for path in build_links
+    }
     expected = (
         set(PACKAGE_PAYLOAD_PATHS)
         | {"/usr/lib/.build-id"}
-        | build_directories
+        | required_build_directories
         | build_links
     )
     if (
         observed != expected
-        or len(build_directories) != 3
         or len(build_links) != 3
-        or len(observed) != 13
+        or build_directories != required_build_directories
     ):
         raise LifecycleLabError("RPM native package inventory is not exact")
 

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -51,8 +51,7 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
                     "/usr/lib/.build-id",
                     "/usr/lib/.build-id/11",
                     "/usr/lib/.build-id/11/" + "1" * 38,
-                    "/usr/lib/.build-id/22",
-                    "/usr/lib/.build-id/22/" + "2" * 38,
+                    "/usr/lib/.build-id/11/" + "2" * 38,
                     "/usr/lib/.build-id/33",
                     "/usr/lib/.build-id/33/" + "3" * 38,
                 }
@@ -71,7 +70,7 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
             "/usr/lib/.build-id/11/" + "1" * 38: (
                 "../../../../opt/syswarden/bin/syswarden-cli"
             ),
-            "/usr/lib/.build-id/22/" + "2" * 38: (
+            "/usr/lib/.build-id/11/" + "2" * 38: (
                 "../../../../opt/syswarden/bin/syswarden-core"
             ),
             "/usr/lib/.build-id/33/" + "3" * 38: (
@@ -440,6 +439,14 @@ class PackageLifecycleLabTests(unittest.TestCase):
             fixture["artifacts"],
             package_lifecycle_lab.FORWARD_ONLY_APK_PREVIOUS,
         )
+        self.assertEqual(
+            fixture["candidate_version"],
+            package_lifecycle_lab.FORWARD_ONLY_APK_CANDIDATE_VERSION,
+        )
+        self.assertEqual(
+            fixture["previous_version"],
+            package_lifecycle_lab.FORWARD_ONLY_APK_PREVIOUS_VERSION,
+        )
         for spec in package_lifecycle_lab.DEFAULT_PLATFORMS:
             if spec.family != "apk":
                 continue
@@ -447,8 +454,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             pair = package_lifecycle_lab.PackagePair(
                 candidate=package_lifecycle_lab.PackageArtifact(
                     self.candidate
-                    / f"syswarden_4.02.13_{spec.package_architecture}.apk",
-                    "4.02.13",
+                    / f"syswarden_4.02.14_{spec.package_architecture}.apk",
+                    "4.02.14",
                     "a" * 64,
                 ),
                 previous=package_lifecycle_lab.PackageArtifact(
@@ -1104,7 +1111,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         previous_path = self.root / "syswarden_4.02.8_x86_64.apk"
         previous_path.write_bytes(b"exact historical APK fixture")
         previous = str(previous_path)
-        candidate_path = self.root / "syswarden_4.02.13_x86_64.apk"
+        candidate_path = self.root / "syswarden_4.02.14_x86_64.apk"
         candidate_path.write_bytes(b"candidate APK fixture")
         candidate = str(candidate_path)
         previous_sha256 = hashlib.sha256(previous_path.read_bytes()).hexdigest()
@@ -1198,11 +1205,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
             f'CALLS="{calls}"\n'
             f'RESTART_STATE_FILE="{restart}"\n'
             'PREVIOUS_PACKAGE="/previous/exact-v4.02.8.apk"\n'
-            'CANDIDATE_PACKAGE="/candidate/v4.02.13.apk"\n'
+            'CANDIDATE_PACKAGE="/candidate/v4.02.14.apk"\n'
             'PREVIOUS_VERSION="4.02.8"\n'
-            'CANDIDATE_VERSION="4.02.13"\n'
+            'CANDIDATE_VERSION="4.02.14"\n'
             'EXPECTED_PREVIOUS_VERSION="4.02.8"\n'
-            'EXPECTED_CANDIDATE_VERSION="4.02.13"\n'
+            'EXPECTED_CANDIDATE_VERSION="4.02.14"\n'
             'FORWARD_ONLY_APK_TRANSITION="1"\n'
             "prepare_expected_payloads() { return 0; }\n"
             "seed_state() { :; }\n"
@@ -1332,6 +1339,54 @@ class PackageLifecycleLabTests(unittest.TestCase):
                     family, [*manifest, manifest[-1]]
                 )
                 self.assertNotEqual(duplicate.returncode, 0)
+
+    def test_rpm_build_id_prefix_collision_requires_exact_unique_parents(
+        self,
+    ) -> None:
+        links = [
+            "/usr/lib/.build-id/1d/" + "1" * 38,
+            "/usr/lib/.build-id/1d/" + "2" * 38,
+            "/usr/lib/.build-id/5b/" + "3" * 38,
+        ]
+        valid = sorted(
+            [
+                *package_lifecycle_lab.PACKAGE_PAYLOAD_PATHS,
+                "/usr/lib/.build-id",
+                "/usr/lib/.build-id/1d",
+                "/usr/lib/.build-id/5b",
+                *links,
+            ]
+        )
+
+        package_lifecycle_lab._validate_manager_paths("rpm", valid)
+        accepted = self.run_embedded_inventory_contract("rpm", valid)
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        mutations = {
+            "orphan-directory": [*valid, "/usr/lib/.build-id/aa"],
+            "missing-parent": [
+                path for path in valid if path != "/usr/lib/.build-id/1d"
+            ],
+            "additional-link": [
+                *valid,
+                "/usr/lib/.build-id/5b/" + "4" * 38,
+            ],
+            "missing-link": [path for path in valid if path != links[1]],
+            "unexpected-path": [*valid, "/etc/shadow"],
+        }
+        for name, mutation in mutations.items():
+            adversarial = sorted(mutation)
+            with self.subTest(name=name):
+                with self.assertRaises(
+                    package_lifecycle_lab.LifecycleLabError
+                ):
+                    package_lifecycle_lab._validate_manager_paths(
+                        "rpm", adversarial
+                    )
+                rejected = self.run_embedded_inventory_contract(
+                    "rpm", adversarial
+                )
+                self.assertNotEqual(rejected.returncode, 0)
 
     def test_embedded_inventory_contract_rejects_type_mode_owner_and_link_drift(
         self,
@@ -1949,11 +2004,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 architecture
             ]
             platform_result.update(
-                candidate_version="4.02.13",
+                candidate_version="4.02.14",
                 previous_version="4.02.8",
                 candidate={
-                    "filename": f"syswarden_4.02.13_{architecture}.apk",
-                    "version": "4.02.13",
+                    "filename": f"syswarden_4.02.14_{architecture}.apk",
+                    "version": "4.02.14",
                     "sha256": "c" * 64,
                 },
                 previous={

--- a/scripts/ci/release_qualification_adapter.py
+++ b/scripts/ci/release_qualification_adapter.py
@@ -1362,8 +1362,8 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
         _string(item["version"], f"freebsd.inputs.{side}.version")
         _sha256(item["sha256"], f"freebsd.inputs.{side}.sha256")
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.13.txz"
-        and inputs["candidate"]["version"] == "4.02.13"
+        inputs["candidate"]["package"] == "syswarden-4.02.14.txz"
+        and inputs["candidate"]["version"] == "4.02.14"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]
@@ -1382,7 +1382,7 @@ def _validate_freebsd_schema(document: dict[str, Any]) -> tuple[dict[str, Any], 
     if historical_binding_touched and not forward_only:
         _fail(
             "FreeBSD historical transition must be the exact byte-bound "
-            "v4.02.8 -> v4.02.13 contract"
+            "v4.02.8 -> v4.02.14 contract"
         )
     _string(inputs["pf_fixture"], "freebsd.inputs.pf_fixture")
     _sha256(inputs["pf_fixture_sha256"], "freebsd.inputs.pf_fixture_sha256")
@@ -1604,8 +1604,8 @@ def _validate_freebsd(
     derived_product = "pass"
     inputs = document["inputs"]
     forward_only = (
-        inputs["candidate"]["package"] == "syswarden-4.02.13.txz"
-        and inputs["candidate"]["version"] == "4.02.13"
+        inputs["candidate"]["package"] == "syswarden-4.02.14.txz"
+        and inputs["candidate"]["version"] == "4.02.14"
         and inputs["previous"]["package"]
         == freebsd_lab.FORWARD_ONLY_PREVIOUS_PACKAGE
         and inputs["previous"]["version"]

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -558,7 +558,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture.save_raw("freebsd-vm-raw.json", report)
         self.assertAdapterError(self.fixture.args())
 
-    def test_freebsd_forward_only_v40213_contract_is_exercised(self) -> None:
+    def test_freebsd_forward_only_v40214_contract_is_exercised(self) -> None:
         evidence = passing_evidence()
         evidence["PF_SNAPSHOT_PROVENANCE"] = "legacy_derived"
         evidence["PREVIOUS_PACKAGE_SHA256"] = (
@@ -569,7 +569,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             "CANDIDATE_REINSTALL",
             "CANDIDATE_RESTART_IDEMPOTENCE",
         ):
-            evidence[f"{phase}_PKG_VERSION"] = "4.02.13"
+            evidence[f"{phase}_PKG_VERSION"] = "4.02.14"
         for phase in ("PREVIOUS_INSTALL", "PREVIOUS_ROLLBACK"):
             evidence[f"{phase}_PKG_VERSION"] = "4.02.8"
             evidence[f"{phase}_PKG_ARCH"] = "FreeBSD:13:amd64"
@@ -585,8 +585,8 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         report = freebsd_vm_lab.build_report(
             evidence,
             freebsd_vm_lab.PackageArtifact(
-                self.fixture.root / "syswarden-4.02.13.txz",
-                "4.02.13",
+                self.fixture.root / "syswarden-4.02.14.txz",
+                "4.02.14",
                 evidence["CANDIDATE_PACKAGE_SHA256"],
             ),
             freebsd_vm_lab.PackageArtifact(

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -122,7 +122,7 @@ var installCmd = &cobra.Command{
 		fmt.Printf("    Password: %s\n", token)
 		fmt.Printf("======================================================\n\n")
 
-		fmt.Println("[SYSWARDEN] v4.02.13 Native Installation Complete.")
+		fmt.Println("[SYSWARDEN] v4.02.14 Native Installation Complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/cmd/manual.go
+++ b/src/core/syswarden-cli/cmd/manual.go
@@ -92,10 +92,10 @@ var manualCmd = &cobra.Command{
 
 		fmt.Printf("%s--- 5. SAFETY LIMITS ---%s\n", ansiYellow, ansiReset)
 		fmt.Printf("  %sRELOAD:%s the Linux nftables candidate is committed atomically and verified; compatibility-wrapper failure leaves nftables authoritative and returns an error. The core normally restarts, so keep console access and a ruleset backup.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.13. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
+		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to v4.02.14. Signed Linux and FreeBSD amd64 updates are then supported.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sUNINSTALL:%s configuration, data, logs, services and firewall tables are deleted; it is not a rollback. On FreeBSD, use this command instead of raw pkg delete.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sALPINE:%s dedicated CGO-free static APK binaries are built for x86_64 and aarch64; install only an exact release-qualified artifact.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sFREEBSD:%s v4.02.13 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
+		fmt.Printf("  %sFREEBSD:%s v4.02.14 uses native /usr/local paths and rc.d on amd64. The first v4.02.8 hop is manual, and fresh installation requires PF disabled with an empty live ruleset.\n\n", ansiRed, ansiReset)
 
 		fmt.Printf("%s================================================================================%s\n", ansiCyan, ansiReset)
 		fmt.Printf("%sRead README.md and the command-specific --help output before a host-mutating action.%s\n", ansiWhite, ansiReset)

--- a/src/core/syswarden-cli/cmd/reload_service_contract_test.go
+++ b/src/core/syswarden-cli/cmd/reload_service_contract_test.go
@@ -19,7 +19,11 @@ func TestReloadServiceUsesNativePlatformManager_SW_PKG_001(t *testing.T) {
 	}
 	defer func() { _ = root.Close() }()
 	tests := map[string][]string{
-		"reload_service_default.go": {`exec.Command("systemctl", "restart", "syswarden-core.service")`},
+		"reload_service_default.go": {
+			`coreServiceRestartCommand(system.IsAlpine()).Run()`,
+			`exec.Command("rc-service", "syswarden-core", "restart")`,
+			`exec.Command("systemctl", "restart", "syswarden-core.service")`,
+		},
 		"reload_service_freebsd.go": {
 			`exec.Command("service", "syswarden", "restart")`,
 			`exec.Command("service", "syswarden", "onestatus")`,

--- a/src/core/syswarden-cli/cmd/reload_service_default.go
+++ b/src/core/syswarden-cli/cmd/reload_service_default.go
@@ -4,8 +4,17 @@ package cmd
 
 import (
 	"os/exec"
+
+	"syswarden-cli/pkg/system"
 )
 
 func restartCoreService() error {
-	return exec.Command("systemctl", "restart", "syswarden-core.service").Run()
+	return coreServiceRestartCommand(system.IsAlpine()).Run()
+}
+
+func coreServiceRestartCommand(alpine bool) *exec.Cmd {
+	if alpine {
+		return exec.Command("rc-service", "syswarden-core", "restart")
+	}
+	return exec.Command("systemctl", "restart", "syswarden-core.service")
 }

--- a/src/core/syswarden-cli/cmd/reload_service_default_test.go
+++ b/src/core/syswarden-cli/cmd/reload_service_default_test.go
@@ -1,0 +1,24 @@
+//go:build !freebsd
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCoreServiceRestartCommandUsesOpenRCOnAlpine_SW_PKG_002(t *testing.T) {
+	command := coreServiceRestartCommand(true)
+	want := []string{"rc-service", "syswarden-core", "restart"}
+	if !reflect.DeepEqual(command.Args, want) {
+		t.Fatalf("Alpine restart command = %q, want %q", command.Args, want)
+	}
+}
+
+func TestCoreServiceRestartCommandUsesSystemdOutsideAlpine_SW_PKG_003(t *testing.T) {
+	command := coreServiceRestartCommand(false)
+	want := []string{"systemctl", "restart", "syswarden-core.service"}
+	if !reflect.DeepEqual(command.Args, want) {
+		t.Fatalf("non-Alpine restart command = %q, want %q", command.Args, want)
+	}
+}

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.02.13
+# Version=v4.02.14
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.02.13", Inline: true},
+						{Name: "Version", Value: "v4.02.14", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var Version = "v4.02.13"
+var Version = "v4.02.14"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -79,7 +79,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.14 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -147,7 +147,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.14 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -359,7 +359,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.02.13 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.02.14 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.02.13"
+const SysWardenVersion = "v4.02.14"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary

- Prepare Alpine upgrades with the same fail-closed pre-install contract used for fresh installs, and reload `syswarden-core` through OpenRC on Alpine.
- Make RPM cron removal resistant to RPM percent processing and validate the generated scriptlets.
- Accept exactly three RPM build-id links with exactly their unique parent directories, while rejecting missing, orphaned and unexpected paths.
- Retarget the byte-bound v4.02.8 to v4.02.14 Linux and FreeBSD qualification contracts.
- Publish the v4.02.14 candidate documentation and anonymized NO-GO report while preserving the failed v4.02.13 history byte-for-byte.

## Validation

- Version contract: v4.02.14 across 7 files and 9 occurrences; exact Patch transition from v4.02.13.
- Targeted release, qualification, package, FreeBSD and documentation campaign: 272 tests; the only two shared-host temporary-path collisions passed on isolated rerun.
- Go CLI, Core, TUI and versionctl: native tests, race detector and vet passed; FreeBSD/amd64 cross-test and vet passed.
- Real package probes: Fedora and AlmaLinux amd64 upgrade/rollback and removal passed; Alpine amd64 v4.02.8 to v4.02.14 upgrade/rollback, three starts, removal and purge passed.
- Generated packages: APK pre-install/pre-upgrade and post-install/post-upgrade hooks are byte-paired; RPM scriptlets contain the exact portable cron parser; build-id inventories passed.
- Package workflow: 24 run commands validated, maximum encoded size 20280 of 21000 bytes.
- Workflow validation: 7 of 7 YAML files passed unique-key parsing and strict `act` validation; maintainer scripts passed syntax and ShellCheck warning-level validation.
- Documentation truth gate passed for README, manual and all 4 wiki pages; the expected Release inventory contains exactly 14 unique public assets.
- Gitleaks v8.24.3 found no leak in the exact staged index; diff-check, U+2014 scan and `go.work.sum` integrity checks passed.

## Release status

v4.02.14 remains NO-GO until protected qualification passes on the exact merged SHA. No tag or public Release is authorized by this PR alone. The previous public Release remains v4.02.8.
