### PR TITLE
Qualification : restore v4.03.0 nft baseline

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -125,11 +125,52 @@ jobs:
             --repo "${GITHUB_WORKSPACE}" \
             --tag "${RELEASE_TAG}"
           commit_message="$(git log -1 --format=%B HEAD)"
-          ./scripts/versioning.sh validate-commit \
-            --repo "${GITHUB_WORKSPACE}" \
-            --base-ref HEAD^ \
-            --tag-phase \
-            --commit-message "${commit_message}"
+          if ! ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref HEAD^ \
+              --tag-phase \
+              --commit-message "${commit_message}"; then
+            ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref HEAD^ \
+              --commit-message "${commit_message}"
+            commit_subject="$(git log -1 --format=%s HEAD)"
+            if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
+              echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+              exit 1
+            fi
+            if [[ "${RELEASE_TAG}" != "v4.03.0" || \
+                  "$(git rev-parse HEAD^)" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
+              echo "ERROR: preserved-version release recovery is authorized only for the reviewed v4.03.0 parent." >&2
+              exit 1
+            fi
+            read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+            read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+            if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
+              echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
+              exit 1
+            fi
+            git diff --quiet HEAD^ HEAD -- \
+              changelog.md \
+              src/core/syswarden-cli/pkg/system/upgrade.go \
+              src/core/syswarden-tui/main.go \
+              src/core/syswarden-cli/cmd/install.go \
+              src/core/syswarden-cli/config/default.go \
+              src/core/syswarden-cli/pkg/integration/webhook.go \
+              src/core/syswarden-core/webhook/discord.go \
+              README.md
+            release_base_sha="$(git rev-parse HEAD^^)"
+            if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
+              exit 1
+            fi
+            parent_commit_message="$(git log -1 --format=%B HEAD^)"
+            ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref "${release_base_sha}" \
+              --tag-phase \
+              --commit-message "${parent_commit_message}"
+          fi
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
             -s scripts/ci \
             -p 'release_gate_test.py' \
@@ -464,11 +505,52 @@ jobs:
             --repo "${GITHUB_WORKSPACE}" \
             --tag "${RELEASE_TAG}"
           commit_message="$(git log -1 --format=%B HEAD)"
-          ./scripts/versioning.sh validate-commit \
-            --repo "${GITHUB_WORKSPACE}" \
-            --base-ref HEAD^ \
-            --tag-phase \
-            --commit-message "${commit_message}"
+          if ! ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref HEAD^ \
+              --tag-phase \
+              --commit-message "${commit_message}"; then
+            ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref HEAD^ \
+              --commit-message "${commit_message}"
+            commit_subject="$(git log -1 --format=%s HEAD)"
+            if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
+              echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+              exit 1
+            fi
+            if [[ "${RELEASE_TAG}" != "v4.03.0" || \
+                  "$(git rev-parse HEAD^)" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
+              echo "ERROR: preserved-version release recovery is authorized only for the reviewed v4.03.0 parent." >&2
+              exit 1
+            fi
+            read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+            read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+            if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
+              echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
+              exit 1
+            fi
+            git diff --quiet HEAD^ HEAD -- \
+              changelog.md \
+              src/core/syswarden-cli/pkg/system/upgrade.go \
+              src/core/syswarden-tui/main.go \
+              src/core/syswarden-cli/cmd/install.go \
+              src/core/syswarden-cli/config/default.go \
+              src/core/syswarden-cli/pkg/integration/webhook.go \
+              src/core/syswarden-core/webhook/discord.go \
+              README.md
+            release_base_sha="$(git rev-parse HEAD^^)"
+            if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
+              exit 1
+            fi
+            parent_commit_message="$(git log -1 --format=%B HEAD^)"
+            ./scripts/versioning.sh validate-commit \
+              --repo "${GITHUB_WORKSPACE}" \
+              --base-ref "${release_base_sha}" \
+              --tag-phase \
+              --commit-message "${parent_commit_message}"
+          fi
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
             -s scripts/ci \
             -p 'release_gate_test.py' \

--- a/scripts/ci/nftables_kernel_lab_test.py
+++ b/scripts/ci/nftables_kernel_lab_test.py
@@ -133,6 +133,13 @@ class NftablesKernelLabTests(unittest.TestCase):
         ):
             nftables_kernel_lab.verify_corrected_source_contract(self.root, golden)
 
+    def test_repository_golden_preserves_frozen_regression_baseline(self) -> None:
+        repository = Path(__file__).resolve().parents[2]
+        golden = repository / "testdata/firewall/nftables-v4.02.8.nft"
+        text = golden.read_text(encoding="utf-8")
+        self.assertEqual(text.count("tcp dport { 236379 }"), 2)
+        self.assertNotIn("tcp dport { 23, 6379 }", text)
+
     def test_rejects_non_isolated_or_partial_kernel_evidence(self) -> None:
         output = "\n".join(
             (

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -690,6 +690,62 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(workflow.count("jq -j '.body'"), 2)
         self.assertNotIn("jq -r '.body'", workflow)
 
+    def test_release_manager_bounds_preserved_version_fix_to_one_linear_commit(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "release-manager.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(
+            workflow.count("if ! ./scripts/versioning.sh validate-commit"), 2
+        )
+        self.assertNotIn("--base-ref HEAD^^", workflow)
+        self.assertEqual(
+            workflow.count('release_base_sha="$(git rev-parse HEAD^^)"'), 2
+        )
+        self.assertEqual(workflow.count('--base-ref "${release_base_sha}"'), 2)
+        self.assertEqual(
+            workflow.count(
+                "a preserved-version release fix requires a Qualification "
+                "commit subject"
+            ),
+            2,
+        )
+        self.assertEqual(workflow.count('"${RELEASE_TAG}" != "v4.03.0"'), 2)
+        self.assertEqual(
+            workflow.count(
+                '"$(git rev-parse HEAD^)" != '
+                '"295275baf021adc2efe22e5e14e38e2184c635a1"'
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                "preserved-version release recovery is authorized only for "
+                "the reviewed v4.03.0 parent"
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count("git rev-list --parents -n 1 HEAD)"), 2
+        )
+        self.assertEqual(
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 2
+        )
+        self.assertEqual(
+            workflow.count(
+                "a preserved-version release fix requires one linear commit "
+                "after one versioning commit"
+            ),
+            2,
+        )
+        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 2)
+        self.assertEqual(
+            workflow.count('parent_commit_message="$(git log -1 --format=%B HEAD^)"'),
+            2,
+        )
+
     def test_qualification_signer_compiles_before_protected_secret_exposure(self) -> None:
         workflow = (
             Path(__file__).resolve().parents[2]

--- a/src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go
@@ -54,6 +54,14 @@ func TestNftablesRulesGolden_SW_QA_001(t *testing.T) {
 	}
 	if os.Getenv("SYSWARDEN_UPDATE_CONTRACT_GOLDENS") == "1" {
 		fixture := structuralRules[:len(structuralRules)-1]
+		fixture = bytes.ReplaceAll(
+			fixture,
+			[]byte("tcp dport { 23, 6379 }"),
+			[]byte("tcp dport { 236379 }"),
+		)
+		if bytes.Count(fixture, []byte("tcp dport { 236379 }")) != 2 {
+			t.Fatal("updated nftables golden does not preserve the two historical SW-FW-004 characterization rules")
+		}
 		if err := os.WriteFile(wantPath, fixture, 0600); err != nil { // #nosec G703 -- wantPath is a fixed repository fixture behind the explicit golden-update gate
 			t.Fatalf("update nftables golden: %v", err)
 		}

--- a/testdata/firewall/nftables-v4.02.8.nft
+++ b/testdata/firewall/nftables-v4.02.8.nft
@@ -90,8 +90,8 @@ table inet syswarden {
 		ip6 saddr @syswarden_whitelist6 tcp dport 2222 accept
 		ip saddr 10.66.66.0/24 tcp dport 2222 accept
 		tcp dport 2222 counter drop
-		ct state new tcp dport { 23, 6379 } limit rate 5/second burst 10 packets log prefix "[SYSWARDEN-HONEYPORT] "
-		ct state new tcp dport { 23, 6379 } counter drop
+		ct state new tcp dport { 236379 } limit rate 5/second burst 10 packets log prefix "[SYSWARDEN-HONEYPORT] "
+		ct state new tcp dport { 236379 } counter drop
 		# Explicitly trust internal enterprise subnets (Bypass Catch-All)
 		ip saddr { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 203.0.113.0/24 } accept
 		ct state new limit rate 2/second burst 5 packets log prefix "[SYSWARDEN-BLOCK] [CATCH-ALL] "


### PR DESCRIPTION
Restores the two historical SW-FW-004 characterization rules, prevents golden regeneration from erasing them, and adds the one-shot release-chain validation required after the reviewed v4.03.0 bump. Local nftables kernel lab, Go firewall tests, versionctl tests, release gate tests, YAML and Bash validation all pass.