### PR TITLE
Qualification : isolate nft golden helper TMPDIR

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -135,41 +135,130 @@ jobs:
               --base-ref HEAD^ \
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
-            if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
-              echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+            if [[ "${RELEASE_TAG}" != "v4.03.0" ]]; then
+              echo "ERROR: preserved-version release recovery is authorized only for v4.03.0." >&2
               exit 1
             fi
-            if [[ "${RELEASE_TAG}" != "v4.03.0" || \
-                  "$(git rev-parse HEAD^)" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
-              echo "ERROR: preserved-version release recovery is authorized only for the reviewed v4.03.0 parent." >&2
-              exit 1
-            fi
-            read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-            read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-            if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
-              echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
-              exit 1
-            fi
-            git diff --quiet HEAD^ HEAD -- \
-              changelog.md \
-              src/core/syswarden-cli/pkg/system/upgrade.go \
-              src/core/syswarden-tui/main.go \
-              src/core/syswarden-cli/cmd/install.go \
-              src/core/syswarden-cli/config/default.go \
-              src/core/syswarden-cli/pkg/integration/webhook.go \
-              src/core/syswarden-core/webhook/discord.go \
-              README.md
-            release_base_sha="$(git rev-parse HEAD^^)"
-            if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
-              exit 1
-            fi
-            parent_commit_message="$(git log -1 --format=%B HEAD^)"
-            ./scripts/versioning.sh validate-commit \
-              --repo "${GITHUB_WORKSPACE}" \
-              --base-ref "${release_base_sha}" \
-              --tag-phase \
-              --commit-message "${parent_commit_message}"
+            current_parent_sha="$(git rev-parse HEAD^)"
+            case "${current_parent_sha}" in
+              295275baf021adc2efe22e5e14e38e2184c635a1)
+                if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
+                  echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+                  exit 1
+                fi
+                read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
+                  echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
+                  exit 1
+                fi
+                git diff --quiet HEAD^ HEAD -- \
+                  changelog.md \
+                  src/core/syswarden-cli/pkg/system/upgrade.go \
+                  src/core/syswarden-tui/main.go \
+                  src/core/syswarden-cli/cmd/install.go \
+                  src/core/syswarden-cli/config/default.go \
+                  src/core/syswarden-cli/pkg/integration/webhook.go \
+                  src/core/syswarden-core/webhook/discord.go \
+                  README.md
+                release_base_sha="$(git rev-parse HEAD^^)"
+                if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                  echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
+                  exit 1
+                fi
+                parent_commit_message="$(git log -1 --format=%B HEAD^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${parent_commit_message}"
+                ;;
+              10af4a7b754e1007fa8167e8c5222ac183cb288a)
+                if [[ "${commit_subject}" != "Qualification : isolate nft golden helper TMPDIR" ]]; then
+                  echo "ERROR: the second preserved-version release fix requires the exact reviewed Qualification subject." >&2
+                  exit 1
+                fi
+                previous_fix_parent_sha="$(git rev-parse HEAD^^)"
+                if [[ "${previous_fix_parent_sha}" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
+                  echo "ERROR: the second preserved-version release fix is not based on the reviewed v4.03.0 follow-up chain." >&2
+                  exit 1
+                fi
+                read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a previous_fix_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                if (( ${#head_line[@]} != 2 || ${#previous_fix_line[@]} != 2 )); then
+                  echo "ERROR: the second preserved-version release fix and its reviewed parent must both be linear commits." >&2
+                  exit 1
+                fi
+                # BEGIN exact second preserved-version fix diff contract
+                expected_fix_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M "scripts/ci/release_gate_test.py"
+                  M "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go"
+                )
+                mapfile -d '' -t actual_fix_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_fix_diff[@]} != ${#expected_fix_diff[@]} )); then
+                  echo "ERROR: the second preserved-version release fix must modify exactly the three reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_fix_diff[@]}; index++)); do
+                  if [[ "${actual_fix_diff[index]}" != "${expected_fix_diff[index]}" ]]; then
+                    echo "ERROR: the second preserved-version release fix contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                fix_paths=(
+                  ".github/workflows/release-manager.yml"
+                  "scripts/ci/release_gate_test.py"
+                  "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${fix_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed fix path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact second preserved-version fix diff contract
+                git diff --quiet HEAD^ HEAD -- \
+                  changelog.md \
+                  src/core/syswarden-cli/pkg/system/upgrade.go \
+                  src/core/syswarden-tui/main.go \
+                  src/core/syswarden-cli/cmd/install.go \
+                  src/core/syswarden-cli/config/default.go \
+                  src/core/syswarden-cli/pkg/integration/webhook.go \
+                  src/core/syswarden-core/webhook/discord.go \
+                  README.md
+                previous_fix_message="$(git log -1 --format=%B HEAD^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${previous_fix_parent_sha}" \
+                  --commit-message "${previous_fix_message}"
+                release_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${release_base_sha}" != "dfb8dfcf52bd1f82dcd2cd3b311119f01270af1e" ]]; then
+                  echo "ERROR: the original v4.03.0 versioning parent is not the reviewed commit." >&2
+                  exit 1
+                fi
+                versioning_commit_message="$(git log -1 --format=%B HEAD^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${versioning_commit_message}"
+                ;;
+              *)
+                echo "ERROR: preserved-version release recovery is not authorized for parent ${current_parent_sha}." >&2
+                exit 1
+                ;;
+            esac
           fi
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
             -s scripts/ci \
@@ -515,41 +604,130 @@ jobs:
               --base-ref HEAD^ \
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
-            if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
-              echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+            if [[ "${RELEASE_TAG}" != "v4.03.0" ]]; then
+              echo "ERROR: preserved-version release recovery is authorized only for v4.03.0." >&2
               exit 1
             fi
-            if [[ "${RELEASE_TAG}" != "v4.03.0" || \
-                  "$(git rev-parse HEAD^)" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
-              echo "ERROR: preserved-version release recovery is authorized only for the reviewed v4.03.0 parent." >&2
-              exit 1
-            fi
-            read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-            read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-            if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
-              echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
-              exit 1
-            fi
-            git diff --quiet HEAD^ HEAD -- \
-              changelog.md \
-              src/core/syswarden-cli/pkg/system/upgrade.go \
-              src/core/syswarden-tui/main.go \
-              src/core/syswarden-cli/cmd/install.go \
-              src/core/syswarden-cli/config/default.go \
-              src/core/syswarden-cli/pkg/integration/webhook.go \
-              src/core/syswarden-core/webhook/discord.go \
-              README.md
-            release_base_sha="$(git rev-parse HEAD^^)"
-            if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
-              exit 1
-            fi
-            parent_commit_message="$(git log -1 --format=%B HEAD^)"
-            ./scripts/versioning.sh validate-commit \
-              --repo "${GITHUB_WORKSPACE}" \
-              --base-ref "${release_base_sha}" \
-              --tag-phase \
-              --commit-message "${parent_commit_message}"
+            current_parent_sha="$(git rev-parse HEAD^)"
+            case "${current_parent_sha}" in
+              295275baf021adc2efe22e5e14e38e2184c635a1)
+                if [[ ! "${commit_subject}" =~ ^Qualification[[:space:]]*:[[:space:]]*[^[:space:]] ]]; then
+                  echo "ERROR: a preserved-version release fix requires a Qualification commit subject." >&2
+                  exit 1
+                fi
+                read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a release_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                if (( ${#head_line[@]} != 2 || ${#release_parent_line[@]} != 2 )); then
+                  echo "ERROR: a preserved-version release fix requires one linear commit after one versioning commit." >&2
+                  exit 1
+                fi
+                git diff --quiet HEAD^ HEAD -- \
+                  changelog.md \
+                  src/core/syswarden-cli/pkg/system/upgrade.go \
+                  src/core/syswarden-tui/main.go \
+                  src/core/syswarden-cli/cmd/install.go \
+                  src/core/syswarden-cli/config/default.go \
+                  src/core/syswarden-cli/pkg/integration/webhook.go \
+                  src/core/syswarden-core/webhook/discord.go \
+                  README.md
+                release_base_sha="$(git rev-parse HEAD^^)"
+                if [[ ! "${release_base_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                  echo "ERROR: the versioning baseline is not a full lowercase commit SHA." >&2
+                  exit 1
+                fi
+                parent_commit_message="$(git log -1 --format=%B HEAD^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${parent_commit_message}"
+                ;;
+              10af4a7b754e1007fa8167e8c5222ac183cb288a)
+                if [[ "${commit_subject}" != "Qualification : isolate nft golden helper TMPDIR" ]]; then
+                  echo "ERROR: the second preserved-version release fix requires the exact reviewed Qualification subject." >&2
+                  exit 1
+                fi
+                previous_fix_parent_sha="$(git rev-parse HEAD^^)"
+                if [[ "${previous_fix_parent_sha}" != "295275baf021adc2efe22e5e14e38e2184c635a1" ]]; then
+                  echo "ERROR: the second preserved-version release fix is not based on the reviewed v4.03.0 follow-up chain." >&2
+                  exit 1
+                fi
+                read -r -a head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a previous_fix_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                if (( ${#head_line[@]} != 2 || ${#previous_fix_line[@]} != 2 )); then
+                  echo "ERROR: the second preserved-version release fix and its reviewed parent must both be linear commits." >&2
+                  exit 1
+                fi
+                # BEGIN exact second preserved-version fix diff contract
+                expected_fix_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M "scripts/ci/release_gate_test.py"
+                  M "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go"
+                )
+                mapfile -d '' -t actual_fix_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_fix_diff[@]} != ${#expected_fix_diff[@]} )); then
+                  echo "ERROR: the second preserved-version release fix must modify exactly the three reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_fix_diff[@]}; index++)); do
+                  if [[ "${actual_fix_diff[index]}" != "${expected_fix_diff[index]}" ]]; then
+                    echo "ERROR: the second preserved-version release fix contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                fix_paths=(
+                  ".github/workflows/release-manager.yml"
+                  "scripts/ci/release_gate_test.py"
+                  "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${fix_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed fix path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact second preserved-version fix diff contract
+                git diff --quiet HEAD^ HEAD -- \
+                  changelog.md \
+                  src/core/syswarden-cli/pkg/system/upgrade.go \
+                  src/core/syswarden-tui/main.go \
+                  src/core/syswarden-cli/cmd/install.go \
+                  src/core/syswarden-cli/config/default.go \
+                  src/core/syswarden-cli/pkg/integration/webhook.go \
+                  src/core/syswarden-core/webhook/discord.go \
+                  README.md
+                previous_fix_message="$(git log -1 --format=%B HEAD^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${previous_fix_parent_sha}" \
+                  --commit-message "${previous_fix_message}"
+                release_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${release_base_sha}" != "dfb8dfcf52bd1f82dcd2cd3b311119f01270af1e" ]]; then
+                  echo "ERROR: the original v4.03.0 versioning parent is not the reviewed commit." >&2
+                  exit 1
+                fi
+                versioning_commit_message="$(git log -1 --format=%B HEAD^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${versioning_commit_message}"
+                ;;
+              *)
+                echo "ERROR: preserved-version release recovery is not authorized for parent ${current_parent_sha}." >&2
+                exit 1
+                ;;
+            esac
           fi
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
             -s scripts/ci \

--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -174,7 +174,8 @@ jobs:
                   --commit-message "${parent_commit_message}"
                 ;;
               10af4a7b754e1007fa8167e8c5222ac183cb288a)
-                if [[ "${commit_subject}" != "Qualification : isolate nft golden helper TMPDIR" ]]; then
+                second_fix_subject_pattern='^Qualification : isolate nft golden helper TMPDIR \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${second_fix_subject_pattern} ]]; then
                   echo "ERROR: the second preserved-version release fix requires the exact reviewed Qualification subject." >&2
                   exit 1
                 fi
@@ -643,7 +644,8 @@ jobs:
                   --commit-message "${parent_commit_message}"
                 ;;
               10af4a7b754e1007fa8167e8c5222ac183cb288a)
-                if [[ "${commit_subject}" != "Qualification : isolate nft golden helper TMPDIR" ]]; then
+                second_fix_subject_pattern='^Qualification : isolate nft golden helper TMPDIR \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${second_fix_subject_pattern} ]]; then
                   echo "ERROR: the second preserved-version release fix requires the exact reviewed Qualification subject." >&2
                   exit 1
                 fi

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -745,8 +745,14 @@ class ReleaseGateTests(unittest.TestCase):
         )
         self.assertEqual(
             workflow.count(
-                '"${commit_subject}" != '
-                '"Qualification : isolate nft golden helper TMPDIR"'
+                "second_fix_subject_pattern='^Qualification : isolate nft "
+                "golden helper TMPDIR \\(#[1-9][0-9]*\\)$'"
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                '[[ ! "${commit_subject}" =~ ${second_fix_subject_pattern} ]]'
             ),
             2,
         )
@@ -846,6 +852,18 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(script.count(end), 1)
         return "set -euo pipefail\n" + script.split(begin, 1)[1].split(end, 1)[0]
 
+    def second_fix_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        script = workflow_step_scripts(
+            workflow, "Validate Tag, Source, Changelog, and Main Ancestry"
+        )[0]
+        start = "second_fix_subject_pattern="
+        end = 'previous_fix_parent_sha="$(git rev-parse HEAD^^)"'
+        self.assertEqual(script.count(start), 1)
+        self.assertEqual(script.count(end), 1)
+        fragment = start + script.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def make_second_fix_diff_repository(self, name: str, mutation: str | None) -> Path:
         repository = self.root / name
         repository.mkdir()
@@ -930,6 +948,54 @@ class ReleaseGateTests(unittest.TestCase):
         for name, mutation in mutations.items():
             with self.subTest(name=name), self.assertRaises(AssertionError):
                 self.assert_preserved_version_recovery_contract(mutation)
+
+    def test_release_manager_second_followup_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        script = self.second_fix_subject_gate_script()
+        cases = {
+            "valid": ("Qualification : isolate nft golden helper TMPDIR (#91)", True),
+            "bare": ("Qualification : isolate nft golden helper TMPDIR", False),
+            "zero": ("Qualification : isolate nft golden helper TMPDIR (#0)", False),
+            "non-numeric": (
+                "Qualification : isolate nft golden helper TMPDIR (#PR)",
+                False,
+            ),
+            "numeric prefix with suffix": (
+                "Qualification : isolate nft golden helper TMPDIR (#91a)",
+                False,
+            ),
+            "double space": (
+                "Qualification : isolate nft golden helper TMPDIR  (#91)",
+                False,
+            ),
+            "trailing space": (
+                "Qualification : isolate nft golden helper TMPDIR (#91) ",
+                False,
+            ),
+            "leading zero": (
+                "Qualification : isolate nft golden helper TMPDIR (#091)",
+                False,
+            ),
+            "extra text": (
+                "Qualification : isolate nft golden helper TMPDIR (#91) extra",
+                False,
+            ),
+        }
+        for name, (subject, accepted) in cases.items():
+            with self.subTest(name=name):
+                environment = dict(os.environ)
+                environment["COMMIT_SUBJECT"] = subject
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=REPOSITORY,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
 
     def test_release_manager_exact_fix_diff_gate_rejects_git_shape_mutations(
         self,

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -38,6 +38,20 @@ def workflow_step_script(workflow: str, step_name: str) -> str:
     return textwrap.dedent(step.split(run_marker, 1)[1])
 
 
+def workflow_step_scripts(workflow: str, step_name: str) -> list[str]:
+    marker = f"      - name: {step_name}\n"
+    scripts = []
+    for remainder in workflow.split(marker)[1:]:
+        step = remainder.split("\n      - name:", 1)[0]
+        run_marker = "        run: |\n"
+        if step.count(run_marker) != 1:
+            raise AssertionError(f"expected one shell body for workflow step {step_name}")
+        scripts.append(textwrap.dedent(step.split(run_marker, 1)[1]))
+    if not scripts:
+        raise AssertionError(f"workflow step {step_name} is missing")
+    return scripts
+
+
 def run_environment_gate(
     script: str,
     environment: dict[str, object],
@@ -690,21 +704,38 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(workflow.count("jq -j '.body'"), 2)
         self.assertNotIn("jq -r '.body'", workflow)
 
-    def test_release_manager_bounds_preserved_version_fix_to_one_linear_commit(self) -> None:
-        workflow = (
-            Path(__file__).resolve().parents[2]
-            / ".github"
-            / "workflows"
-            / "release-manager.yml"
-        ).read_text(encoding="utf-8")
+    def assert_preserved_version_recovery_contract(self, workflow: str) -> None:
+        scripts = workflow_step_scripts(
+            workflow, "Validate Tag, Source, Changelog, and Main Ancestry"
+        )
+        self.assertEqual(len(scripts), 2)
+        self.assertEqual(scripts[0], scripts[1])
         self.assertEqual(
             workflow.count("if ! ./scripts/versioning.sh validate-commit"), 2
         )
-        self.assertNotIn("--base-ref HEAD^^", workflow)
+        self.assertEqual(
+            workflow.count('if [[ "${RELEASE_TAG}" != "v4.03.0" ]]'), 2
+        )
+        self.assertEqual(
+            workflow.count('case "${current_parent_sha}" in'), 2
+        )
+        self.assertEqual(
+            workflow.count("295275baf021adc2efe22e5e14e38e2184c635a1)"), 2
+        )
+        self.assertEqual(
+            workflow.count("10af4a7b754e1007fa8167e8c5222ac183cb288a)"), 2
+        )
         self.assertEqual(
             workflow.count('release_base_sha="$(git rev-parse HEAD^^)"'), 2
         )
-        self.assertEqual(workflow.count('--base-ref "${release_base_sha}"'), 2)
+        self.assertEqual(
+            workflow.count('release_base_sha="$(git rev-parse HEAD^^^)"'), 2
+        )
+        self.assertEqual(workflow.count('--base-ref "${release_base_sha}"'), 4)
+        self.assertNotIn("--base-ref HEAD^^", workflow)
+        self.assertEqual(
+            workflow.count('--base-ref "${previous_fix_parent_sha}"'), 2
+        )
         self.assertEqual(
             workflow.count(
                 "a preserved-version release fix requires a Qualification "
@@ -712,26 +743,37 @@ class ReleaseGateTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(workflow.count('"${RELEASE_TAG}" != "v4.03.0"'), 2)
         self.assertEqual(
             workflow.count(
-                '"$(git rev-parse HEAD^)" != '
+                '"${commit_subject}" != '
+                '"Qualification : isolate nft golden helper TMPDIR"'
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                'previous_fix_parent_sha="$(git rev-parse HEAD^^)"'
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                '"${previous_fix_parent_sha}" != '
                 '"295275baf021adc2efe22e5e14e38e2184c635a1"'
             ),
             2,
         )
         self.assertEqual(
+            workflow.count("git rev-list --parents -n 1 HEAD)"), 4
+        )
+        self.assertEqual(
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 4
+        )
+        self.assertEqual(
             workflow.count(
-                "preserved-version release recovery is authorized only for "
-                "the reviewed v4.03.0 parent"
+                'previous_fix_line <<< "$(git rev-list --parents -n 1 HEAD^)"'
             ),
             2,
-        )
-        self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD)"), 2
-        )
-        self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD^)"), 2
         )
         self.assertEqual(
             workflow.count(
@@ -740,11 +782,176 @@ class ReleaseGateTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 2)
+        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 4)
         self.assertEqual(
             workflow.count('parent_commit_message="$(git log -1 --format=%B HEAD^)"'),
             2,
         )
+        self.assertEqual(
+            workflow.count('previous_fix_message="$(git log -1 --format=%B HEAD^)"'),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                'versioning_commit_message="$(git log -1 --format=%B HEAD^^)"'
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                '"${release_base_sha}" != '
+                '"dfb8dfcf52bd1f82dcd2cd3b311119f01270af1e"'
+            ),
+            2,
+        )
+        for script in scripts:
+            self.assertEqual(script.count("--tag-phase"), 3)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 5)
+            self.assertEqual(
+                script.count("# BEGIN exact second preserved-version fix diff contract"),
+                1,
+            )
+            self.assertEqual(
+                script.count("# END exact second preserved-version fix diff contract"),
+                1,
+            )
+            self.assertEqual(
+                script.count(
+                    "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 1)
+            self.assertEqual(
+                script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
+                1,
+            )
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 1)
+            for path in (
+                ".github/workflows/release-manager.yml",
+                "scripts/ci/release_gate_test.py",
+                "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go",
+            ):
+                self.assertEqual(script.count(f'"{path}"'), 2)
+
+    def exact_second_fix_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        script = workflow_step_scripts(
+            workflow, "Validate Tag, Source, Changelog, and Main Ancestry"
+        )[0]
+        begin = "# BEGIN exact second preserved-version fix diff contract\n"
+        end = "# END exact second preserved-version fix diff contract"
+        self.assertEqual(script.count(begin), 1)
+        self.assertEqual(script.count(end), 1)
+        return "set -euo pipefail\n" + script.split(begin, 1)[1].split(end, 1)[0]
+
+    def make_second_fix_diff_repository(self, name: str, mutation: str | None) -> Path:
+        repository = self.root / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.email", "release-gate@example.invalid"],
+            check=True,
+        )
+        paths = [
+            repository / ".github/workflows/release-manager.yml",
+            repository / "scripts/ci/release_gate_test.py",
+            repository
+            / "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go",
+        ]
+        for path in paths:
+            self.write_file(path, b"reviewed parent\n")
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed parent"],
+            check=True,
+        )
+        for path in paths:
+            path.write_bytes(b"reviewed follow-up\n")
+        if mutation == "extra file":
+            self.write_file(repository / "unauthorized.txt", b"unexpected\n")
+        elif mutation == "mode":
+            paths[0].chmod(0o755)
+        elif mutation == "symlink":
+            paths[1].unlink()
+            paths[1].symlink_to("unauthorized-target")
+        elif mutation == "rename":
+            paths[2].rename(paths[2].with_name("renamed_golden_test.go"))
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed fix"],
+            check=True,
+        )
+        return repository
+
+    def test_release_manager_bounds_two_preserved_version_fixes_to_exact_chain(
+        self,
+    ) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        self.assert_preserved_version_recovery_contract(workflow)
+
+    def test_release_manager_second_followup_contract_rejects_mutations(self) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        mutations = {
+            "release tag": workflow.replace('"v4.03.0" ]]', '"v4.03.1" ]]'),
+            "exact parent": workflow.replace(
+                "10af4a7b754e1007fa8167e8c5222ac183cb288a)",
+                "20af4a7b754e1007fa8167e8c5222ac183cb288a)",
+            ),
+            "canonical subject": workflow.replace(
+                "Qualification : isolate nft golden helper TMPDIR",
+                "Qualification : arbitrary follow-up",
+            ),
+            "linear history": workflow.replace(
+                'previous_fix_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+                'previous_fix_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
+            ),
+            "byte identity": workflow.replace(
+                "git diff --quiet HEAD^ HEAD --", "git diff --quiet HEAD^^ HEAD --"
+            ),
+            "ordinary prior fix": workflow.replace(
+                '--base-ref "${previous_fix_parent_sha}"',
+                '--base-ref "${release_base_sha}"',
+            ),
+            "original bump": workflow.replace(
+                'versioning_commit_message="$(git log -1 --format=%B HEAD^^)"',
+                'versioning_commit_message="$(git log -1 --format=%B HEAD^)"',
+            ),
+            "pinned bump parent": workflow.replace(
+                "dfb8dfcf52bd1f82dcd2cd3b311119f01270af1e",
+                "efb8dfcf52bd1f82dcd2cd3b311119f01270af1e",
+            ),
+        }
+        for name, mutation in mutations.items():
+            with self.subTest(name=name), self.assertRaises(AssertionError):
+                self.assert_preserved_version_recovery_contract(mutation)
+
+    def test_release_manager_exact_fix_diff_gate_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        script = self.exact_second_fix_diff_script()
+        for index, mutation in enumerate((None, "extra file", "mode", "symlink", "rename")):
+            with self.subTest(mutation=mutation or "exact"):
+                repository = self.make_second_fix_diff_repository(
+                    f"fix-diff-{index}", mutation
+                )
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=repository,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if mutation is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_qualification_signer_compiles_before_protected_secret_exposure(self) -> None:
         workflow = (

--- a/src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	actContainerIsolationEnvironment = "SYSWARDEN_ACT_CONTAINER_ISOLATION"
-	actContainerIsolationMarker      = "security-audit-v1"
-	linuxFirewallHelperEnvironment   = "SYSWARDEN_LINUX_FIREWALL_GOLDEN_HELPER"
-	linuxFirewallTargetDirectory     = "/etc/syswarden"
-	linuxFirewallTargetFile          = "/etc/syswarden/syswarden.nft"
+	actContainerIsolationEnvironment   = "SYSWARDEN_ACT_CONTAINER_ISOLATION"
+	actContainerIsolationMarker        = "security-audit-v1"
+	bubblewrapTempDirHelperEnvironment = "SYSWARDEN_BUBBLEWRAP_TMPDIR_HELPER"
+	linuxFirewallHelperEnvironment     = "SYSWARDEN_LINUX_FIREWALL_GOLDEN_HELPER"
+	linuxFirewallTargetDirectory       = "/etc/syswarden"
+	linuxFirewallTargetFile            = "/etc/syswarden/syswarden.nft"
 )
 
 func TestNftablesRulesGolden_SW_QA_001(t *testing.T) {
@@ -102,15 +103,7 @@ func runBubblewrapFirewallGolden(t *testing.T) []byte {
 
 	command := exec.Command( // #nosec G204 G702 -- bwrap is resolved by LookPath and every command argument is a controlled test fixture
 		bwrap,
-		"--ro-bind", "/", "/",
-		"--dev", "/dev",
-		"--bind", etcDir, "/etc",
-		"--tmpfs", "/tmp",
-		"--ro-bind", os.Args[0], "/tmp/syswarden-firewall.test",
-		"--ro-bind", toolDir, "/tmp/test-tools",
-		"--setenv", "PATH", "/tmp/test-tools",
-		"--setenv", linuxFirewallHelperEnvironment, "1",
-		"--", "/tmp/syswarden-firewall.test", "-test.run=^TestNftablesRulesGolden_SW_QA_001$",
+		bubblewrapFirewallGoldenArguments(etcDir, toolDir)...,
 	)
 	if output, err := command.CombinedOutput(); err != nil {
 		requireOrSkipFirewallSandbox(t, string(output))
@@ -123,6 +116,87 @@ func runBubblewrapFirewallGolden(t *testing.T) []byte {
 		t.Fatalf("read isolated nftables output: %v", err)
 	}
 	return got
+}
+
+func bubblewrapFirewallGoldenArguments(etcDir, toolDir string) []string {
+	return bubblewrapFirewallHelperArguments(
+		etcDir,
+		toolDir,
+		linuxFirewallHelperEnvironment,
+		"^TestNftablesRulesGolden_SW_QA_001$",
+	)
+}
+
+func bubblewrapFirewallHelperArguments(etcDir, toolDir, helperEnvironment, testPattern string) []string {
+	// TestMain runs again in the helper. Keep its temporary state in the private
+	// writable tmpfs instead of an inherited runner path under the read-only root.
+	return []string{
+		"--ro-bind", "/", "/",
+		"--dev", "/dev",
+		"--bind", etcDir, "/etc",
+		"--tmpfs", "/tmp",
+		"--ro-bind", os.Args[0], "/tmp/syswarden-firewall.test",
+		"--ro-bind", toolDir, "/tmp/test-tools",
+		"--setenv", "TMPDIR", "/tmp",
+		"--setenv", "GOTMPDIR", "/tmp",
+		"--setenv", "PATH", "/tmp/test-tools",
+		"--setenv", helperEnvironment, "1",
+		"--", "/tmp/syswarden-firewall.test", "-test.run=" + testPattern,
+	}
+}
+
+func TestBubblewrapFirewallGoldenTemporaryDirectoryContract_SW_QA_001(t *testing.T) {
+	if os.Getenv(bubblewrapTempDirHelperEnvironment) == "1" {
+		if got := os.Getenv("TMPDIR"); got != "/tmp" {
+			t.Fatalf("bubblewrap helper TMPDIR = %q, want /tmp", got)
+		}
+		if got := os.Getenv("GOTMPDIR"); got != "/tmp" {
+			t.Fatalf("bubblewrap helper GOTMPDIR = %q, want /tmp", got)
+		}
+		writeProbe := func(directory string) {
+			t.Helper()
+			path := filepath.Join(directory, "write-probe")
+			if err := os.WriteFile(path, []byte("ok\n"), 0600); err != nil {
+				t.Fatalf("write bubblewrap temporary-directory probe: %v", err)
+			}
+		}
+		writeProbe(t.TempDir())
+		directory, err := os.MkdirTemp("", "syswarden-bubblewrap-mkdir-")
+		if err != nil {
+			t.Fatalf("create bubblewrap temporary directory: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(directory) })
+		writeProbe(directory)
+		return
+	}
+
+	bwrap, err := exec.LookPath("bwrap")
+	if err != nil {
+		t.Fatalf("bubblewrap temporary-directory regression test requires bwrap: %v", err)
+	}
+	root := t.TempDir()
+	etcDir := filepath.Join(root, "etc")
+	toolDir := filepath.Join(root, "tools")
+	if err := os.MkdirAll(etcDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(toolDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", "/proc/sys")
+	t.Setenv("GOTMPDIR", "/sys")
+	command := exec.Command( // #nosec G204 G702 -- bwrap is resolved by LookPath and every command argument is a controlled test fixture
+		bwrap,
+		bubblewrapFirewallHelperArguments(
+			etcDir,
+			toolDir,
+			bubblewrapTempDirHelperEnvironment,
+			"^TestBubblewrapFirewallGoldenTemporaryDirectoryContract_SW_QA_001$",
+		)...,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("bubblewrap temporary-directory regression helper failed: %v\n%s", err, string(output))
+	}
 }
 
 func runActContainerFirewallGolden(t *testing.T) []byte {


### PR DESCRIPTION
Fixes the qualification harness EROFS seen in run 32467967704.

- remaps TMPDIR and GOTMPDIR to the private bwrap /tmp tmpfs
- adds an executable hostile regression test
- keeps v4.03.0 publication bound to the exact linear follow-up chain
- restricts the final squash diff to exactly three reviewed 100644 blobs
- validates the canonical GitHub squash subject with a numeric PR suffix

Evidence: firewall normal/race/vet/gosec PASS; nftables kernel lab 7/7 PASS; release gate 40/40 PASS; complete tag-chain simulation PASS.

Merge requirement: SQUASH ONLY. Keep the PR title unchanged.