### PR TITLE
Patch : make v4.03.1 packages reproducible

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -78,8 +78,17 @@ jobs:
               exit 1
             fi
           fi
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct HEAD)"
+          if [[ ! "${SOURCE_DATE_EPOCH}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "ERROR: unable to derive a reproducible source timestamp from HEAD." >&2
+            exit 1
+          fi
           echo "RELEASE_TAG=${SOURCE_TAG}" >> "${GITHUB_ENV}"
           echo "VERSION=${SOURCE_TAG#v}" >> "${GITHUB_ENV}"
+          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "${GITHUB_ENV}"
+          echo "LC_ALL=C" >> "${GITHUB_ENV}"
+          echo "LANG=C" >> "${GITHUB_ENV}"
+          echo "TZ=UTC" >> "${GITHUB_ENV}"
 
       - name: Capture Candidate Repository State
         shell: bash
@@ -864,6 +873,47 @@ jobs:
             "${PACKAGE_SCRIPTS}/postrm.sh" \
             "${PACKAGE_SCRIPTS}/prerm.sh"
 
+      - name: Normalize Package Input Timestamps
+        shell: bash
+        run: |
+          set -euo pipefail
+          prepare_rpm_changelog() {
+            local destination="$1"
+            local changelog_date
+            local changelog_day
+            changelog_day="$(date --utc --date="@${SOURCE_DATE_EPOCH}" '+%Y-%m-%d')" || return 1
+            changelog_date="$(date --utc --date="@${SOURCE_DATE_EPOCH}" '+%a %b %e %Y')" || return 1
+            RPM_CHANGELOG_EPOCH="$(date --utc --date="${changelog_day} 12:00:00" '+%s')" || return 1
+            case "${RPM_CHANGELOG_EPOCH}" in
+              ''|0|*[!0-9]*) return 1 ;;
+            esac
+            printf '* %s SysWarden Engineering - %s-1\n- Package created with FPM\n' \
+              "${changelog_date}" "${VERSION}" > "${destination}"
+            chmod 0600 "${destination}"
+          }
+          normalize_package_mtimes() {
+            local target
+            for target in "$@"; do
+              if [ ! -e "${target}" ] && [ ! -L "${target}" ]; then
+                echo "ERROR: package timestamp target is missing: ${target}" >&2
+                return 1
+              fi
+              find "${target}" -depth -exec \
+                touch -h --date="@${SOURCE_DATE_EPOCH}" -- {} +
+            done
+          }
+          RPM_CHANGELOG="${PACKAGE_CONFIGS}/rpm-changelog"
+          prepare_rpm_changelog "${RPM_CHANGELOG}"
+          normalize_package_mtimes \
+            "${STAGING_AMD64}" \
+            "${STAGING_ARM64}" \
+            "${STAGING_APK_AMD64}" \
+            "${STAGING_APK_ARM64}" \
+            "${PACKAGE_SCRIPTS}" \
+            "${RPM_CHANGELOG}"
+          echo "RPM_CHANGELOG=${RPM_CHANGELOG}" >> "${GITHUB_ENV}"
+          echo "RPM_CHANGELOG_EPOCH=${RPM_CHANGELOG_EPOCH}" >> "${GITHUB_ENV}"
+
       - name: Build Debian Package (.deb)
         run: |
           set -euo pipefail
@@ -876,6 +926,7 @@ jobs:
             --description "SysWarden Host-based Security Orchestrator for Linux" \
             --url "https://github.com/${{ github.repository }}" \
             --architecture amd64 \
+            --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
             -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cron" -d "bash-completion" \
             -d "wireguard-tools" -d "qrencode" -d "jq" -d "unattended-upgrades" -d "apt-listchanges" -d "procps" -d "e2fsprogs" \
             --before-install "${PACKAGE_SCRIPTS}/preinst.sh" \
@@ -893,6 +944,7 @@ jobs:
             --description "SysWarden Host-based Security Orchestrator for Linux (ARM64)" \
             --url "https://github.com/${{ github.repository }}" \
             --architecture arm64 \
+            --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
             -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cron" -d "bash-completion" \
             -d "wireguard-tools" -d "qrencode" -d "jq" -d "unattended-upgrades" -d "apt-listchanges" -d "procps" -d "e2fsprogs" \
             --before-install "${PACKAGE_SCRIPTS}/preinst.sh" \
@@ -913,6 +965,11 @@ jobs:
             --description "SysWarden Host-based Security Orchestrator for Linux" \
             --url "https://github.com/${{ github.repository }}" \
             --architecture x86_64 \
+            --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
+            --rpm-changelog "${RPM_CHANGELOG}" \
+            --rpm-rpmbuild-define "use_source_date_epoch_as_buildtime 1" \
+            --rpm-rpmbuild-define "clamp_mtime_to_source_date_epoch 1" \
+            --rpm-rpmbuild-define "_buildhost syswarden-build.invalid" \
             -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cronie" -d "bash-completion" \
             -d "wireguard-tools" -d "qrencode" -d "jq" -d "checkpolicy" -d "policycoreutils-python-utils" \
             -d "dnf-automatic" -d "procps-ng" -d "e2fsprogs" \
@@ -931,6 +988,11 @@ jobs:
             --description "SysWarden Host-based Security Orchestrator for Linux (ARM64)" \
             --url "https://github.com/${{ github.repository }}" \
             --architecture aarch64 \
+            --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
+            --rpm-changelog "${RPM_CHANGELOG}" \
+            --rpm-rpmbuild-define "use_source_date_epoch_as_buildtime 1" \
+            --rpm-rpmbuild-define "clamp_mtime_to_source_date_epoch 1" \
+            --rpm-rpmbuild-define "_buildhost syswarden-build.invalid" \
             -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cronie" -d "bash-completion" \
             -d "wireguard-tools" -d "qrencode" -d "jq" -d "checkpolicy" -d "policycoreutils-python-utils" \
             -d "dnf-automatic" -d "procps-ng" -d "e2fsprogs" \
@@ -1053,6 +1115,9 @@ jobs:
             local expected_cron_extraction
             [[ "$(rpm --query --package --queryformat '%{VERSION}' "${path}")" == "${VERSION}" ]]
             [[ "$(rpm --query --package --queryformat '%{ARCH}' "${path}")" == "${architecture}" ]]
+            [[ "$(rpm --query --package --queryformat '%{BUILDTIME}' "${path}")" == "${SOURCE_DATE_EPOCH}" ]]
+            [[ "$(rpm --query --package --queryformat '%{BUILDHOST}' "${path}")" == "syswarden-build.invalid" ]]
+            [[ "$(rpm --query --package --queryformat '%{CHANGELOGTIME}' "${path}")" == "${RPM_CHANGELOG_EPOCH}" ]]
             scriptlets="$(rpm --query --package --scripts "${path}")"
             expected_cron_extraction="syswarden_cron_minute=\"\$(printf '%s\\n' \"\${syswarden_cron_candidate}\" | awk 'NR == 1 { print \$1; exit }')\""
             [[ "$(grep --fixed-strings --count "${expected_cron_extraction}" <<< "${scriptlets}")" -eq 2 ]]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ terminal dashboard.
 It is not an inline HTTP proxy, a traffic sanitizer or a regulatory
 certification product.
 
-Current source version: **v4.03.0**.
+Current source version: **v4.03.1**.
 
-Target candidate: **v4.03.0**. This documentation describes the candidate
-contract. It does not claim that v4.03.0 is qualified, tagged or published.
+Target candidate: **v4.03.1**. This documentation describes the candidate
+contract. It does not claim that v4.03.1 is qualified, tagged or published.
 Publication remains blocked until every protected gate passes on one exact
 merged commit.
 
@@ -27,12 +27,12 @@ merged commit.
 
 | Target | Candidate artifact | Required release proof |
 | --- | --- | --- |
-| Debian or Ubuntu amd64 | `syswarden_4.03.0_amd64.deb` | Native install, upgrade, restart, removal and rollback lifecycle |
-| Debian or Ubuntu arm64 | `syswarden_4.03.0_arm64.deb` | Native ARM64 lifecycle on the exact candidate package |
-| RHEL-family x86_64 | `syswarden-4.03.0-1.x86_64.rpm` | Native install, upgrade, restart, removal and rollback lifecycle |
-| RHEL-family aarch64 | `syswarden-4.03.0-1.aarch64.rpm` | Native ARM64 lifecycle on the exact candidate package |
-| Alpine x86_64 | `syswarden_4.03.0_x86_64.apk` | Native OpenRC lifecycle with the dedicated CGO-free executable |
-| Alpine aarch64 | `syswarden_4.03.0_aarch64.apk` | Native ARM64 OpenRC lifecycle with the dedicated CGO-free executable |
+| Debian or Ubuntu amd64 | `syswarden_4.03.1_amd64.deb` | Native install, upgrade, restart, removal and rollback lifecycle |
+| Debian or Ubuntu arm64 | `syswarden_4.03.1_arm64.deb` | Native ARM64 lifecycle on the exact candidate package |
+| RHEL-family x86_64 | `syswarden-4.03.1-1.x86_64.rpm` | Native install, upgrade, restart, removal and rollback lifecycle |
+| RHEL-family aarch64 | `syswarden-4.03.1-1.aarch64.rpm` | Native ARM64 lifecycle on the exact candidate package |
+| Alpine x86_64 | `syswarden_4.03.1_x86_64.apk` | Native OpenRC lifecycle with the dedicated CGO-free executable |
+| Alpine aarch64 | `syswarden_4.03.1_aarch64.apk` | Native ARM64 OpenRC lifecycle with the dedicated CGO-free executable |
 
 The package workflow is configured to generate two DEB, two RPM and two APK
 packages plus `SHA256SUMS.txt`. No current package or updater route exists
@@ -41,14 +41,14 @@ emulation.
 
 ## Exact release inventory
 
-A qualified v4.03.0 Release contains exactly thirteen public assets:
+A qualified v4.03.1 Release contains exactly thirteen public assets:
 
-1. `syswarden_4.03.0_amd64.deb`
-2. `syswarden_4.03.0_arm64.deb`
-3. `syswarden-4.03.0-1.x86_64.rpm`
-4. `syswarden-4.03.0-1.aarch64.rpm`
-5. `syswarden_4.03.0_x86_64.apk`
-6. `syswarden_4.03.0_aarch64.apk`
+1. `syswarden_4.03.1_amd64.deb`
+2. `syswarden_4.03.1_arm64.deb`
+3. `syswarden-4.03.1-1.x86_64.rpm`
+4. `syswarden-4.03.1-1.aarch64.rpm`
+5. `syswarden_4.03.1_x86_64.apk`
+6. `syswarden_4.03.1_aarch64.apk`
 7. `SHA256SUMS.txt`
 8. `RELEASE_SHA256SUMS.txt`
 9. `syswarden-release.tar.gz`
@@ -99,7 +99,7 @@ Use only assets attached to the intended GitHub Release. Replace the example
 version only after that tag is public and its complete inventory is visible.
 
 ```console
-VERSION=4.03.0
+VERSION=4.03.1
 TAG="v${VERSION}"
 ```
 
@@ -114,9 +114,9 @@ Stop if the selected package is not reported as valid. Then use the matching
 native command:
 
 ```console
-sudo apt-get install -y ./syswarden_4.03.0_amd64.deb
-sudo dnf install -y ./syswarden-4.03.0-1.x86_64.rpm
-sudo apk add --allow-untrusted ./syswarden_4.03.0_x86_64.apk
+sudo apt-get install -y ./syswarden_4.03.1_amd64.deb
+sudo dnf install -y ./syswarden-4.03.1-1.x86_64.rpm
+sudo apk add --allow-untrusted ./syswarden_4.03.1_x86_64.apk
 ```
 
 Run only the command for the actual distribution and architecture. For APK,
@@ -428,7 +428,7 @@ enabled.
 
 ## Release evidence and report
 
-The [v4.03.0 public release readiness report](docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.0.md)
+The [v4.03.1 public release readiness report](docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md)
 records the exact package and asset inventory, migration contract, security
 limits and remaining release gates.
 

--- a/assets/syswarden_architecture.svg
+++ b/assets/syswarden_architecture.svg
@@ -32,7 +32,7 @@
   </defs>
 
   <rect width="1600" height="940" rx="28" fill="url(#bg)"/>
-  <text x="70" y="68" class="h1">SysWarden v4.03.0 candidate architecture</text>
+  <text x="70" y="68" class="h1">SysWarden v4.03.1 candidate architecture</text>
   <text x="70" y="100" class="body">Linux-only host enforcement, local terminal operations and condition-bound HA migration</text>
 
   <g transform="translate(70 154)" filter="url(#shadow)">

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -53,7 +53,7 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-for required_command in python3 git go fpm nfpm readelf file ar rpm tar; do
+for required_command in python3 git go fpm nfpm readelf file ar rpm tar touch date; do
     command -v "${required_command}" >/dev/null 2>&1 || {
         echo "[-] Required pinned build tool is unavailable: ${required_command}" >&2
         exit 1
@@ -152,14 +152,17 @@ chmod 0700 \
     "${PACKAGE_WORKSPACE}/dist" \
     "${PACKAGE_WORKSPACE}/dist/bin" \
     "${PACKAGE_WORKSPACE}/dist/bin-apk"
-SOURCE_DATE_EPOCH="$(git -C "${REPOSITORY_ROOT}" log -1 --format=%ct)"
-export SOURCE_DATE_EPOCH
+SOURCE_DATE_EPOCH="$(git -C "${REPOSITORY_ROOT}" log -1 --format=%ct HEAD)"
 case "${SOURCE_DATE_EPOCH}" in
-    ''|*[!0-9]*)
+    ''|0|*[!0-9]*)
         echo "[-] Unable to derive a reproducible source timestamp." >&2
         exit 1
         ;;
 esac
+export SOURCE_DATE_EPOCH
+export LC_ALL=C
+export LANG=C
+export TZ=UTC
 
 # Extract the version through the repository-wide version contract.
 SOURCE_TAG="$(PATH="${GO_TOOLCHAIN_ROOT}/bin:${PATH}" \
@@ -835,6 +838,43 @@ EOF
 
 chmod +x preinst.sh postinst.sh postrm.sh prerm.sh
 
+prepare_rpm_changelog() {
+    local destination="$1"
+    local changelog_date
+    local changelog_day
+    changelog_day="$(date --utc --date="@${SOURCE_DATE_EPOCH}" '+%Y-%m-%d')" || return 1
+    changelog_date="$(date --utc --date="@${SOURCE_DATE_EPOCH}" '+%a %b %e %Y')" || return 1
+    RPM_CHANGELOG_EPOCH="$(date --utc --date="${changelog_day} 12:00:00" '+%s')" || return 1
+    case "${RPM_CHANGELOG_EPOCH}" in
+        ''|0|*[!0-9]*) return 1 ;;
+    esac
+    printf '* %s SysWarden Engineering - %s-1\n- Package created with FPM\n' \
+        "${changelog_date}" "${VERSION}" > "${destination}"
+    chmod 0600 "${destination}"
+}
+normalize_package_mtimes() {
+    local target
+    for target in "$@"; do
+        if [ ! -e "${target}" ] && [ ! -L "${target}" ]; then
+            echo "ERROR: package timestamp target is missing: ${target}" >&2
+            return 1
+        fi
+        find "${target}" -depth -exec \
+            touch -h --date="@${SOURCE_DATE_EPOCH}" -- {} +
+    done
+}
+RPM_CHANGELOG="${PACKAGE_WORKSPACE}/rpm-changelog"
+prepare_rpm_changelog "${RPM_CHANGELOG}"
+normalize_package_mtimes \
+    staging \
+    staging-rpm \
+    staging-apk \
+    preinst.sh \
+    postinst.sh \
+    prerm.sh \
+    postrm.sh \
+    "${RPM_CHANGELOG}"
+
 # 4. Generate Packages
 echo "[*] Generating .deb and .rpm packages via FPM..."
 
@@ -850,6 +890,7 @@ echo "[*] Generating .deb and .rpm packages via FPM..."
         --vendor "SysWarden Security" \
         --maintainer "SysWarden Engineering" \
         --description "SysWarden Host-based Security Orchestrator for Linux" \
+        --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
         -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cron" -d "bash-completion" \
         -d "wireguard-tools" -d "qrencode" -d "jq" -d "unattended-upgrades" -d "apt-listchanges" -d "procps" -d "e2fsprogs" \
         --before-install preinst.sh \
@@ -872,6 +913,8 @@ echo "[*] Generating .deb and .rpm packages via FPM..."
         --vendor "SysWarden Security" \
         --maintainer "SysWarden Engineering" \
         --description "SysWarden Host-based Security Orchestrator for Linux" \
+        --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
+        --rpm-changelog "${RPM_CHANGELOG}" \
         -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cronie" -d "bash-completion" \
         -d "wireguard-tools" -d "qrencode" -d "jq" -d "checkpolicy" -d "policycoreutils-python-utils" \
         -d "dnf-automatic" -d "procps-ng" -d "e2fsprogs" \
@@ -880,6 +923,9 @@ echo "[*] Generating .deb and .rpm packages via FPM..."
         --before-remove prerm.sh \
         --after-remove postrm.sh \
         --rpm-rpmbuild-define "_build_id_links none" \
+        --rpm-rpmbuild-define "use_source_date_epoch_as_buildtime 1" \
+        --rpm-rpmbuild-define "clamp_mtime_to_source_date_epoch 1" \
+        --rpm-rpmbuild-define "_buildhost syswarden-build.invalid" \
         --directories /usr/lib/.build-id \
         -p "${PACKAGE_WORKSPACE}/syswarden-${VERSION}-1.x86_64.rpm" \
         -C staging-rpm .
@@ -958,6 +1004,9 @@ validate_local_rpm_build_ids() {
     declare -A rpm_build_id_targets=()
     local rpm_build_id_root_count=0
     local rpm_inventory rpm_pathname rpm_permissions rpm_owner rpm_target rpm_prefix
+    [ "$(rpm -qp --qf '%{BUILDTIME}' "${rpm_path}")" = "${SOURCE_DATE_EPOCH}" ] || return 1
+    [ "$(rpm -qp --qf '%{BUILDHOST}' "${rpm_path}")" = syswarden-build.invalid ] || return 1
+    [ "$(rpm -qp --qf '%{CHANGELOGTIME}' "${rpm_path}")" = "${RPM_CHANGELOG_EPOCH}" ] || return 1
     rpm_inventory="$(
         rpm -qp --qf \
             '[%{FILENAMES}\t%{FILEMODES:perms}\t%{FILEUSERNAME}:%{FILEGROUPNAME}\t%{FILELINKTOS}\n]' \

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,43 @@
+# Release v4.03.1
+
+> Release status: v4.03.1 supersedes the unpublished v4.03.0 candidate. The
+> signed v4.03.0 tag remains immutable and was not moved or published.
+
+### RELEASE RECOVERY
+
+- **Unpublished v4.03.0:** The v4.03.0 publisher stopped before asset staging
+  or publication. Its byte-exact gate correctly rejected DEB, RPM and APK
+  archives rebuilt from the same commit because their build timestamps, build
+  host data and archive metadata were not reproducible.
+- **Reproducible packages:** Generate the six Linux packages from a deterministic
+  release epoch with normalized package metadata so independent qualification
+  and signed-tag builds produce the same bytes.
+- **Fail-closed publication:** Keep the exact pre-tag-to-tag byte comparison.
+  v4.03.1 fixes package production rather than weakening the release gate or
+  accepting payload-only equivalence.
+
+### INCLUDED PRODUCT SCOPE
+
+- **Complete candidate content:** Carry forward the complete intended v4.03.0
+  product and security scope into v4.03.1. This includes the Linux-only DEB,
+  RPM and APK matrix, removal of the network-facing browser terminal, the local
+  terminal dashboard, HA migration fencing, challenge-bound attestations and
+  strict partner cleanup conditions.
+- **Configuration and lists:** Retain read-only modular configuration
+  validation, transactional migration, authoritative SaaS monitor settings,
+  canonical persistent lists and typed WAAP log inputs.
+- **Security hardening:** Retain owner-only fence state, race-safe conditional
+  cleanup, fail-closed list application, bounded feed publication and
+  destination-specific configuration encoding.
+
+### RELEASE GATE
+
+- v4.03.1 still requires a fresh protected qualification and signed-tag gate on
+  one immutable commit. Publication remains limited to the exact six packages
+  and thirteen public assets only after every existing release check passes.
+
+---
+
 # Release v4.03.0
 
 > Candidate status: this block describes the intended v4.03.0 release. It does not authorize a tag or publication. The exact merged commit must pass every protected qualification and release-governance gate first.

--- a/docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md
+++ b/docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md
@@ -1,23 +1,23 @@
-# SysWarden v4.03.0 Public Release Readiness Report
+# SysWarden v4.03.1 Public Release Readiness Report
 
 ## Document status
 
 | Field | Value |
 |---|---|
-| Candidate | v4.03.0 |
+| Candidate | v4.03.1 |
 | Distribution boundary | Linux packages only |
 | Public package count | 6 |
 | Public release asset count | 13 |
 | Decision | NO-GO until protected qualification passes on the exact merged SHA |
 | Scope | Source, package, firewall, HA migration, documentation and release governance |
 
-This report describes the intended v4.03.0 candidate contract. It is not a
+This report describes the intended v4.03.1 candidate contract. It is not a
 release authorization, does not assert that final qualification has passed and
 does not authorize a tag or public Release.
 
 ## Executive summary
 
-v4.03.0 narrows the supported distribution surface to six Linux packages,
+v4.03.1 narrows the supported distribution surface to six Linux packages,
 removes the network-facing browser terminal while retaining the native local
 TUI, and introduces a verifiable HA migration fence for the BunkerWeb partner
 handoff from historical static ownership to provenance-aware ownership.
@@ -31,26 +31,26 @@ the immutable thirteen-asset publisher.
 
 | Package family | Architecture | Expected asset |
 |---|---|---|
-| DEB | amd64 | `syswarden_4.03.0_amd64.deb` |
-| DEB | arm64 | `syswarden_4.03.0_arm64.deb` |
-| RPM | x86_64 | `syswarden-4.03.0-1.x86_64.rpm` |
-| RPM | aarch64 | `syswarden-4.03.0-1.aarch64.rpm` |
-| APK | x86_64 | `syswarden_4.03.0_x86_64.apk` |
-| APK | aarch64 | `syswarden_4.03.0_aarch64.apk` |
+| DEB | amd64 | `syswarden_4.03.1_amd64.deb` |
+| DEB | arm64 | `syswarden_4.03.1_arm64.deb` |
+| RPM | x86_64 | `syswarden-4.03.1-1.x86_64.rpm` |
+| RPM | aarch64 | `syswarden-4.03.1-1.aarch64.rpm` |
+| APK | x86_64 | `syswarden_4.03.1_x86_64.apk` |
+| APK | aarch64 | `syswarden_4.03.1_aarch64.apk` |
 
 No current package or updater route exists outside this matrix. ARM64 package
 qualification runs on a native ARM64 runner rather than through emulation.
 
 ## Exact public release inventory
 
-A qualified v4.03.0 Release must contain exactly these thirteen assets:
+A qualified v4.03.1 Release must contain exactly these thirteen assets:
 
-1. `syswarden_4.03.0_amd64.deb`
-2. `syswarden_4.03.0_arm64.deb`
-3. `syswarden-4.03.0-1.x86_64.rpm`
-4. `syswarden-4.03.0-1.aarch64.rpm`
-5. `syswarden_4.03.0_x86_64.apk`
-6. `syswarden_4.03.0_aarch64.apk`
+1. `syswarden_4.03.1_amd64.deb`
+2. `syswarden_4.03.1_arm64.deb`
+3. `syswarden-4.03.1-1.x86_64.rpm`
+4. `syswarden-4.03.1-1.aarch64.rpm`
+5. `syswarden_4.03.1_x86_64.apk`
+6. `syswarden_4.03.1_aarch64.apk`
 7. `SHA256SUMS.txt`
 8. `RELEASE_SHA256SUMS.txt`
 9. `syswarden-release.tar.gz`
@@ -224,7 +224,7 @@ Written partner freeze confirmation was received on 20 August 2026. This
 closes the written partner-confirmation gate only; the technical residue-free
 migration evidence remains pending.
 
-The v4.03.0 candidate remains NO-GO until all required gates pass on the exact
+The v4.03.1 candidate remains NO-GO until all required gates pass on the exact
 merged commit, no unexplained partner-attributable static residue remains, and
 the publisher verifies exactly thirteen public assets. Only then may the
 maintainer authorize the immutable tag and public Release.

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -48,9 +48,9 @@
   ],
   "required_readme_phrases": [
     "Current source version: **{version}**.",
-    "Target candidate: **v4.03.0**.",
+    "Target candidate: **v4.03.1**.",
     "The package workflow is configured to generate two DEB, two RPM and two APK packages plus `SHA256SUMS.txt`.",
-    "A qualified v4.03.0 Release contains exactly thirteen public assets:",
+    "A qualified v4.03.1 Release contains exactly thirteen public assets:",
     "The TUI reads local telemetry and HA status. It runs inside the invoking terminal and opens no listening socket.",
     "SysWarden owns no listener and no generated firewall permission on TCP 62027.",
     "`DELETE {{\"bans\": [...]}}` removes provenance ledger entries only",
@@ -110,7 +110,7 @@
       "stream": "stdout",
       "reason": "Advance the minor version while preserving the bounded built-in operator reference.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.03.0 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.03.1 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     },
     {
       "case": "help:syswarden",
@@ -628,32 +628,32 @@
         "rows": [
           [
             "Debian or Ubuntu amd64",
-            "`syswarden_4.03.0_amd64.deb`",
+            "`syswarden_4.03.1_amd64.deb`",
             "Native install, upgrade, restart, removal and rollback lifecycle"
           ],
           [
             "Debian or Ubuntu arm64",
-            "`syswarden_4.03.0_arm64.deb`",
+            "`syswarden_4.03.1_arm64.deb`",
             "Native ARM64 lifecycle on the exact candidate package"
           ],
           [
             "RHEL-family x86_64",
-            "`syswarden-4.03.0-1.x86_64.rpm`",
+            "`syswarden-4.03.1-1.x86_64.rpm`",
             "Native install, upgrade, restart, removal and rollback lifecycle"
           ],
           [
             "RHEL-family aarch64",
-            "`syswarden-4.03.0-1.aarch64.rpm`",
+            "`syswarden-4.03.1-1.aarch64.rpm`",
             "Native ARM64 lifecycle on the exact candidate package"
           ],
           [
             "Alpine x86_64",
-            "`syswarden_4.03.0_x86_64.apk`",
+            "`syswarden_4.03.1_x86_64.apk`",
             "Native OpenRC lifecycle with the dedicated CGO-free executable"
           ],
           [
             "Alpine aarch64",
-            "`syswarden_4.03.0_aarch64.apk`",
+            "`syswarden_4.03.1_aarch64.apk`",
             "Native ARM64 OpenRC lifecycle with the dedicated CGO-free executable"
           ]
         ]
@@ -661,9 +661,9 @@
     }
   },
   "public_report_contract": {
-    "path": "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.0.md",
+    "path": "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md",
     "required_phrases": [
-      "| Candidate | v4.03.0 |",
+      "| Candidate | v4.03.1 |",
       "| Distribution boundary | Linux packages only |",
       "| Public package count | 6 |",
       "| Public release asset count | 13 |",
@@ -689,15 +689,15 @@
       "Rsyslog strings and WireGuard values are validated and encoded for their destination grammars",
       "SSH/HA port separation while WireGuard is enabled.",
       "Written partner freeze confirmation was received on 20 August 2026",
-      "The v4.03.0 candidate remains NO-GO"
+      "The v4.03.1 candidate remains NO-GO"
     ],
     "expected_assets": [
-      "syswarden_4.03.0_amd64.deb",
-      "syswarden_4.03.0_arm64.deb",
-      "syswarden-4.03.0-1.x86_64.rpm",
-      "syswarden-4.03.0-1.aarch64.rpm",
-      "syswarden_4.03.0_x86_64.apk",
-      "syswarden_4.03.0_aarch64.apk",
+      "syswarden_4.03.1_amd64.deb",
+      "syswarden_4.03.1_arm64.deb",
+      "syswarden-4.03.1-1.x86_64.rpm",
+      "syswarden-4.03.1-1.aarch64.rpm",
+      "syswarden_4.03.1_x86_64.apk",
+      "syswarden_4.03.1_aarch64.apk",
       "SHA256SUMS.txt",
       "RELEASE_SHA256SUMS.txt",
       "syswarden-release.tar.gz",
@@ -716,7 +716,7 @@
     "documents": [
       "README.md",
       "changelog.md",
-      "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.0.md",
+      "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md",
       "assets/syswarden_hero.svg",
       "assets/syswarden_architecture.svg"
     ],

--- a/scripts/ci/documentation_gate.py
+++ b/scripts/ci/documentation_gate.py
@@ -846,7 +846,7 @@ def validate_active_public_surfaces(
             errors.extend(require_phrases(report, required, version, report_relative))
 
         expected_assets = report_contract.get("expected_assets")
-        release_assets = release_gate.expected_release_assets("v4.03.0")
+        release_assets = release_gate.expected_release_assets(version)
         if not isinstance(expected_assets, list) or not all(
             isinstance(asset, str) and asset for asset in expected_assets
         ):
@@ -922,9 +922,10 @@ def validate_active_public_surfaces(
 
     package_count = surface.get("package_count")
     asset_count = surface.get("public_asset_count")
-    if package_count != 6 or len(release_gate.package_names("4.03.0")) != 6:
+    release_version = version.removeprefix("v")
+    if package_count != 6 or len(release_gate.package_names(release_version)) != 6:
         errors.append("active surface package count must equal the six-package release gate")
-    if asset_count != 13 or len(release_gate.expected_release_assets("v4.03.0")) != 13:
+    if asset_count != 13 or len(release_gate.expected_release_assets(version)) != 13:
         errors.append("active surface asset count must equal the thirteen-asset release gate")
     return errors
 

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -16,7 +16,7 @@ import release_gate
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-REPORT = REPO_ROOT / "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.0.md"
+REPORT = REPO_ROOT / "docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.1.md"
 ARCHIVE_DIGEST = "a6ebcab7a81769c52147be710622995779cedf9523270cf08cf03e275501cde5"
 
 
@@ -27,12 +27,12 @@ class DocumentationGateTest(unittest.TestCase):
         self.assertEqual([record.path for record in records], ["README.md"])
 
     def test_current_version_and_candidate_status_are_explicit(self) -> None:
-        self.assertEqual(documentation_gate.source_version(REPO_ROOT), "v4.03.0")
+        self.assertEqual(documentation_gate.source_version(REPO_ROOT), "v4.03.1")
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         changelog = (REPO_ROOT / "changelog.md").read_text(encoding="utf-8")
         report = REPORT.read_text(encoding="utf-8")
-        self.assertIn("Current source version: **v4.03.0**.", readme)
-        self.assertIn("does not claim that v4.03.0 is qualified", readme)
+        self.assertIn("Current source version: **v4.03.1**.", readme)
+        self.assertIn("does not claim that v4.03.1 is qualified", readme)
         self.assertIn(
             "does not authorize a tag or publication",
             documentation_gate.normalized(changelog),
@@ -43,7 +43,8 @@ class DocumentationGateTest(unittest.TestCase):
         changelog = (REPO_ROOT / "changelog.md").read_text(encoding="utf-8")
         pointer = f"Archived pre-v4.03.0 changelog SHA-256: {ARCHIVE_DIGEST}"
         self.assertTrue(changelog.endswith("\n---\n" + pointer + "\n"))
-        self.assertEqual(changelog.count("\n---\n"), 1)
+        self.assertEqual(changelog.count(pointer), 1)
+        self.assertEqual(changelog.count("\n---\n" + pointer + "\n"), 1)
 
     def test_current_public_report_inventory_is_exact(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
@@ -63,15 +64,15 @@ class DocumentationGateTest(unittest.TestCase):
                 documentation_gate.cobra_commands(REPO_ROOT),
                 documentation_gate.config_schema(REPO_ROOT),
                 contract["forbidden_phrases"],
-                "v4.03.0",
+                "v4.03.1",
             ),
             [],
         )
 
     def test_public_release_contract_is_six_packages_and_thirteen_assets(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
-        expected_packages = release_gate.package_names("4.03.0")
-        expected_assets = release_gate.expected_release_assets("v4.03.0")
+        expected_packages = release_gate.package_names("4.03.1")
+        expected_assets = release_gate.expected_release_assets("v4.03.1")
         self.assertEqual(len(expected_packages), 6)
         self.assertEqual(len(expected_assets), 13)
         self.assertEqual(
@@ -105,7 +106,7 @@ class DocumentationGateTest(unittest.TestCase):
             documentation_gate.cobra_commands(REPO_ROOT),
             documentation_gate.config_schema(REPO_ROOT),
             changed["forbidden_phrases"],
-            "v4.03.0",
+            "v4.03.1",
         )
         self.assertTrue(any("exact release gate" in error for error in errors))
 
@@ -170,7 +171,7 @@ class DocumentationGateTest(unittest.TestCase):
                 documentation_gate.cobra_commands(REPO_ROOT),
                 documentation_gate.config_schema(REPO_ROOT),
                 contract["forbidden_phrases"],
-                "v4.03.0",
+                "v4.03.1",
             )
         self.assertTrue(any("retired platform" in error for error in errors))
 
@@ -355,6 +356,8 @@ class DocumentationGateTest(unittest.TestCase):
                     if attribute.rsplit("}", 1)[-1].casefold() in {"href", "src"}:
                         self.assertNotIn(":", value)
             self.assertIn("Linux", text)
+            if name == "syswarden_architecture.svg":
+                self.assertIn("SysWarden v4.03.1 candidate architecture", text)
 
     def test_source_assertions_remain_bound_to_runtime(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
@@ -377,7 +380,7 @@ class DocumentationGateTest(unittest.TestCase):
                 documentation_gate.cobra_commands(REPO_ROOT),
                 documentation_gate.config_schema(REPO_ROOT),
                 [],
-                "v4.03.0",
+                "v4.03.1",
                 None,
             )
         self.assertTrue(any("unclosed Markdown fence" in error for error in errors))

--- a/scripts/ci/fixtures/package-forward-only-v4.02.8.json
+++ b/scripts/ci/fixtures/package-forward-only-v4.02.8.json
@@ -1,5 +1,5 @@
 {
-  "candidate_version": "4.03.0",
+  "candidate_version": "4.03.1",
   "previous_version": "4.02.8",
   "artifacts": {
     "aarch64": {

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -325,6 +325,241 @@ class PackageLifecycleContractTests(unittest.TestCase):
         self.assertIn("trap cleanup_package_workspace EXIT", source)
         self.assertIn("PACKAGE_STATE_VERIFIED=1", source)
 
+    def test_workflow_and_local_packages_have_exact_reproducibility_contract(self) -> None:
+        local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
+        version_step = workflow_step_script(
+            self.workflow, "Validate and Export Version Contract"
+        )
+        normalization_step = workflow_step_script(
+            self.workflow, "Normalize Package Input Timestamps"
+        )
+        workflow_deb = workflow_step_script(
+            self.workflow, "Build Debian Package (.deb)"
+        )
+        workflow_rpm = workflow_step_script(
+            self.workflow, "Build RHEL Family Package (.rpm)"
+        )
+        workflow_validation = workflow_step_script(
+            self.workflow, "Validate Package Metadata"
+        )
+        local_deb = local.split("# Generate DEB", 1)[1].split(
+            "# Generate RPM", 1
+        )[0]
+        local_rpm = local.split("# Generate RPM", 1)[1].split(
+            "# Generate Alpine APK", 1
+        )[0]
+
+        self.assertIn(
+            'SOURCE_DATE_EPOCH="$(git log -1 --format=%ct HEAD)"', version_step
+        )
+        self.assertIn(
+            'SOURCE_DATE_EPOCH="$(git -C "${REPOSITORY_ROOT}" log -1 '
+            '--format=%ct HEAD)"',
+            local,
+        )
+        self.assertIn(
+            'if [[ ! "${SOURCE_DATE_EPOCH}" =~ ^[1-9][0-9]*$ ]]; then',
+            version_step,
+        )
+        self.assertIn('echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"', version_step)
+        for assignment in ("LC_ALL=C", "LANG=C", "TZ=UTC"):
+            with self.subTest(environment=assignment):
+                self.assertIn(f'echo "{assignment}" >> "${{GITHUB_ENV}}"', version_step)
+                self.assertIn(f"export {assignment}", local)
+
+        workflow_changelog_start = normalization_step.index(
+            "prepare_rpm_changelog() {"
+        )
+        workflow_changelog_end = normalization_step.index(
+            "\n}\n", workflow_changelog_start
+        ) + len("\n}\n")
+        workflow_changelog = normalization_step[
+            workflow_changelog_start:workflow_changelog_end
+        ]
+        local_changelog_start = local.index("prepare_rpm_changelog() {")
+        local_changelog_end = local.index("\n}\n", local_changelog_start) + len(
+            "\n}\n"
+        )
+        local_changelog = local[local_changelog_start:local_changelog_end]
+        for changelog in (workflow_changelog, local_changelog):
+            self.assertIn('date --utc --date="@${SOURCE_DATE_EPOCH}"', changelog)
+            self.assertIn('date --utc --date="${changelog_day} 12:00:00"', changelog)
+            self.assertIn("SysWarden Engineering - %s-1", changelog)
+            self.assertIn('chmod 0600 "${destination}"', changelog)
+
+        workflow_normalizer_start = normalization_step.index(
+            "normalize_package_mtimes() {"
+        )
+        workflow_normalizer_end = normalization_step.index(
+            "\n}\n", workflow_normalizer_start
+        ) + len("\n}\n")
+        workflow_normalizer = normalization_step[
+            workflow_normalizer_start:workflow_normalizer_end
+        ]
+        local_normalizer_start = local.index("normalize_package_mtimes() {")
+        local_normalizer_end = local.index("\n}\n", local_normalizer_start) + len(
+            "\n}\n"
+        )
+        local_normalizer = local[local_normalizer_start:local_normalizer_end]
+        for normalizer in (workflow_normalizer, local_normalizer):
+            self.assertIn('find "${target}" -depth -exec', normalizer)
+            self.assertIn(
+                'touch -h --date="@${SOURCE_DATE_EPOCH}" -- {} +', normalizer
+            )
+            self.assertIn('[ ! -e "${target}" ] && [ ! -L "${target}" ]', normalizer)
+
+        for target in (
+            "STAGING_AMD64",
+            "STAGING_ARM64",
+            "STAGING_APK_AMD64",
+            "STAGING_APK_ARM64",
+            "PACKAGE_SCRIPTS",
+        ):
+            self.assertEqual(normalization_step.count(f'"${{{target}}}"'), 1, target)
+        self.assertIn('prepare_rpm_changelog "${RPM_CHANGELOG}"', normalization_step)
+        self.assertIn('"${RPM_CHANGELOG}"\n', normalization_step)
+        self.assertIn('echo "RPM_CHANGELOG=${RPM_CHANGELOG}"', normalization_step)
+        self.assertIn(
+            'echo "RPM_CHANGELOG_EPOCH=${RPM_CHANGELOG_EPOCH}"',
+            normalization_step,
+        )
+        local_targets = (
+            "staging",
+            "staging-rpm",
+            "staging-apk",
+            "preinst.sh",
+            "postinst.sh",
+            "prerm.sh",
+            "postrm.sh",
+            '"${RPM_CHANGELOG}"',
+        )
+        local_normalization_call = local[
+            local_normalizer_end : local.index("# 4. Generate Packages")
+        ]
+        for index, target in enumerate(local_targets):
+            suffix = " \\" if index < len(local_targets) - 1 else ""
+            self.assertIn(f"    {target}{suffix}\n", local_normalization_call)
+        self.assertLess(
+            self.workflow.index("Normalize Package Input Timestamps"),
+            self.workflow.index("Build Debian Package (.deb)"),
+        )
+        self.assertLess(local_normalizer_end, local.index("# Generate DEB"))
+
+        for block, count in (
+            (workflow_deb, 2),
+            (workflow_rpm, 2),
+            (local_deb, 1),
+            (local_rpm, 1),
+        ):
+            self.assertEqual(
+                block.count('--source-date-epoch-default "${SOURCE_DATE_EPOCH}"'),
+                count,
+            )
+        rpm_defines = (
+            "use_source_date_epoch_as_buildtime 1",
+            "clamp_mtime_to_source_date_epoch 1",
+            "_buildhost syswarden-build.invalid",
+        )
+        for definition in rpm_defines:
+            with self.subTest(rpm_definition=definition):
+                flag = f'--rpm-rpmbuild-define "{definition}"'
+                self.assertEqual(workflow_rpm.count(flag), 2)
+                self.assertEqual(local_rpm.count(flag), 1)
+        self.assertEqual(workflow_rpm.count('--rpm-changelog "${RPM_CHANGELOG}"'), 2)
+        self.assertEqual(local_rpm.count('--rpm-changelog "${RPM_CHANGELOG}"'), 1)
+        for query, expected in (
+            ("%{BUILDTIME}", "${SOURCE_DATE_EPOCH}"),
+            ("%{BUILDHOST}", "syswarden-build.invalid"),
+            ("%{CHANGELOGTIME}", "${RPM_CHANGELOG_EPOCH}"),
+        ):
+            self.assertIn(query, workflow_validation)
+            self.assertIn(expected, workflow_validation)
+            self.assertIn(query, local)
+            self.assertIn(expected, local)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root_path = Path(temporary)
+            changelog_epochs: list[int] = []
+            for index, (epoch, expected_date) in enumerate(
+                (
+                    (946684800, "Sat Jan  1 2000"),
+                    (946771200, "Sun Jan  2 2000"),
+                )
+            ):
+                destination = root_path / f"rpm-changelog-{index}"
+                generated = subprocess.run(
+                    [
+                        "/bin/bash",
+                        "-c",
+                        local_changelog
+                        + '\nprepare_rpm_changelog "$1"\n'
+                        + 'printf "%s" "${RPM_CHANGELOG_EPOCH}"',
+                        "rpm-changelog-cross-day-contract",
+                        str(destination),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "LC_ALL": "C",
+                        "SOURCE_DATE_EPOCH": str(epoch),
+                        "TZ": "UTC",
+                        "VERSION": "4.03.1",
+                    },
+                )
+                self.assertEqual(generated.returncode, 0, generated)
+                changelog_epochs.append(int(generated.stdout))
+                self.assertEqual(
+                    destination.read_text(encoding="utf-8"),
+                    f"* {expected_date} SysWarden Engineering - 4.03.1-1\n"
+                    "- Package created with FPM\n",
+                )
+                self.assertEqual(destination.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(changelog_epochs[1] - changelog_epochs[0], 86400)
+
+            epoch = 946684800
+            root = Path(temporary) / "random workspace\nwith spaces"
+            nested = root / "nested"
+            nested.mkdir(parents=True)
+            payload = nested / "payload\nname"
+            payload.write_bytes(b"deterministic")
+            dangling = root / "dangling link"
+            dangling.symlink_to("missing-target")
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    local_normalizer + '\nnormalize_package_mtimes "$1"',
+                    "package-mtime-contract",
+                    str(root),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "SOURCE_DATE_EPOCH": str(epoch)},
+            )
+            self.assertEqual(result.returncode, 0, result)
+            for path in (root, nested, payload, dangling):
+                with self.subTest(normalized_path=path):
+                    self.assertEqual(path.lstat().st_mtime_ns, epoch * 1_000_000_000)
+
+            missing = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    local_normalizer + '\nnormalize_package_mtimes "$1"',
+                    "package-mtime-missing-contract",
+                    str(root / "missing"),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "SOURCE_DATE_EPOCH": str(epoch)},
+            )
+            self.assertNotEqual(missing.returncode, 0, missing)
+            self.assertIn("package timestamp target is missing", missing.stderr)
+
     def test_local_builder_closes_deb_mode_and_rpm_build_id_parity(self) -> None:
         source = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
         deb_block = source.split("# Generate DEB", 1)[1].split(
@@ -2286,6 +2521,9 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "case \"$4\" in\n"
                 "  '%{VERSION}') printf 4.02.14 ;;\n"
                 "  '%{ARCH}') printf x86_64 ;;\n"
+                "  '%{BUILDTIME}') printf '%s' \"${SOURCE_DATE_EPOCH}\" ;;\n"
+                "  '%{BUILDHOST}') printf syswarden-build.invalid ;;\n"
+                "  '%{CHANGELOGTIME}') printf '%s' \"${RPM_CHANGELOG_EPOCH}\" ;;\n"
                 "  *) exit 91 ;;\n"
                 "esac\n",
                 encoding="utf-8",
@@ -2295,6 +2533,8 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 **os.environ,
                 "PATH": f"{fake_bin}:{os.environ['PATH']}",
                 "RPM_SCRIPTLETS_FILE": str(scriptlets),
+                "SOURCE_DATE_EPOCH": "946684800",
+                "RPM_CHANGELOG_EPOCH": "946728000",
             }
 
             def validate(payload: str) -> subprocess.CompletedProcess[bytes]:

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -389,7 +389,7 @@ PACKAGE_PAYLOAD_PATHS = (
     "/usr/local/bin/syswarden",
     "/usr/local/bin/syswarden-tui",
 )
-FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.03.0"
+FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.03.1"
 FORWARD_ONLY_APK_PREVIOUS_VERSION = "4.02.8"
 FORWARD_ONLY_APK_PREVIOUS = {
     "x86_64": {
@@ -605,7 +605,7 @@ def validate_forward_only_apk_pair(spec: PlatformSpec, pair: PackagePair) -> boo
     if historical_binding_touched and not forward_only:
         raise LifecycleLabError(
             "historical APK transition must be the exact byte-bound "
-            "v4.02.8 -> v4.03.0 contract for "
+            "v4.02.8 -> v4.03.1 contract for "
             f"{spec.package_architecture}"
         )
     return forward_only

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -454,8 +454,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             pair = package_lifecycle_lab.PackagePair(
                 candidate=package_lifecycle_lab.PackageArtifact(
                     self.candidate
-                    / f"syswarden_4.03.0_{spec.package_architecture}.apk",
-                    "4.03.0",
+                    / f"syswarden_4.03.1_{spec.package_architecture}.apk",
+                    "4.03.1",
                     "a" * 64,
                 ),
                 previous=package_lifecycle_lab.PackageArtifact(
@@ -1116,7 +1116,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         previous_path = self.root / "syswarden_4.02.8_x86_64.apk"
         previous_path.write_bytes(b"exact historical APK fixture")
         previous = str(previous_path)
-        candidate_path = self.root / "syswarden_4.03.0_x86_64.apk"
+        candidate_path = self.root / "syswarden_4.03.1_x86_64.apk"
         candidate_path.write_bytes(b"candidate APK fixture")
         candidate = str(candidate_path)
         previous_sha256 = hashlib.sha256(previous_path.read_bytes()).hexdigest()
@@ -1210,11 +1210,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
             f'CALLS="{calls}"\n'
             f'RESTART_STATE_FILE="{restart}"\n'
             'PREVIOUS_PACKAGE="/previous/exact-v4.02.8.apk"\n'
-            'CANDIDATE_PACKAGE="/candidate/v4.03.0.apk"\n'
+            'CANDIDATE_PACKAGE="/candidate/v4.03.1.apk"\n'
             'PREVIOUS_VERSION="4.02.8"\n'
-            'CANDIDATE_VERSION="4.03.0"\n'
+            'CANDIDATE_VERSION="4.03.1"\n'
             'EXPECTED_PREVIOUS_VERSION="4.02.8"\n'
-            'EXPECTED_CANDIDATE_VERSION="4.03.0"\n'
+            'EXPECTED_CANDIDATE_VERSION="4.03.1"\n'
             'FORWARD_ONLY_APK_TRANSITION="1"\n'
             "prepare_expected_payloads() { return 0; }\n"
             "seed_state() { :; }\n"
@@ -2013,11 +2013,11 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 architecture
             ]
             platform_result.update(
-                candidate_version="4.03.0",
+                candidate_version="4.03.1",
                 previous_version="4.02.8",
                 candidate={
-                    "filename": f"syswarden_4.03.0_{architecture}.apk",
-                    "version": "4.03.0",
+                    "filename": f"syswarden_4.03.1_{architecture}.apk",
+                    "version": "4.03.1",
                     "sha256": "c" * 64,
                 },
                 previous={

--- a/scripts/ci/release_gate.py
+++ b/scripts/ci/release_gate.py
@@ -29,7 +29,7 @@ UPDATE_SIGNATURE_NAME = f"{UPDATE_MANIFEST_NAME}.sig"
 UPDATE_MANIFEST_TOOL = "scripts/ci/update_manifest.go"
 UPDATE_PRIVATE_KEY_ENV = "SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY"
 FIRST_SIGNED_UPDATE_TAG = "v4.02.9"
-# One-release bridge for qualifying v4.03.0 against its exact public predecessor.
+# One-release bridge for qualifying the current Linux release against its exact public predecessor.
 # Delete this bridge once v4.02.8 is no longer the qualification predecessor.
 HISTORICAL_LINUX_TRANSITION_TAG = "v4.02.8"
 HISTORICAL_LINUX_TRANSITION_REPOSITORY = "duggytuxy/syswarden"

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -106,7 +106,7 @@ var installCmd = &cobra.Command{
 			return installStageError("service setup failed", err)
 		}
 
-		fmt.Println("[SYSWARDEN] v4.03.0 native installation complete.")
+		fmt.Println("[SYSWARDEN] v4.03.1 native installation complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/cmd/manual.go
+++ b/src/core/syswarden-cli/cmd/manual.go
@@ -108,10 +108,10 @@ var manualCmd = &cobra.Command{
 
 		fmt.Printf("%s--- 5. SAFETY LIMITS ---%s\n", ansiYellow, ansiReset)
 		fmt.Printf("  %sRELOAD:%s the Linux nftables candidate is committed atomically and verified; compatibility-wrapper failure leaves nftables authoritative and returns an error. The core normally restarts, so keep console access and a ruleset backup.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to the qualified v4.03.0 Linux package.\n", ansiRed, ansiReset)
+		fmt.Printf("  %sUPDATE:%s v4.02.9+ requires a trusted Ed25519 release manifest; v4.02.8 needs a separately verified manual first hop to the qualified v4.03.1 Linux package.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sUNINSTALL:%s configuration, data, logs, services and firewall tables are deleted; it is not a rollback.\n", ansiRed, ansiReset)
 		fmt.Printf("  %sALPINE:%s dedicated CGO-free static APK binaries are built for x86_64 and aarch64; install only an exact release-qualified artifact.\n", ansiRed, ansiReset)
-		fmt.Printf("  %sPLATFORMS:%s v4.03.0 supports the qualified Linux DEB, RPM and APK package matrix only.\n\n", ansiRed, ansiReset)
+		fmt.Printf("  %sPLATFORMS:%s v4.03.1 supports the qualified Linux DEB, RPM and APK package matrix only.\n\n", ansiRed, ansiReset)
 
 		fmt.Printf("%s================================================================================%s\n", ansiCyan, ansiReset)
 		fmt.Printf("%sRead README.md and the command-specific --help output before a host-mutating action.%s\n", ansiWhite, ansiReset)

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.03.0
+# Version=v4.03.1
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.03.0", Inline: true},
+						{Name: "Version", Value: "v4.03.1", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-var Version = "v4.03.0"
+var Version = "v4.03.1"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -79,7 +79,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.03.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.03.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -147,7 +147,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.03.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.03.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -359,7 +359,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.03.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.03.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.03.0"
+const SysWardenVersion = "v4.03.1"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary

- make DEB, RPM, and APK builds reproducible between main and tag workflows
- normalize SOURCE_DATE_EPOCH, source mtimes, the RPM changelog, and the RPM build host
- publish the v4.03.1 patch correction and align documentation and CI contracts
- preserve the Alpine lifecycle bridge from the latest public release, v4.02.8

## Root cause

The v4.03.0 publisher correctly rejected the tag-built packages because their timestamp metadata differed from the pre-tag qualified bytes. The embedded binary payloads were identical. This change keeps the byte-exact gate strict and removes the nondeterministic packaging metadata.

## Local validation

- versionctl: v4.03.0 to v4.03.1, Patch, PASS
- documentation: 21/21 PASS
- package lifecycle contracts: 56/56 PASS
- package lifecycle lab: 76/76 PASS
- release gate: 40/40 PASS
- package workflow canonical bundle: 115/115 PASS
- two independent real builds of all 6 packages and SHA256SUMS: byte-identical
- affected Go tests, syntax checks, and diff-check: PASS

Do not create the v4.03.1 tag or release before squash-merging this PR, completing qualification on the exact merged commit, and approving production publication.
