### PR TITLE
Qualification : repair v4.03.2 package lifecycle qualification (#95)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -490,7 +490,6 @@ jobs:
                           echo "Service-manager runtime changed during package installation" >&2
                           exit 1
                       }
-                      /opt/syswarden/bin/syswarden-cli reload
                       ;;
                   OFFLINE)
                       echo "Service-manager runtime is offline; host configuration is deferred until an explicit online install."

--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -137,38 +137,62 @@ jobs:
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               v4032_parent_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4032_parent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
-                echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
+              if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
+                echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
                 exit 1
               fi
-              v4032_subject_pattern='^Qualification : repair v4\.03\.2 release qualification \(#[1-9][0-9]*\)$'
-              if [[ ! "${commit_subject}" =~ ${v4032_subject_pattern} ]]; then
-                echo "ERROR: the v4.03.2 qualification repair requires the exact reviewed squash subject." >&2
+              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95)'
+              if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 package lifecycle repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
               read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
               read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_parent_line[@]} != 2 )); then
-                echo "ERROR: the v4.03.2 qualification repair requires one linear follow-up after the reviewed release commit." >&2
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              if (( ${#v4032_head_line[@]} != 2 || \
+                    ${#v4032_parent_line[@]} != 2 || \
+                    ${#v4032_release_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 package lifecycle repair requires the reviewed three-commit linear chain." >&2
                 exit 1
               fi
               v4032_grandparent_sha="$(git rev-parse HEAD^^)"
-              if [[ "${v4032_grandparent_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
+              if [[ "${v4032_grandparent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
+                echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
+                exit 1
+              fi
+              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
+              if [[ "${v4032_release_base_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
                 echo "ERROR: the v4.03.2 release commit does not have the reviewed Patch baseline." >&2
                 exit 1
               fi
               # BEGIN exact v4.03.2 preserved-version recovery diff contract
               expected_v4032_diff=(
+                M ".github/workflows/package.yml"
                 M ".github/workflows/release-manager.yml"
                 M ".github/workflows/release-qualification.yml"
+                M "build_packages.sh"
+                M "scripts/ci/package_lifecycle_contract_test.py"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/package_webtui_retirement.sh"
                 M "scripts/ci/release_gate_test.py"
                 M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+                M "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go"
+                M "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
+                M "src/core/syswarden-cli/pkg/system/firewall_optimizer.go"
+                M "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go"
+                M "src/core/syswarden-cli/pkg/system/service_linux.go"
+                M "src/core/syswarden-cli/pkg/system/service_linux_test.go"
+                M "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
+                M "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_diff < <(
                 git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
               )
               if (( ${#actual_v4032_diff[@]} != ${#expected_v4032_diff[@]} )); then
-                echo "ERROR: the v4.03.2 qualification repair must modify exactly the four reviewed files." >&2
+                echo "ERROR: the v4.03.2 package lifecycle repair must modify exactly the twenty reviewed files." >&2
                 exit 1
               fi
               for ((index = 0; index < ${#expected_v4032_diff[@]}; index++)); do
@@ -178,21 +202,41 @@ jobs:
                 fi
               done
               v4032_fix_paths=(
+                ".github/workflows/package.yml"
                 ".github/workflows/release-manager.yml"
                 ".github/workflows/release-qualification.yml"
+                "build_packages.sh"
+                "scripts/ci/package_lifecycle_contract_test.py"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/package_webtui_retirement.sh"
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+                "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go"
+                "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
+                "src/core/syswarden-cli/pkg/system/firewall_optimizer.go"
+                "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go"
+                "src/core/syswarden-cli/pkg/system/service_linux.go"
+                "src/core/syswarden-cli/pkg/system/service_linux_test.go"
+                "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
+                "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               for tree_ref in HEAD^ HEAD; do
                 for fix_path in "${v4032_fix_paths[@]}"; do
+                  expected_mode="100644"
+                  if [[ "${fix_path}" == "build_packages.sh" ]]; then
+                    expected_mode="100755"
+                  fi
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
-                  if [[ "${tree_mode}" != "100644" || \
+                  if [[ "${tree_mode}" != "${expected_mode}" || \
                         "${tree_type}" != "blob" || \
                         ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
                         "${tree_path}" != "${fix_path}" || \
                         -n "${tree_extra:-}" ]]; then
-                    echo "ERROR: reviewed v4.03.2 repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    echo "ERROR: reviewed v4.03.2 repair path ${fix_path} is not one exact ${expected_mode} blob at ${tree_ref}." >&2
                     exit 1
                   fi
                 done
@@ -211,8 +255,13 @@ jobs:
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_grandparent_sha}" \
-                --tag-phase \
                 --commit-message "${v4032_parent_commit_message}"
+              v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_release_base_sha}" \
+                --tag-phase \
+                --commit-message "${v4032_release_commit_message}"
             else
               if [[ "${RELEASE_TAG}" != "v4.03.0" ]]; then
                 echo "ERROR: preserved-version release recovery is authorized only for v4.03.0 or v4.03.2." >&2
@@ -687,38 +736,62 @@ jobs:
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               v4032_parent_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4032_parent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
-                echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
+              if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
+                echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
                 exit 1
               fi
-              v4032_subject_pattern='^Qualification : repair v4\.03\.2 release qualification \(#[1-9][0-9]*\)$'
-              if [[ ! "${commit_subject}" =~ ${v4032_subject_pattern} ]]; then
-                echo "ERROR: the v4.03.2 qualification repair requires the exact reviewed squash subject." >&2
+              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95)'
+              if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 package lifecycle repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
               read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
               read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_parent_line[@]} != 2 )); then
-                echo "ERROR: the v4.03.2 qualification repair requires one linear follow-up after the reviewed release commit." >&2
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              if (( ${#v4032_head_line[@]} != 2 || \
+                    ${#v4032_parent_line[@]} != 2 || \
+                    ${#v4032_release_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 package lifecycle repair requires the reviewed three-commit linear chain." >&2
                 exit 1
               fi
               v4032_grandparent_sha="$(git rev-parse HEAD^^)"
-              if [[ "${v4032_grandparent_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
+              if [[ "${v4032_grandparent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
+                echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
+                exit 1
+              fi
+              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
+              if [[ "${v4032_release_base_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
                 echo "ERROR: the v4.03.2 release commit does not have the reviewed Patch baseline." >&2
                 exit 1
               fi
               # BEGIN exact v4.03.2 preserved-version recovery diff contract
               expected_v4032_diff=(
+                M ".github/workflows/package.yml"
                 M ".github/workflows/release-manager.yml"
                 M ".github/workflows/release-qualification.yml"
+                M "build_packages.sh"
+                M "scripts/ci/package_lifecycle_contract_test.py"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/package_webtui_retirement.sh"
                 M "scripts/ci/release_gate_test.py"
                 M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+                M "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go"
+                M "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
+                M "src/core/syswarden-cli/pkg/system/firewall_optimizer.go"
+                M "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go"
+                M "src/core/syswarden-cli/pkg/system/service_linux.go"
+                M "src/core/syswarden-cli/pkg/system/service_linux_test.go"
+                M "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
+                M "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_diff < <(
                 git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
               )
               if (( ${#actual_v4032_diff[@]} != ${#expected_v4032_diff[@]} )); then
-                echo "ERROR: the v4.03.2 qualification repair must modify exactly the four reviewed files." >&2
+                echo "ERROR: the v4.03.2 package lifecycle repair must modify exactly the twenty reviewed files." >&2
                 exit 1
               fi
               for ((index = 0; index < ${#expected_v4032_diff[@]}; index++)); do
@@ -728,21 +801,41 @@ jobs:
                 fi
               done
               v4032_fix_paths=(
+                ".github/workflows/package.yml"
                 ".github/workflows/release-manager.yml"
                 ".github/workflows/release-qualification.yml"
+                "build_packages.sh"
+                "scripts/ci/package_lifecycle_contract_test.py"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/package_webtui_retirement.sh"
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+                "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go"
+                "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
+                "src/core/syswarden-cli/pkg/system/firewall_optimizer.go"
+                "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go"
+                "src/core/syswarden-cli/pkg/system/service_linux.go"
+                "src/core/syswarden-cli/pkg/system/service_linux_test.go"
+                "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
+                "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               for tree_ref in HEAD^ HEAD; do
                 for fix_path in "${v4032_fix_paths[@]}"; do
+                  expected_mode="100644"
+                  if [[ "${fix_path}" == "build_packages.sh" ]]; then
+                    expected_mode="100755"
+                  fi
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
-                  if [[ "${tree_mode}" != "100644" || \
+                  if [[ "${tree_mode}" != "${expected_mode}" || \
                         "${tree_type}" != "blob" || \
                         ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
                         "${tree_path}" != "${fix_path}" || \
                         -n "${tree_extra:-}" ]]; then
-                    echo "ERROR: reviewed v4.03.2 repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    echo "ERROR: reviewed v4.03.2 repair path ${fix_path} is not one exact ${expected_mode} blob at ${tree_ref}." >&2
                     exit 1
                   fi
                 done
@@ -761,8 +854,13 @@ jobs:
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_grandparent_sha}" \
-                --tag-phase \
                 --commit-message "${v4032_parent_commit_message}"
+              v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_release_base_sha}" \
+                --tag-phase \
+                --commit-message "${v4032_release_commit_message}"
             else
               if [[ "${RELEASE_TAG}" != "v4.03.0" ]]; then
                 echo "ERROR: preserved-version release recovery is authorized only for v4.03.0 or v4.03.2." >&2

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -91,13 +91,38 @@ jobs:
           test "$(uname -m)" = "aarch64"
           command -v gh >/dev/null
           command -v jq >/dev/null
-          command -v podman >/dev/null
           command -v python3 >/dev/null
           command -v runc >/dev/null
           command -v sha256sum >/dev/null
           command -v sudo >/dev/null
           command -v systemctl >/dev/null
           command -v systemd-run >/dev/null
+          podman_path="/usr/local/bin/podman"
+          for parent in /usr /usr/local /usr/local/bin; do
+            if [[ ! -d "${parent}" || -L "${parent}" || \
+                  "$(stat -c '%u:%g' "${parent}")" != "0:0" ]]; then
+              echo "ERROR: the native ARM64 Podman parent path is not a trusted root-owned directory: ${parent}." >&2
+              exit 1
+            fi
+            parent_mode="$(stat -c '%a' "${parent}")"
+            if [[ ! "${parent_mode}" =~ ^[0-7]{3,4}$ ]] || \
+               (( (8#${parent_mode} & 0022) != 0 )); then
+              echo "ERROR: the native ARM64 Podman parent path is writable by an untrusted account: ${parent}." >&2
+              exit 1
+            fi
+          done
+          if [[ ! -f "${podman_path}" || -L "${podman_path}" || \
+                ! -x "${podman_path}" || \
+                "$(stat -c '%u:%g' "${podman_path}")" != "0:0" ]]; then
+            echo "ERROR: the native ARM64 Podman executable is not the exact trusted regular file." >&2
+            exit 1
+          fi
+          podman_mode="$(stat -c '%a' "${podman_path}")"
+          if [[ ! "${podman_mode}" =~ ^[0-7]{3,4}$ ]] || \
+             (( (8#${podman_mode} & 0022) != 0 )); then
+            echo "ERROR: the native ARM64 Podman executable is writable by an untrusted account." >&2
+            exit 1
+          fi
 
       - name: Create Native ARM64 Shard Workspace
         id: arm_workspace
@@ -462,7 +487,7 @@ jobs:
             /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
             --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \
-            --podman /usr/bin/podman \
+            --podman /usr/local/bin/podman \
             --architecture-shard arm64 \
             --qualification-repository "${GITHUB_REPOSITORY}" \
             --qualification-release-sha "${RELEASE_SHA}" \
@@ -534,6 +559,36 @@ jobs:
           if-no-files-found: error
           retention-days: 3
           compression-level: 0
+
+      - name: Enforce Native ARM64 Package Lifecycle Verdict
+        shell: bash
+        run: |
+          set -euo pipefail
+          report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"
+          status="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
+          test -s "${report}"
+          test -f "${report}"
+          test ! -L "${report}"
+          test -s "${status}"
+          test -f "${status}"
+          test ! -L "${status}"
+          shard_rc="$(cat "${status}")"
+          if [[ ! "${shard_rc}" =~ ^[0-9]+$ || "${shard_rc}" != "0" ]]; then
+            echo "ERROR: the native ARM64 package lifecycle command failed with rc=${shard_rc}." >&2
+            exit 1
+          fi
+          if ! jq -e '
+            type == "object" and
+            .status == "pass" and
+            .harness_complete == true and
+            .release_ready == true and
+            (.blocker_ids | type == "array" and length == 0) and
+            (.unexpected_failed_checks | type == "array" and length == 0) and
+            (has("error") | not)
+          ' "${report}" >/dev/null; then
+            echo "ERROR: the native ARM64 package lifecycle report is not release-ready." >&2
+            exit 1
+          fi
 
   qualify-release:
     name: Qualify Exact Pre-Tag Commit
@@ -1375,7 +1430,7 @@ jobs:
           )
           if [[ "${sorted_expected[*]}" != "${actual_before_manifest[*]}" ]]; then
             echo "ERROR: qualification evidence inventory is incomplete or contains unexpected files." >&2
-            diff --no-index \
+            diff -u \
               <(printf '%s\n' "${sorted_expected[@]}") \
               <(printf '%s\n' "${actual_before_manifest[@]}") >&2 || true
             exit 1

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -450,7 +450,6 @@ if [ "$1" = "2" ] || [ "$1" = "1" ] || [ "$1" = "configure" ] || [ -f /etc/alpin
                 echo "Service-manager runtime changed during package installation" >&2
                 exit 1
             }
-            /opt/syswarden/bin/syswarden-cli reload
             ;;
         OFFLINE)
             echo "Service-manager runtime is offline; host configuration is deferred until an explicit online install."

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -844,7 +844,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
         self.assertIn('[ "$1" = "2" ]', postinstall)
         self.assertIn('[ "$1" = "configure" ]', postinstall)
         self.assertIn("syswarden_classify_service_manager", postinstall)
-        self.assertNotIn("reload --no-restart", postinstall)
+        self.assertNotIn("/opt/syswarden/bin/syswarden-cli reload", postinstall)
         self.assertIn(
             "Service-manager runtime is offline; host configuration is deferred until an explicit online install.",
             postinstall,
@@ -1142,6 +1142,24 @@ class PackageLifecycleContractTests(unittest.TestCase):
             self.assertEqual(openrc_result.returncode, 0, openrc_result)
             self.assertEqual(openrc_result.stdout.strip(), "ACTIVE")
 
+            openrc.chmod(0o775)
+            standard_mode_result = subprocess.run(
+                [
+                    "/bin/sh",
+                    "-c",
+                    '. "$1"; syswarden_classify_service_manager "$2" openrc',
+                    "probe",
+                    str(WEBTUI_RETIREMENT_HELPER),
+                    str(root),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "SYSWARDEN_PKG_INSTALL": "1"},
+            )
+            self.assertEqual(standard_mode_result.returncode, 0, standard_mode_result)
+            self.assertEqual(standard_mode_result.stdout.strip(), "ACTIVE")
+
     def test_openrc_softlevel_encoding_and_metadata_are_fail_closed(self) -> None:
         def seed_runtime(root: Path, content: bytes) -> tuple[Path, Path, str]:
             runtime = root / "run/openrc"
@@ -1189,6 +1207,25 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 runtime, _, owner = seed_runtime(root, content)
                 result = attest(root, runtime, owner)
                 self.assertEqual(result.returncode, 0, result)
+
+        with self.subTest(
+            runtime_mode="openrc-standard-0775"
+        ), tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "root"
+            runtime, _, owner = seed_runtime(root, b"default")
+            runtime.chmod(0o775)
+            result = attest(root, runtime, owner)
+            self.assertEqual(result.returncode, 0, result)
+
+        for mode in (0o770, 0o777, 0o1775):
+            with self.subTest(
+                rejected_runtime_mode=oct(mode)
+            ), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary) / "root"
+                runtime, _, owner = seed_runtime(root, b"default")
+                runtime.chmod(mode)
+                result = attest(root, runtime, owner)
+                self.assertNotEqual(result.returncode, 0, result)
 
         rejected = (
             ("empty", b""),
@@ -1677,6 +1714,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
         )
         cases = (
             "exact",
+            "merged-usr",
             "operator-path",
             "second-path",
             "content",
@@ -1691,6 +1729,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
             "drift",
             "late-drift",
             "rpm-path",
+            "rpm-outside-alias",
             "rpm-mode",
             "rpm-nlink",
             "rpm-drift",
@@ -1830,10 +1869,25 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 elif case == "second-path":
                     dropins += " " + str(root / "etc/systemd/system/operator.conf")
                 path_entries = [str(mock_bin), str(rooted_bin), os.environ["PATH"]]
-                if case == "rpm-path":
+                if case == "merged-usr":
+                    merged_bin = root / "bin"
+                    merged_bin.symlink_to("usr/bin", target_is_directory=True)
+                    path_entries = [
+                        str(mock_bin),
+                        str(merged_bin),
+                        str(rooted_bin),
+                        os.environ["PATH"],
+                    ]
+                elif case == "rpm-path":
                     fake_rpm = mock_bin / "rpm"
                     fake_rpm.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
                     fake_rpm.chmod(0o755)
+                    path_entries = [str(mock_bin), str(rooted_bin), os.environ["PATH"]]
+                elif case == "rpm-outside-alias":
+                    foreign_rpm = mock_bin / "rpm-foreign"
+                    foreign_rpm.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+                    foreign_rpm.chmod(0o755)
+                    (mock_bin / "rpm").symlink_to(foreign_rpm)
                     path_entries = [str(mock_bin), str(rooted_bin), os.environ["PATH"]]
                 result = subprocess.run(
                     [
@@ -1871,7 +1925,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                     )
                     self.assertTrue(temporary_link.name.endswith(".operator-link"))
                     temporary_link.unlink(missing_ok=False)
-                if case == "exact":
+                if case in ("exact", "merged-usr"):
                     self.assertEqual(result.returncode, 0, result)
                     self.assertEqual(
                         len(rpm_calls.read_text(encoding="ascii").splitlines()),
@@ -2784,6 +2838,46 @@ class PackageLifecycleContractTests(unittest.TestCase):
         if listener.stderr is not None:
             listener.stderr.close()
 
+    def test_process_match_distinguishes_vanished_from_unreadable_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            executable = root / "syswarden-cli"
+            shutil.copy2("/bin/true", executable)
+            identity = executable.stat()
+            expected_identity = f"{identity.st_dev}:{identity.st_ino}"
+
+            for mode, expected_status in (("vanish", 1), ("unreadable", 2)):
+                with self.subTest(mode=mode):
+                    process_root = root / f"proc-{mode}" / "4242"
+                    process_root.mkdir(parents=True)
+                    (process_root / "exe").symlink_to(executable)
+                    result = subprocess.run(
+                        [
+                            "/bin/sh",
+                            "-c",
+                            '. "$1"; '
+                            'syswarden_test_process_root="$3/$4"; '
+                            'syswarden_test_mode="$6"; '
+                            "syswarden_webtui_process_starttime() { "
+                            'if [ "${syswarden_test_mode}" = vanish ]; then '
+                            'mv -- "${syswarden_test_process_root}" '
+                            '"${syswarden_test_process_root}.gone" || return 2; '
+                            "fi; return 1; }; "
+                            'syswarden_webtui_process_matches "$4" "$3" "$2" "$5"',
+                            "probe",
+                            str(WEBTUI_RETIREMENT_HELPER),
+                            str(executable),
+                            str(process_root.parent),
+                            process_root.name,
+                            expected_identity,
+                            mode,
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, expected_status, result)
+
     def test_deleted_old_process_with_replaced_binary_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             executable = Path(temporary) / "syswarden-cli"
@@ -3597,15 +3691,17 @@ class PackageLifecycleContractTests(unittest.TestCase):
         self.assertIn("syswarden_classify_service_manager", postinstall)
         self.assertIn("AMBIGUOUS", postinstall)
         self.assertIn("OFFLINE", postinstall)
-        self.assertIn("/opt/syswarden/bin/syswarden-cli reload\n", postinstall)
-        self.assertNotIn("/opt/syswarden/bin/syswarden-cli reload --no-restart", postinstall)
+        self.assertNotIn("/opt/syswarden/bin/syswarden-cli reload", postinstall)
         active_branch = postinstall.index("ACTIVE)")
         offline_branch = postinstall.index("OFFLINE)", active_branch)
         install = postinstall.index("/opt/syswarden/bin/syswarden-cli install", active_branch)
-        reload = postinstall.index("/opt/syswarden/bin/syswarden-cli reload", install)
+        revalidate = postinstall.index(
+            '[ "$(syswarden_classify_service_manager / "${manager}")" = ACTIVE ]',
+            install,
+        )
         self.assertLess(active_branch, install)
-        self.assertLess(install, reload)
-        self.assertLess(reload, offline_branch)
+        self.assertLess(install, revalidate)
+        self.assertLess(revalidate, offline_branch)
 
     def test_linux_packages_declare_every_runtime_dependency(self) -> None:
         for dependency in (

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -2364,6 +2364,35 @@ prepare_service_runtime_fixture() {
     esac
 }
 
+prepare_package_transition() {
+    prepare_service_runtime_fixture || return 1
+    case "${PACKAGE_FAMILY}" in
+        deb|rpm)
+            [ "$(systemctl is-enabled rsyslog.service 2>/dev/null || true)" = enabled ] || return 1
+            [ "$(systemctl is-active rsyslog.service 2>/dev/null || true)" = active ] || return 1
+            syswarden_transition_rsyslog_pid_before="$(
+                systemctl show -p MainPID --value rsyslog.service 2>/dev/null || true
+            )"
+            case "${syswarden_transition_rsyslog_pid_before}" in
+                ''|*[!0-9]*) return 1 ;;
+            esac
+            [ "${syswarden_transition_rsyslog_pid_before}" -gt 1 ] || return 1
+            kill -0 "${syswarden_transition_rsyslog_pid_before}" 2>/dev/null || return 1
+            systemctl reset-failed rsyslog.service >/dev/null 2>&1 || return 1
+            [ "$(systemctl is-enabled rsyslog.service 2>/dev/null || true)" = enabled ] || return 1
+            [ "$(systemctl is-active rsyslog.service 2>/dev/null || true)" = active ] || return 1
+            syswarden_transition_rsyslog_pid_after="$(
+                systemctl show -p MainPID --value rsyslog.service 2>/dev/null || true
+            )"
+            [ "${syswarden_transition_rsyslog_pid_after}" = "${syswarden_transition_rsyslog_pid_before}" ] || return 1
+            kill -0 "${syswarden_transition_rsyslog_pid_after}" 2>/dev/null || return 1
+            [ "$(syswarden_classify_service_manager / systemd)" = ACTIVE ] || return 1
+            ;;
+        apk) ;;
+        *) return 1 ;;
+    esac
+}
+
 expected_systemd_enablement_prefix() {
     label="$1"
     case "${SCENARIO}:${label}" in
@@ -3833,6 +3862,7 @@ probe_execution_architecture() {
 
 scenario_upgrade_rollback_initial() {
     prepare_expected_payloads || return
+    prepare_package_transition || return
     run_install_step install.previous "${PREVIOUS_PACKAGE}" || return
     if [ "${FORWARD_ONLY_APK_TRANSITION}" = "1" ]; then
         probe_forward_only_apk_payload previous
@@ -3845,11 +3875,12 @@ scenario_upgrade_rollback_initial() {
     seed_live_legacy_webtui_process || return
     seed_legacy_saas_monitor_state || return
 
-    prepare_service_runtime_fixture || return
+    prepare_package_transition || return
     run_install_step upgrade.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload candidate candidate "${CANDIDATE_VERSION}"
     assert_all_state_preserved candidate
 
+    prepare_package_transition || return
     run_install_step reinstall.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload reinstall candidate "${CANDIDATE_VERSION}"
     assert_all_state_preserved reinstall
@@ -3870,7 +3901,7 @@ scenario_upgrade_rollback_restart_two() {
     prepare_service_runtime_fixture || return
     probe_payload restart-two candidate "${EXPECTED_CANDIDATE_VERSION}"
     assert_all_state_preserved restart-two
-    prepare_service_runtime_fixture || return
+    prepare_package_transition || return
     run_install_step rollback.previous "${PREVIOUS_PACKAGE}" || return
     if [ "${FORWARD_ONLY_APK_TRANSITION}" = "1" ]; then
         probe_forward_only_apk_payload rollback
@@ -3878,7 +3909,7 @@ scenario_upgrade_rollback_restart_two() {
         probe_payload rollback previous "${EXPECTED_PREVIOUS_VERSION}"
     fi
     assert_all_state_preserved rollback
-    prepare_service_runtime_fixture || return
+    prepare_package_transition || return
     run_install_step recovery.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload recovery candidate "${EXPECTED_CANDIDATE_VERSION}"
     assert_all_state_preserved recovery
@@ -3888,7 +3919,7 @@ scenario_upgrade_rollback_restart_two() {
 scenario_remove() {
     prepare_expected_payloads || return
     seed_state
-    prepare_service_runtime_fixture || return
+    prepare_package_transition || return
     run_install_step install.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload fresh candidate "${CANDIDATE_VERSION}"
     assert_all_state_preserved fresh
@@ -3923,7 +3954,7 @@ scenario_remove() {
 scenario_purge() {
     prepare_expected_payloads || return
     seed_state
-    prepare_service_runtime_fixture || return
+    prepare_package_transition || return
     run_install_step install.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload fresh candidate "${CANDIDATE_VERSION}"
     assert_all_state_preserved fresh

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -2750,6 +2750,7 @@ probe
             "seed_live_legacy_webtui_process() { :; }\n"
             "seed_legacy_saas_monitor_state() { :; }\n"
             "prepare_service_runtime_fixture() { :; }\n"
+            "prepare_package_transition() { prepare_service_runtime_fixture; }\n"
             "remove_service_manager_sentinels() { :; }\n"
             "load_state_contract() { return 0; }\n"
             'run_install_step() { printf "%s\\n" "$1" >> "${CALLS}"; }\n'
@@ -2800,6 +2801,7 @@ probe
             'FORWARD_ONLY_APK_TRANSITION="0"\n'
             "FAILURES=0\n"
             "probe_execution_architecture() { return 0; }\n"
+            "prepare_package_transition() { return 0; }\n"
             "prepare_expected_payloads() {\n"
             '    case "${SCENARIO}" in\n'
             "        upgrade-rollback) return 0 ;;\n"
@@ -4779,6 +4781,135 @@ probe
                 self.assertIn(
                     f"{scenario}.{label}.service_manager_calls", checks
                 )
+
+    def test_package_transitions_reset_only_an_active_rsyslog_rate_limit(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("prepare_package_transition() {")
+        end = source.index("\nexpected_systemd_enablement_prefix() {", start)
+        function = source[start:end]
+
+        self.assertIn("prepare_service_runtime_fixture || return 1", function)
+        self.assertIn("systemctl is-enabled rsyslog.service", function)
+        self.assertIn("systemctl is-active rsyslog.service", function)
+        self.assertIn("systemctl reset-failed rsyslog.service", function)
+        self.assertNotIn("systemctl start", function)
+        self.assertNotIn("systemctl restart", function)
+        self.assertNotIn("systemctl try-restart", function)
+        self.assertLess(
+            function.index("systemctl is-active rsyslog.service"),
+            function.index("systemctl reset-failed rsyslog.service"),
+        )
+        self.assertLess(
+            function.index("systemctl reset-failed rsyslog.service"),
+            function.rindex("systemctl is-active rsyslog.service"),
+        )
+        self.assertIn(
+            '[ "${syswarden_transition_rsyslog_pid_after}" = '
+            '"${syswarden_transition_rsyslog_pid_before}" ]',
+            function,
+        )
+        self.assertEqual(function.count("kill -0"), 2)
+
+        commands = (
+            ('install.previous "${PREVIOUS_PACKAGE}"', 1),
+            ('upgrade.candidate "${CANDIDATE_PACKAGE}"', 1),
+            ('reinstall.candidate "${CANDIDATE_PACKAGE}"', 1),
+            ('rollback.previous "${PREVIOUS_PACKAGE}"', 1),
+            ('recovery.candidate "${CANDIDATE_PACKAGE}"', 1),
+            ('install.candidate "${CANDIDATE_PACKAGE}"', 2),
+        )
+        for command, expected_count in commands:
+            with self.subTest(command=command):
+                self.assertEqual(
+                    source.count(
+                        "    prepare_package_transition || return\n"
+                        f"    run_install_step {command} || return"
+                    ),
+                    expected_count,
+                )
+
+        harness = function + r'''
+prepare_service_runtime_fixture() {
+    printf '%s\n' prepare-service-runtime >> "${TEST_CALLS}"
+    return "${TEST_FIXTURE_RC:-0}"
+}
+systemctl() {
+    printf 'systemctl %s\n' "$*" >> "${TEST_CALLS}"
+    case "$*" in
+        'is-enabled rsyslog.service') printf '%s\n' "${TEST_ENABLED:-enabled}" ;;
+        'is-active rsyslog.service') printf '%s\n' "${TEST_ACTIVE:-active}" ;;
+        'show -p MainPID --value rsyslog.service')
+            if [ -n "${TEST_PID_AFTER:-}" ] && grep -q '^systemctl reset-failed ' "${TEST_CALLS}"; then
+                printf '%s\n' "${TEST_PID_AFTER}"
+            else
+                printf '%s\n' "${TEST_PID_BEFORE:-123}"
+            fi
+            ;;
+        'reset-failed rsyslog.service') return "${TEST_RESET_RC:-0}" ;;
+        *) return 97 ;;
+    esac
+}
+kill() {
+    printf 'kill %s\n' "$*" >> "${TEST_CALLS}"
+    return "${TEST_KILL_RC:-0}"
+}
+syswarden_classify_service_manager() {
+    printf '%s\n' "${TEST_MANAGER_STATE:-ACTIVE}"
+}
+prepare_package_transition
+'''
+
+        with tempfile.TemporaryDirectory() as temporary:
+            calls = Path(temporary) / "calls"
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PACKAGE_FAMILY": "deb",
+                    "TEST_CALLS": str(calls),
+                }
+            )
+            accepted = subprocess.run(
+                ["/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted)
+            accepted_calls = calls.read_text(encoding="ascii").splitlines()
+            self.assertEqual(accepted_calls.count("systemctl reset-failed rsyslog.service"), 1)
+            self.assertEqual(accepted_calls.count("kill -0 123"), 2)
+
+            calls.unlink()
+            environment["TEST_ACTIVE"] = "inactive"
+            rejected = subprocess.run(
+                ["/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertNotEqual(rejected.returncode, 0, rejected)
+            self.assertNotIn(
+                "systemctl reset-failed rsyslog.service",
+                calls.read_text(encoding="ascii").splitlines(),
+            )
+
+            calls.unlink()
+            environment.pop("TEST_ACTIVE")
+            environment["TEST_PID_AFTER"] = "124"
+            changed_pid = subprocess.run(
+                ["/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertNotEqual(changed_pid.returncode, 0, changed_pid)
+            self.assertIn(
+                "systemctl reset-failed rsyslog.service",
+                calls.read_text(encoding="ascii").splitlines(),
+            )
 
     def test_alpine_crond_provider_attestation_rejects_ambiguous_evidence(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT

--- a/scripts/ci/package_webtui_retirement.sh
+++ b/scripts/ci/package_webtui_retirement.sh
@@ -57,7 +57,17 @@ syswarden_attest_openrc_runtime() {
     syswarden_openrc_owner="$3"
     syswarden_openrc_softlevel="${syswarden_openrc_runtime}/softlevel"
     syswarden_openrc_comm="${syswarden_openrc_root}/proc/1/comm"
-    syswarden_safe_runtime_object "${syswarden_openrc_runtime}" directory "${syswarden_openrc_owner}" || return 1
+    [ ! -L "${syswarden_openrc_runtime}" ] && [ -d "${syswarden_openrc_runtime}" ] || return 1
+    syswarden_openrc_runtime_metadata="$(
+        stat -c '%u:%g:%a' "${syswarden_openrc_runtime}" 2>/dev/null
+    )" || return 1
+    case "${syswarden_openrc_runtime_metadata}" in
+        "${syswarden_openrc_owner}":755|"${syswarden_openrc_owner}":775) ;;
+        *) return 1 ;;
+    esac
+    syswarden_openrc_runtime_before="$(
+        stat -c '%d:%i:%f:%u:%g:%a:%s:%Y:%Z' "${syswarden_openrc_runtime}" 2>/dev/null
+    )" || return 1
     syswarden_safe_runtime_object "${syswarden_openrc_softlevel}" file "${syswarden_openrc_owner}" || return 1
     syswarden_openrc_softlevel_before="$(stat -c '%d:%i:%u:%g:%a:%s:%Y:%Z' "${syswarden_openrc_softlevel}" 2>/dev/null)" || return 1
     syswarden_openrc_softlevel_digest_before="$(
@@ -95,6 +105,10 @@ syswarden_attest_openrc_runtime() {
     case "${syswarden_openrc_identity}" in init|openrc-init) ;; *) return 1 ;; esac
     [ "$(wc -c < "${syswarden_openrc_comm}" | tr -d ' ')" -eq "$((${#syswarden_openrc_identity} + 1))" ] || return 1
     syswarden_safe_runtime_object "${syswarden_openrc_comm}" file "${syswarden_openrc_owner}" || return 1
+    [ "$(stat -c '%d:%i:%f:%u:%g:%a:%s:%Y:%Z' "${syswarden_openrc_runtime}" 2>/dev/null)" = \
+        "${syswarden_openrc_runtime_before}" ] || return 1
+    [ "$(stat -c '%u:%g:%a' "${syswarden_openrc_runtime}" 2>/dev/null)" = \
+        "${syswarden_openrc_runtime_metadata}" ] || return 1
     return 0
 }
 
@@ -153,6 +167,15 @@ syswarden_classify_service_manager() {
         return 0
     fi
     for syswarden_manager_path in "${syswarden_manager_expected}" "${syswarden_manager_competing}"; do
+        if [ "${syswarden_manager_kind}" = openrc ] && \
+           [ "${syswarden_manager_path}" = "${syswarden_manager_expected}" ]; then
+            if [ -L "${syswarden_manager_path}" ] || \
+               { [ -e "${syswarden_manager_path}" ] && [ ! -d "${syswarden_manager_path}" ]; }; then
+                printf '%s\n' AMBIGUOUS
+                return 0
+            fi
+            continue
+        fi
         if { [ -e "${syswarden_manager_path}" ] || [ -L "${syswarden_manager_path}" ]; } && \
            ! syswarden_safe_runtime_object "${syswarden_manager_path}" directory "${syswarden_manager_owner}"; then
             printf '%s\n' AMBIGUOUS
@@ -248,7 +271,7 @@ syswarden_remove_exact_product_services() {
                 8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd 600 || return 1
             syswarden_remove_exact_service_file \
                 /etc/systemd/system/syswarden-firewall.service \
-                bc730793c007273a380261155b7602571c42efd93972f45ad2dd440f98251724 600 || return 1
+                989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1 600 || return 1
             ;;
         openrc)
             syswarden_remove_exact_service_enablement \
@@ -260,7 +283,7 @@ syswarden_remove_exact_product_services() {
                 99adff6d6bcb6c5f0fad472e11668d3f8f4e19136c3b3ce473493101db136558 755 || return 1
             syswarden_remove_exact_service_file \
                 /etc/init.d/syswarden-firewall \
-                82a936e4f9ce394d6cc0ffd3978a1842a899570842ab5d283184384e73af5905 755 || return 1
+                d8c57c59dae9493523275026acb2a5c599bd4949ff8993add6760e725f89a5ba 755 || return 1
             ;;
         *) return 1 ;;
     esac
@@ -542,7 +565,8 @@ syswarden_attest_approved_systemd_service_dropins() {
         printf '%s\n' 'Refusing approved systemd drop-in with inexact bytes' >&2
         return 1
     }
-    syswarden_retire_rpm="$(command -v rpm 2>/dev/null)" || return 1
+    syswarden_retire_rpm_path="$(command -v rpm 2>/dev/null)" || return 1
+    syswarden_retire_rpm="$(readlink -f -- "${syswarden_retire_rpm_path}" 2>/dev/null)" || return 1
     syswarden_retire_expected_rpm="${syswarden_retire_root}/usr/bin/rpm"
     if [ "${syswarden_retire_rpm}" != "${syswarden_retire_expected_rpm}" ] || \
        [ -L "${syswarden_retire_rpm}" ] || [ ! -f "${syswarden_retire_rpm}" ] || \
@@ -1037,7 +1061,10 @@ syswarden_webtui_process_matches() {
     [ -n "${syswarden_retire_process_identity}" ] || return 1
     [ "${syswarden_retire_process_identity}" = "${syswarden_retire_expected_identity}" ] || return 1
     syswarden_retire_starttime="$(syswarden_webtui_process_starttime "${syswarden_retire_process_root}/stat" 2>/dev/null || true)"
-    [ -n "${syswarden_retire_starttime}" ] || return 2
+    if [ -z "${syswarden_retire_starttime}" ]; then
+        [ ! -d "${syswarden_retire_process_root}" ] && return 1
+        return 2
+    fi
     if syswarden_webtui_cmdline_matches "${syswarden_retire_process_root}"; then
         syswarden_retire_argv_match=1
     else

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -729,7 +729,10 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('release_base_sha="$(git rev-parse HEAD^^)"'), 2
         )
         self.assertEqual(
-            workflow.count('release_base_sha="$(git rev-parse HEAD^^^)"'), 2
+            workflow.count(
+                '\n                release_base_sha="$(git rev-parse HEAD^^^)"'
+            ),
+            2,
         )
         self.assertEqual(workflow.count('--base-ref "${release_base_sha}"'), 4)
         self.assertNotIn("--base-ref HEAD^^", workflow)
@@ -814,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 6)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 7)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -834,7 +837,7 @@ class ReleaseGateTests(unittest.TestCase):
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
                 2,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 2)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(script.count('"${tree_type}" != "blob"'), 2)
             expected_path_counts = {
                 ".github/workflows/release-manager.yml": 4,
@@ -871,26 +874,49 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(
             workflow.count(
                 'if [[ "${v4032_parent_sha}" != '
-                '"3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then'
+                '"3839d592467a4f92f24b613412d8d89bb6905251" ]]; then'
             ),
             2,
         )
         self.assertEqual(
             workflow.count(
                 'if [[ "${v4032_grandparent_sha}" != '
+                '"3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then'
+            ),
+            2,
+        )
+        self.assertEqual(
+            workflow.count(
+                'if [[ "${v4032_release_base_sha}" != '
                 '"f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then'
             ),
             2,
         )
         subject_contract = (
-            "v4032_subject_pattern='^Qualification : repair v4\\.03\\.2 "
-            "release qualification \\(#[1-9][0-9]*\\)$'"
+            "v4032_expected_subject='Qualification : repair v4.03.2 "
+            "package lifecycle qualification (#95)'"
         )
         expected_paths = (
+            ".github/workflows/package.yml",
             ".github/workflows/release-manager.yml",
             ".github/workflows/release-qualification.yml",
+            "build_packages.sh",
+            "scripts/ci/package_lifecycle_contract_test.py",
+            "scripts/ci/package_lifecycle_lab.py",
+            "scripts/ci/package_lifecycle_lab_test.py",
+            "scripts/ci/package_webtui_retirement.sh",
             "scripts/ci/release_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
+            "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+            "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
+            "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go",
+            "src/core/syswarden-cli/pkg/security/hardening_linux_test.go",
+            "src/core/syswarden-cli/pkg/system/firewall_optimizer.go",
+            "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go",
+            "src/core/syswarden-cli/pkg/system/service_linux.go",
+            "src/core/syswarden-cli/pkg/system/service_linux_test.go",
+            "src/core/syswarden-cli/pkg/system/uninstall_linux.go",
+            "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go",
         )
         unchanged_targets = (
             "changelog.md",
@@ -906,7 +932,7 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(block.count(subject_contract), 1)
             self.assertEqual(
                 block.count(
-                    '[[ ! "${commit_subject}" =~ ${v4032_subject_pattern} ]]'
+                    '[[ "${commit_subject}" != "${v4032_expected_subject}" ]]'
                 ),
                 1,
             )
@@ -930,14 +956,22 @@ class ReleaseGateTests(unittest.TestCase):
             )
             self.assertEqual(
                 block.count(
-                    "${#v4032_head_line[@]} != 2 || "
-                    "${#v4032_parent_line[@]} != 2"
+                    'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_head_line[@]} != 2"), 1)
+            self.assertEqual(block.count("${#v4032_parent_line[@]} != 2"), 1)
+            self.assertEqual(block.count("${#v4032_release_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_grandparent_sha="$(git rev-parse HEAD^^)"'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_grandparent_sha="$(git rev-parse HEAD^^)"'
+                    'v4032_release_base_sha="$(git rev-parse HEAD^^^)"'
                 ),
                 1,
             )
@@ -967,15 +1001,23 @@ class ReleaseGateTests(unittest.TestCase):
                 ),
                 1,
             )
-            self.assertEqual(block.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(
+                block.count('"${tree_mode}" != "${expected_mode}"'), 1
+            )
             self.assertEqual(block.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(block.count('expected_mode="100644"'), 1)
+            self.assertEqual(
+                block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
+            )
+            self.assertEqual(block.count('expected_mode="100755"'), 1)
             self.assertEqual(
                 block.count("${#actual_v4032_diff[@]} != "
                             "${#expected_v4032_diff[@]}"),
                 1,
             )
             for path in expected_paths:
-                self.assertEqual(block.count(f'"{path}"'), 2)
+                expected_count = 3 if path == "build_packages.sh" else 2
+                self.assertEqual(block.count(f'"{path}"'), expected_count)
                 self.assertEqual(block.count(f'M "{path}"'), 1)
             self.assertEqual(block.count("git diff --quiet HEAD^ HEAD --"), 1)
             for path in unchanged_targets:
@@ -987,16 +1029,37 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 1
+                block.count('./scripts/versioning.sh validate-commit'), 2
             )
             self.assertEqual(
                 block.count('--base-ref "${v4032_grandparent_sha}"'), 1
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('--base-ref "${v4032_release_base_sha}"'), 1
             )
             self.assertEqual(block.count("--tag-phase"), 1)
             self.assertEqual(
                 block.count('--commit-message "${v4032_parent_commit_message}"'),
                 1,
             )
+            self.assertEqual(
+                block.count('--commit-message "${v4032_release_commit_message}"'),
+                1,
+            )
+            parent_validation = block.split(
+                'v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"',
+                1,
+            )[1].split(
+                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"',
+                1,
+            )[0]
+            self.assertNotIn("--tag-phase", parent_validation)
 
     def exact_v4032_fix_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1010,7 +1073,7 @@ class ReleaseGateTests(unittest.TestCase):
     def v4032_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
-        start = "v4032_subject_pattern="
+        start = "v4032_expected_subject="
         end = 'read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
         self.assertEqual(block.count(start), 1)
         self.assertEqual(block.count(end), 1)
@@ -1039,13 +1102,36 @@ class ReleaseGateTests(unittest.TestCase):
             check=True,
         )
         paths = [
+            repository / ".github/workflows/package.yml",
             repository / ".github/workflows/release-manager.yml",
             repository / ".github/workflows/release-qualification.yml",
+            repository / "build_packages.sh",
+            repository / "scripts/ci/package_lifecycle_contract_test.py",
+            repository / "scripts/ci/package_lifecycle_lab.py",
+            repository / "scripts/ci/package_lifecycle_lab_test.py",
+            repository / "scripts/ci/package_webtui_retirement.sh",
             repository / "scripts/ci/release_gate_test.py",
             repository / "scripts/ci/release_qualification_workflow_test.py",
+            repository / "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+            repository
+            / "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
+            repository
+            / "src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go",
+            repository
+            / "src/core/syswarden-cli/pkg/security/hardening_linux_test.go",
+            repository
+            / "src/core/syswarden-cli/pkg/system/firewall_optimizer.go",
+            repository
+            / "src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go",
+            repository / "src/core/syswarden-cli/pkg/system/service_linux.go",
+            repository / "src/core/syswarden-cli/pkg/system/service_linux_test.go",
+            repository / "src/core/syswarden-cli/pkg/system/uninstall_linux.go",
+            repository
+            / "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go",
         ]
         for path in paths:
             self.write_file(path, b"reviewed parent\n")
+        (repository / "build_packages.sh").chmod(0o755)
         subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
         subprocess.run(
             ["git", "-C", repository, "commit", "-q", "-m", "reviewed parent"],
@@ -1059,6 +1145,8 @@ class ReleaseGateTests(unittest.TestCase):
             paths[3].write_bytes(b"reviewed parent\n")
         elif mutation == "mode":
             paths[0].chmod(0o755)
+        elif mutation == "executable mode":
+            (repository / "build_packages.sh").chmod(0o644)
         elif mutation == "symlink":
             paths[1].unlink()
             paths[1].symlink_to("unauthorized-target")
@@ -1165,12 +1253,12 @@ class ReleaseGateTests(unittest.TestCase):
                 'v4032_parent_sha="$(git rev-parse HEAD^^)"',
             ),
             "exact parent": workflow.replace(
-                "3655abe045deffc669e0ba9c11a6e4cf17a317a5",
-                "4655abe045deffc669e0ba9c11a6e4cf17a317a5",
+                "3839d592467a4f92f24b613412d8d89bb6905251",
+                "4839d592467a4f92f24b613412d8d89bb6905251",
             ),
             "canonical subject": workflow.replace(
-                "Qualification : repair v4\\.03\\.2 release qualification",
-                "Qualification : arbitrary v4\\.03\\.2 repair",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95)",
+                "Qualification : arbitrary v4.03.2 repair (#95)",
             ),
             "linear head": workflow.replace(
                 'v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
@@ -1180,11 +1268,23 @@ class ReleaseGateTests(unittest.TestCase):
                 'v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
                 'v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
             ),
+            "linear release": workflow.replace(
+                'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
+                'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+            ),
             "grandparent resolution": workflow.replace(
                 'v4032_grandparent_sha="$(git rev-parse HEAD^^)"',
                 'v4032_grandparent_sha="$(git rev-parse HEAD^)"',
             ),
             "exact grandparent": workflow.replace(
+                "3655abe045deffc669e0ba9c11a6e4cf17a317a5",
+                "4655abe045deffc669e0ba9c11a6e4cf17a317a5",
+            ),
+            "release base resolution": workflow.replace(
+                'v4032_release_base_sha="$(git rev-parse HEAD^^^)"',
+                'v4032_release_base_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact release base": workflow.replace(
                 "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa",
                 "e2270a2a8138f1f2b72a6200f6febbdc83fa5eaa",
             ),
@@ -1203,6 +1303,13 @@ class ReleaseGateTests(unittest.TestCase):
                 "for tree_ref in HEAD^ HEAD; do", "for tree_ref in HEAD; do"
             ),
             "regular mode": workflow.replace('"100644"', '"100755"'),
+            "executable mode selector": workflow.replace(
+                '[[ "${fix_path}" == "build_packages.sh" ]]',
+                '[[ "${fix_path}" == "unauthorized.sh" ]]',
+            ),
+            "executable mode": workflow.replace(
+                'expected_mode="100755"', 'expected_mode="100644"'
+            ),
             "regular blob": workflow.replace('"${tree_type}" != "blob"',
                                               '"${tree_type}" != "tree"'),
             "changelog identity": workflow.replace(
@@ -1219,7 +1326,16 @@ class ReleaseGateTests(unittest.TestCase):
             "parent validation base": workflow.replace(
                 '--base-ref "${v4032_grandparent_sha}"', '--base-ref HEAD^'
             ),
-            "parent tag phase": workflow.replace("--tag-phase", "--ordinary-phase"),
+            "release message": workflow.replace(
+                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"',
+                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^)"',
+            ),
+            "release validation base": workflow.replace(
+                '--base-ref "${v4032_release_base_sha}"', '--base-ref HEAD^^'
+            ),
+            "release tag phase": workflow.replace(
+                "--tag-phase", "--ordinary-phase"
+            ),
         }
         for name, mutation in mutations.items():
             with self.subTest(name=name), self.assertRaises(AssertionError):
@@ -1229,39 +1345,39 @@ class ReleaseGateTests(unittest.TestCase):
         script = self.v4032_subject_gate_script()
         cases = {
             "valid": (
-                "Qualification : repair v4.03.2 release qualification (#94)",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95)",
                 True,
             ),
             "bare": (
-                "Qualification : repair v4.03.2 release qualification",
+                "Qualification : repair v4.03.2 package lifecycle qualification",
                 False,
             ),
-            "zero": (
-                "Qualification : repair v4.03.2 release qualification (#0)",
+            "previous pull request": (
+                "Qualification : repair v4.03.2 package lifecycle qualification (#94)",
                 False,
             ),
-            "leading zero": (
-                "Qualification : repair v4.03.2 release qualification (#094)",
+            "different pull request": (
+                "Qualification : repair v4.03.2 package lifecycle qualification (#96)",
                 False,
             ),
             "non-numeric": (
-                "Qualification : repair v4.03.2 release qualification (#PR)",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#PR)",
                 False,
             ),
             "wrong version": (
-                "Qualification : repair v4.03.3 release qualification (#94)",
+                "Qualification : repair v4.03.3 package lifecycle qualification (#95)",
                 False,
             ),
             "double space": (
-                "Qualification : repair v4.03.2  release qualification (#94)",
+                "Qualification : repair v4.03.2  package lifecycle qualification (#95)",
                 False,
             ),
             "trailing space": (
-                "Qualification : repair v4.03.2 release qualification (#94) ",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95) ",
                 False,
             ),
             "extra text": (
-                "Qualification : repair v4.03.2 release qualification (#94) extra",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95) extra",
                 False,
             ),
         }
@@ -1289,6 +1405,7 @@ class ReleaseGateTests(unittest.TestCase):
             "extra file",
             "unchanged file",
             "mode",
+            "executable mode",
             "symlink",
             "rename",
             "delete",

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -27,7 +27,15 @@ def workflow_step(workflow: str, step_name: str) -> str:
     marker = f"      - name: {step_name}\n"
     if workflow.count(marker) != 1:
         raise AssertionError(f"expected exactly one workflow step named {step_name}")
-    step = workflow.split(marker, 1)[1].split("\n      - name:", 1)[0]
+    remainder = workflow.split(marker, 1)[1]
+    boundaries = []
+    next_step = remainder.find("\n      - name:")
+    if next_step >= 0:
+        boundaries.append(next_step)
+    next_job = re.search(r"(?m)^  [a-zA-Z0-9_-]+:\n", remainder)
+    if next_job is not None:
+        boundaries.append(next_job.start())
+    step = remainder[: min(boundaries)] if boundaries else remainder
     return marker + step
 
 
@@ -207,6 +215,34 @@ def run_runner_gate(
         )
         if context_overrides is not None:
             process_environment.update(context_overrides)
+        return subprocess.run(
+            ["/bin/bash", "-c", script],
+            cwd=REPOSITORY,
+            env=process_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+
+def run_arm_verdict(
+    script: str,
+    report: dict[str, object],
+    status: str = "0\n",
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        evidence_directory = Path(temporary)
+        (evidence_directory / "package-lifecycle-arm64.json").write_text(
+            json.dumps(report, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        (evidence_directory / "package-lifecycle-arm64.rc").write_text(
+            status,
+            encoding="utf-8",
+        )
+        process_environment = os.environ.copy()
+        process_environment["ARM_EVIDENCE_DIR"] = str(evidence_directory)
         return subprocess.run(
             ["/bin/bash", "-c", script],
             cwd=REPOSITORY,
@@ -666,8 +702,17 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"${EVENT_ACTOR}" != "${REPOSITORY_OWNER}"',
             '"${EVENT_TRIGGERING_ACTOR}" != "${REPOSITORY_OWNER}"',
             '"${RUN_ATTEMPT}" != "1"',
+            'podman_path="/usr/local/bin/podman"',
+            "for parent in /usr /usr/local /usr/local/bin; do",
+            '"$(stat -c \'%u:%g\' "${parent}")" != "0:0"',
+            "(( (8#${parent_mode} & 0022) != 0 ))",
+            '[[ ! -f "${podman_path}" || -L "${podman_path}"',
+            '! -x "${podman_path}"',
+            '"$(stat -c \'%u:%g\' "${podman_path}")" != "0:0"',
+            "(( (8#${podman_mode} & 0022) != 0 ))",
         ):
             self.assertIn(contract, arm_context)
+        self.assertNotIn("command -v podman", arm_context)
         self.assertNotIn("--tag-phase", self.workflow)
         self.assertNotIn("--require-tag", self.workflow)
 
@@ -887,7 +932,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
             '/usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py"',
-            '--podman /usr/bin/podman',
+            '--podman /usr/local/bin/podman',
             'sudo -n rm -f -- "${delegate_drop_in}"',
             'sudo -n test -e "${delegate_drop_in}"',
             'rm -f -- "${containers_override}"',
@@ -909,6 +954,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             self.assertNotIn(forbidden, script)
         self.assertEqual(script.count("sudo -n systemd-run"), 1)
         self.assertEqual(script.count("scripts/ci/package_lifecycle_lab.py"), 1)
+        self.assertNotIn("--podman /usr/bin/podman", self.workflow)
         ownership_guard = script.index(
             'if sudo -n test -e "${delegate_drop_in}"'
         )
@@ -1036,6 +1082,62 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
         self.assertIn('"${UPLOAD_OUTCOME}" != "success"', x64[verdict:])
         self.assertIn("all(.[]; . == 0)", x64[verdict:])
+
+    def test_arm64_failure_evidence_uploads_before_shard_verdict(self) -> None:
+        arm = workflow_job(self.workflow, "package-lifecycle-arm64")
+        upload = arm.index("Upload Native ARM64 Package Lifecycle Shard")
+        verdict = arm.index("Enforce Native ARM64 Package Lifecycle Verdict")
+        self.assertLess(upload, verdict)
+        verdict_script = workflow_step_script(
+            self.workflow, "Enforce Native ARM64 Package Lifecycle Verdict"
+        )
+        for contract in (
+            'shard_rc="$(cat "${status}")"',
+            '"${shard_rc}" != "0"',
+            '.status == "pass"',
+            ".harness_complete == true",
+            ".release_ready == true",
+            '(.blocker_ids | type == "array" and length == 0)',
+            '(.unexpected_failed_checks | type == "array" and length == 0)',
+            '(has("error") | not)',
+        ):
+            self.assertIn(contract, verdict_script)
+
+        valid_report: dict[str, object] = {
+            "status": "pass",
+            "harness_complete": True,
+            "release_ready": True,
+            "blocker_ids": [],
+            "unexpected_failed_checks": [],
+        }
+        accepted = run_arm_verdict(verdict_script, valid_report)
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        rejected_reports = (
+            {**valid_report, "status": "fail"},
+            {**valid_report, "harness_complete": False},
+            {**valid_report, "release_ready": False},
+            {**valid_report, "blocker_ids": ["arm64:blocker"]},
+            {
+                **valid_report,
+                "unexpected_failed_checks": ["arm64:unexpected"],
+            },
+            {**valid_report, "error": "harness failed"},
+        )
+        for report in rejected_reports:
+            with self.subTest(report=report):
+                rejected = run_arm_verdict(verdict_script, report)
+                self.assertNotEqual(rejected.returncode, 0)
+        rejected_rc = run_arm_verdict(verdict_script, valid_report, "1\n")
+        self.assertNotEqual(rejected_rc.returncode, 0)
+
+    def test_unsigned_inventory_diff_uses_supported_gnu_invocation(self) -> None:
+        inventory = workflow_step_script(
+            self.workflow, "Seal Exact Unsigned Qualification Evidence Inventory"
+        )
+        self.assertIn("diff -u", inventory)
+        self.assertNotIn("diff --no-index", inventory)
+        self.assertIn("exit 1", inventory)
 
     def test_hosted_gate_sign_seal_upload_cleanup_and_verdict_order_is_exact(self) -> None:
         hosted = workflow_job(self.workflow, "seal-release")

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
@@ -133,22 +133,61 @@ func SetupWAFLogForwarder() error {
 }
 
 func restartManagedService(service string) error {
-	state, err := system.ServiceManagerRuntimeState()
+	return restartManagedServiceUsing(
+		service,
+		system.ServiceManagerRuntimeState,
+		system.IsAlpine,
+		func(name string, args ...string) error {
+			return exec.Command(name, args...).Run() // #nosec G204 -- callers pass fixed product integration service constants
+		},
+	)
+}
+
+func restartManagedServiceUsing(
+	service string,
+	classify func() (string, error),
+	isAlpine func() bool,
+	run func(string, ...string) error,
+) error {
+	state, err := classify()
 	if err != nil {
 		return err
 	}
 	switch state {
 	case "OFFLINE":
-		fmt.Printf("[INFO] Service-manager runtime is offline; %s restart is deferred to boot.\n", service)
+		fmt.Printf("[INFO] Service-manager runtime is offline; %s activation is deferred to boot.\n", service)
 		return nil
 	case "ACTIVE":
-		if system.IsAlpine() {
-			if err := exec.Command("rc-service", service, "restart").Run(); err != nil { // #nosec G204 -- caller passes fixed product integration service constants
+		if isAlpine() {
+			if service == "rsyslog" {
+				// The firewall OpenRC service needs rsyslog and invokes the reload
+				// pipeline during start. Stopping that dependency here creates a
+				// circular OpenRC wait. Rsyslog on Alpine does not apply new rules
+				// after its nominal reload action, so restart it without traversing
+				// the dependency graph after validating the complete configuration.
+				if err := run("/usr/sbin/rsyslogd", "-N1", "-f", "/etc/rsyslog.conf"); err != nil {
+					return fmt.Errorf("validate rsyslog configuration before OpenRC restart: %w", err)
+				}
+				if err := run("/sbin/rc-service", "--ifnotstarted", service, "start"); err != nil {
+					return fmt.Errorf("conditionally start OpenRC service %s with dependencies: %w", service, err)
+				}
+				if err := run("/sbin/rc-service", service, "status"); err != nil {
+					return fmt.Errorf("attest active OpenRC service %s before dependency-bypassing restart: %w", service, err)
+				}
+				if err := run("/sbin/rc-service", "--nodeps", service, "restart"); err != nil {
+					return fmt.Errorf("restart OpenRC service %s without dependency traversal: %w", service, err)
+				}
+				if err := run("/sbin/rc-service", service, "status"); err != nil {
+					return fmt.Errorf("attest restarted OpenRC service %s: %w", service, err)
+				}
+				return nil
+			}
+			if err := run("/sbin/rc-service", service, "restart"); err != nil {
 				return fmt.Errorf("restart OpenRC service %s: %w", service, err)
 			}
 			return nil
 		}
-		if err := exec.Command("systemctl", "restart", service).Run(); err != nil { // #nosec G204 -- caller passes fixed product integration service constants
+		if err := run("systemctl", "restart", service); err != nil {
 			return fmt.Errorf("restart systemd service %s: %w", service, err)
 		}
 		return nil

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
@@ -64,3 +64,168 @@ func TestPrivateSELinuxPolicyWorkspaceCleansUpAfterFailure(t *testing.T) {
 		t.Fatalf("failed policy action left temporary artifacts: %#v", entries)
 	}
 }
+
+func TestRestartManagedServiceUsesOpenRCNodepsRestartForRsyslog_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return true },
+		func(name string, args ...string) error {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/sbin/rc-service --ifnotstarted rsyslog start",
+		"/sbin/rc-service rsyslog status",
+		"/sbin/rc-service --nodeps rsyslog restart",
+		"/sbin/rc-service rsyslog status",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("service-manager calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceKeepsOpenRCRestartForOtherServices_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsing(
+		"wazuh-agent",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return true },
+		func(name string, args ...string) error {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() error = %v", err)
+	}
+	if got, want := strings.Join(calls, "\n"), "/sbin/rc-service wazuh-agent restart"; got != want {
+		t.Fatalf("service-manager calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceKeepsSystemdRestartForRsyslog_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) error {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() error = %v", err)
+	}
+	if got, want := strings.Join(calls, "\n"), "systemctl restart rsyslog"; got != want {
+		t.Fatalf("service-manager calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceDefersOfflineWithoutCommand_SW_PKG_001(t *testing.T) {
+	called := false
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "OFFLINE", nil },
+		func() bool { return true },
+		func(string, ...string) error {
+			called = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() error = %v", err)
+	}
+	if called {
+		t.Fatal("offline service-manager state executed a runtime command")
+	}
+}
+
+func TestRestartManagedServiceFailsClosedOnUnknownStateAndRunnerError_SW_PKG_001(t *testing.T) {
+	t.Run("unknown state", func(t *testing.T) {
+		called := false
+		err := restartManagedServiceUsing(
+			"rsyslog",
+			func() (string, error) { return "UNKNOWN", nil },
+			func() bool { return true },
+			func(string, ...string) error {
+				called = true
+				return nil
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "refusing unrecognized service-manager runtime state") {
+			t.Fatalf("unknown-state error = %v", err)
+		}
+		if called {
+			t.Fatal("unknown service-manager state executed a runtime command")
+		}
+	})
+
+	for _, test := range []struct {
+		name          string
+		failCall      int
+		wantCalls     int
+		wantErrorText string
+	}{
+		{
+			name:          "configuration validation failure",
+			failCall:      1,
+			wantCalls:     1,
+			wantErrorText: "validate rsyslog configuration before OpenRC restart",
+		},
+		{
+			name:          "conditional start failure",
+			failCall:      2,
+			wantCalls:     2,
+			wantErrorText: "conditionally start OpenRC service rsyslog with dependencies",
+		},
+		{
+			name:          "pre-restart active-state failure",
+			failCall:      3,
+			wantCalls:     3,
+			wantErrorText: "attest active OpenRC service rsyslog before dependency-bypassing restart",
+		},
+		{
+			name:          "nodeps restart failure",
+			failCall:      4,
+			wantCalls:     4,
+			wantErrorText: "restart OpenRC service rsyslog without dependency traversal",
+		},
+		{
+			name:          "post-restart attestation failure",
+			failCall:      5,
+			wantCalls:     5,
+			wantErrorText: "attest restarted OpenRC service rsyslog",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sentinel := errors.New("synthetic service-manager failure")
+			calls := 0
+			err := restartManagedServiceUsing(
+				"rsyslog",
+				func() (string, error) { return "ACTIVE", nil },
+				func() bool { return true },
+				func(string, ...string) error {
+					calls++
+					if calls == test.failCall {
+						return sentinel
+					}
+					return nil
+				},
+			)
+			if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), test.wantErrorText) {
+				t.Fatalf("OpenRC activation error = %v", err)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("runtime commands after failure = %d, want %d", calls, test.wantCalls)
+			}
+		})
+	}
+}

--- a/src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go
+++ b/src/core/syswarden-cli/pkg/security/hardening_linux_helpers.go
@@ -22,6 +22,8 @@ import (
 
 const hardeningMaximumFileSize = 4 << 20
 
+const hardeningOpenRCRuntimePath = "/run/openrc"
+
 type hardeningExecutor struct {
 	run    func(name string, args ...string) error
 	output func(name string, args ...string) ([]byte, error)
@@ -288,14 +290,24 @@ func productionHardeningExecutionDecision() (hardeningExecutionDecision, error) 
 			return hardeningExecutionDecision{}, err
 		}
 	}
-	openRCParent, err := inspectRuntimeDirectory("/run/openrc", 0)
+	openRCProof, openRCParent, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+		hardeningOpenRCRuntimePath,
+		0,
+		0,
+	)
 	if err != nil {
 		return hardeningExecutionDecision{}, err
 	}
+	if openRCProof != nil {
+		defer func() { _ = openRCProof.directory.Close() }()
+	}
 	openRCActive := false
 	if openRCParent {
-		openRCActive, err = inspectRuntimeFile("/run/openrc/softlevel", 0)
+		openRCActive, err = inspectRuntimeFile(filepath.Join(hardeningOpenRCRuntimePath, "softlevel"), 0)
 		if err != nil {
+			return hardeningExecutionDecision{}, err
+		}
+		if err := openRCProof.reattest(0, 0); err != nil {
 			return hardeningExecutionDecision{}, err
 		}
 	}
@@ -400,6 +412,95 @@ func inspectRuntimeDirectory(path string, expectedUID uint32) (bool, error) {
 		return false, fmt.Errorf("runtime directory changed while opening: %s", path)
 	}
 	return true, nil
+}
+
+type hardeningOpenRCRuntimeDirectoryProof struct {
+	path      string
+	directory *os.File
+	info      os.FileInfo
+}
+
+func safeHardeningOpenRCRuntimeDirectory(info os.FileInfo, expectedUID, expectedGID uint32) bool {
+	if info == nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	unsafeMode := os.ModeSymlink | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+	if !ok || !info.IsDir() || info.Mode()&unsafeMode != 0 ||
+		stat.Uid != expectedUID || stat.Gid != expectedGID {
+		return false
+	}
+	return info.Mode().Perm() == 0755 || info.Mode().Perm() == 0775
+}
+
+func sameHardeningOpenRCRuntimeDirectory(
+	first os.FileInfo,
+	second os.FileInfo,
+	expectedUID uint32,
+	expectedGID uint32,
+) bool {
+	return first != nil && second != nil && os.SameFile(first, second) &&
+		first.Mode() == second.Mode() &&
+		safeHardeningOpenRCRuntimeDirectory(first, expectedUID, expectedGID) &&
+		safeHardeningOpenRCRuntimeDirectory(second, expectedUID, expectedGID)
+}
+
+func beginHardeningOpenRCRuntimeDirectoryAttestation(
+	path string,
+	expectedUID uint32,
+	expectedGID uint32,
+) (*hardeningOpenRCRuntimeDirectoryProof, bool, error) {
+	if filepath.Clean(path) != path {
+		return nil, false, fmt.Errorf("refusing non-canonical OpenRC runtime directory %s", path)
+	}
+	before, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect OpenRC runtime directory %s: %w", path, err)
+	}
+	if !safeHardeningOpenRCRuntimeDirectory(before, expectedUID, expectedGID) {
+		return nil, false, fmt.Errorf("refusing unsafe OpenRC runtime directory %s", path)
+	}
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, false, fmt.Errorf("open OpenRC runtime directory %s: %w", path, err)
+	}
+	directory := os.NewFile(uintptr(fd), path)
+	if directory == nil {
+		_ = syscall.Close(fd)
+		return nil, false, fmt.Errorf("open OpenRC runtime directory %s", path)
+	}
+	opened, statErr := directory.Stat()
+	if statErr != nil || !sameHardeningOpenRCRuntimeDirectory(
+		before,
+		opened,
+		expectedUID,
+		expectedGID,
+	) {
+		_ = directory.Close()
+		return nil, false, fmt.Errorf("OpenRC runtime directory %s changed while opening", path)
+	}
+	return &hardeningOpenRCRuntimeDirectoryProof{
+		path:      path,
+		directory: directory,
+		info:      opened,
+	}, true, nil
+}
+
+func (proof *hardeningOpenRCRuntimeDirectoryProof) reattest(expectedUID, expectedGID uint32) error {
+	if proof == nil || proof.directory == nil {
+		return fmt.Errorf("OpenRC runtime directory proof is unavailable")
+	}
+	opened, openedErr := proof.directory.Stat()
+	after, afterErr := os.Lstat(proof.path)
+	if openedErr != nil || afterErr != nil ||
+		!sameHardeningOpenRCRuntimeDirectory(proof.info, opened, expectedUID, expectedGID) ||
+		!sameHardeningOpenRCRuntimeDirectory(proof.info, after, expectedUID, expectedGID) {
+		return fmt.Errorf("OpenRC runtime directory %s changed while attesting", proof.path)
+	}
+	return nil
 }
 
 func inspectRuntimeFile(path string, expectedUID uint32) (bool, error) {

--- a/src/core/syswarden-cli/pkg/security/hardening_linux_test.go
+++ b/src/core/syswarden-cli/pkg/security/hardening_linux_test.go
@@ -751,6 +751,210 @@ func TestRuntimeMarkerInspectionRejectsUnsafeState(t *testing.T) {
 	})
 }
 
+func TestOpenRCRuntimeDirectoryAttestationAcceptsOnlyExactStandardModes(t *testing.T) {
+	ownerRoot := t.TempDir()
+	ownerInfo, err := os.Stat(ownerRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerStat, ok := ownerInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("fixture ownership is unavailable")
+	}
+
+	for _, mode := range []os.FileMode{0755, 0775} {
+		t.Run(mode.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "openrc")
+			if err := os.Mkdir(path, 0750); err != nil {
+				t.Fatal(err)
+			}
+			if err := chmodHardeningFixture(path, mode); err != nil {
+				t.Fatal(err)
+			}
+			proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+				path,
+				ownerStat.Uid,
+				ownerStat.Gid,
+			)
+			if err != nil || !present || proof == nil {
+				t.Fatalf("proof=%v present=%t error=%v", proof, present, err)
+			}
+			defer func() { _ = proof.directory.Close() }()
+			if err := proof.reattest(ownerStat.Uid, ownerStat.Gid); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestOpenRCRuntimeDirectoryAttestationRejectsUnsafeState(t *testing.T) {
+	ownerRoot := t.TempDir()
+	ownerInfo, err := os.Stat(ownerRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerStat, ok := ownerInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("fixture ownership is unavailable")
+	}
+
+	tests := []struct {
+		name        string
+		mode        os.FileMode
+		expectedUID uint32
+		expectedGID uint32
+	}{
+		{name: "mode 0770", mode: 0770, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid},
+		{name: "mode 0777", mode: 0777, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid},
+		{name: "sticky", mode: 0775 | os.ModeSticky, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid},
+		{name: "setuid", mode: 0775 | os.ModeSetuid, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid},
+		{name: "setgid", mode: 0775 | os.ModeSetgid, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid},
+		{name: "wrong owner", mode: 0775, expectedUID: ownerStat.Uid ^ 1, expectedGID: ownerStat.Gid},
+		{name: "wrong group", mode: 0775, expectedUID: ownerStat.Uid, expectedGID: ownerStat.Gid ^ 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "openrc")
+			if err := os.Mkdir(path, 0750); err != nil {
+				t.Fatal(err)
+			}
+			if err := chmodHardeningFixture(path, test.mode); err != nil {
+				t.Fatal(err)
+			}
+			proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+				path,
+				test.expectedUID,
+				test.expectedGID,
+			)
+			if proof != nil {
+				_ = proof.directory.Close()
+			}
+			if err == nil || present || proof != nil {
+				t.Fatalf("unsafe OpenRC runtime accepted: proof=%v present=%t error=%v", proof, present, err)
+			}
+		})
+	}
+
+	t.Run("symlink", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "target")
+		if err := os.Mkdir(target, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := chmodHardeningFixture(target, 0775); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(root, "openrc")
+		if err := os.Symlink("target", path); err != nil {
+			t.Fatal(err)
+		}
+		if proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+			path,
+			ownerStat.Uid,
+			ownerStat.Gid,
+		); err == nil || present || proof != nil {
+			t.Fatalf("symlink OpenRC runtime accepted: proof=%v present=%t error=%v", proof, present, err)
+		}
+	})
+
+	t.Run("regular file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "openrc")
+		if err := writeHardeningFixtureFile(path, []byte("not a directory\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+			path,
+			ownerStat.Uid,
+			ownerStat.Gid,
+		); err == nil || present || proof != nil {
+			t.Fatalf("regular-file OpenRC runtime accepted: proof=%v present=%t error=%v", proof, present, err)
+		}
+	})
+
+	t.Run("generic policy remains strict", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "systemd")
+		if err := os.Mkdir(path, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := chmodHardeningFixture(path, 0775); err != nil {
+			t.Fatal(err)
+		}
+		if present, err := inspectRuntimeDirectory(path, ownerStat.Uid); err == nil || present {
+			t.Fatalf("generic runtime policy accepted mode 0775: present=%t error=%v", present, err)
+		}
+	})
+}
+
+func TestOpenRCRuntimeDirectoryProofRejectsReplacementAndModeDrift(t *testing.T) {
+	ownerRoot := t.TempDir()
+	ownerInfo, err := os.Stat(ownerRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerStat, ok := ownerInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("fixture ownership is unavailable")
+	}
+
+	t.Run("replacement", func(t *testing.T) {
+		root := t.TempDir()
+		path := filepath.Join(root, "openrc")
+		if err := os.Mkdir(path, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := chmodHardeningFixture(path, 0775); err != nil {
+			t.Fatal(err)
+		}
+		proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+			path,
+			ownerStat.Uid,
+			ownerStat.Gid,
+		)
+		if err != nil || !present || proof == nil {
+			t.Fatalf("proof=%v present=%t error=%v", proof, present, err)
+		}
+		defer func() { _ = proof.directory.Close() }()
+		original := filepath.Join(root, "original")
+		if err := os.Rename(path, original); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(path, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := chmodHardeningFixture(path, 0775); err != nil {
+			t.Fatal(err)
+		}
+		if err := proof.reattest(ownerStat.Uid, ownerStat.Gid); err == nil {
+			t.Fatal("replacement OpenRC runtime was accepted")
+		}
+	})
+
+	t.Run("mode drift", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "openrc")
+		if err := os.Mkdir(path, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := chmodHardeningFixture(path, 0775); err != nil {
+			t.Fatal(err)
+		}
+		proof, present, err := beginHardeningOpenRCRuntimeDirectoryAttestation(
+			path,
+			ownerStat.Uid,
+			ownerStat.Gid,
+		)
+		if err != nil || !present || proof == nil {
+			t.Fatalf("proof=%v present=%t error=%v", proof, present, err)
+		}
+		defer func() { _ = proof.directory.Close() }()
+		if err := chmodHardeningFixture(path, 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := proof.reattest(ownerStat.Uid, ownerStat.Gid); err == nil {
+			t.Fatal("OpenRC runtime mode drift was accepted")
+		}
+	})
+}
+
 func TestSysctlPersistentPolicyWhenKernelRuntimeIsOutsideNamespace(t *testing.T) {
 	commands := 0
 	host := hardeningTestHost(t, hardeningExecutor{

--- a/src/core/syswarden-cli/pkg/system/firewall_optimizer.go
+++ b/src/core/syswarden-cli/pkg/system/firewall_optimizer.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"syswarden-cli/config"
 	"time"
@@ -116,6 +117,52 @@ func (output *boundedFirewallPreflightOutput) Write(content []byte) (int, error)
 	return len(content), nil
 }
 
+type boundedFirewallPreflightStreams struct {
+	mutex    sync.Mutex
+	stdout   bytes.Buffer
+	stderr   bytes.Buffer
+	captured int
+	exceeded bool
+}
+
+type boundedFirewallPreflightStreamWriter struct {
+	streams *boundedFirewallPreflightStreams
+	target  *bytes.Buffer
+}
+
+func (writer *boundedFirewallPreflightStreamWriter) Write(content []byte) (int, error) {
+	writer.streams.mutex.Lock()
+	defer writer.streams.mutex.Unlock()
+
+	remaining := maximumFirewallPreflightOutput - writer.streams.captured
+	if remaining > 0 {
+		written := len(content)
+		if written > remaining {
+			written = remaining
+		}
+		_, _ = writer.target.Write(content[:written])
+		writer.streams.captured += written
+	}
+	if len(content) > remaining {
+		writer.streams.exceeded = true
+	}
+	return len(content), nil
+}
+
+func (streams *boundedFirewallPreflightStreams) snapshot() ([]byte, []byte, bool) {
+	streams.mutex.Lock()
+	defer streams.mutex.Unlock()
+	stdout := append([]byte(nil), streams.stdout.Bytes()...)
+	stderr := append([]byte(nil), streams.stderr.Bytes()...)
+	return stdout, stderr, streams.exceeded
+}
+
+func firewallPreflightCommandEvidence(stdout, stderr []byte) []byte {
+	evidence := make([]byte, 0, len(stdout)+len(stderr))
+	evidence = append(evidence, stdout...)
+	return append(evidence, stderr...)
+}
+
 func validateResolvedFirewallExecutable(path string) error {
 	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return fmt.Errorf("firewall preflight executable path %q is not a clean absolute path", path)
@@ -186,21 +233,28 @@ func runFirewallPreflightCommandWithTimeout(path string, timeout time.Duration, 
 		}
 		return err
 	}
-	output := &boundedFirewallPreflightOutput{}
-	command.Stdout = output
-	command.Stderr = output
+	streams := &boundedFirewallPreflightStreams{}
+	command.Stdout = &boundedFirewallPreflightStreamWriter{streams: streams, target: &streams.stdout}
+	command.Stderr = &boundedFirewallPreflightStreamWriter{streams: streams, target: &streams.stderr}
 	err := command.Run()
 	if errors.Is(err, exec.ErrWaitDelay) && command.Process != nil {
 		_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 	}
-	content := append([]byte(nil), output.content.Bytes()...)
-	if output.exceeded {
-		return content, fmt.Errorf("firewall preflight command output exceeds %d bytes", maximumFirewallPreflightOutput)
+	stdout, stderr, exceeded := streams.snapshot()
+	if exceeded {
+		return firewallPreflightCommandEvidence(stdout, stderr), fmt.Errorf(
+			"firewall preflight command output exceeds %d bytes", maximumFirewallPreflightOutput,
+		)
 	}
 	if ctx.Err() != nil {
-		return content, fmt.Errorf("firewall preflight command exceeded %s: %w", timeout, ctx.Err())
+		return firewallPreflightCommandEvidence(stdout, stderr), fmt.Errorf(
+			"firewall preflight command exceeded %s: %w", timeout, ctx.Err(),
+		)
 	}
-	return content, err
+	if err != nil {
+		return firewallPreflightCommandEvidence(stdout, stderr), err
+	}
+	return stdout, nil
 }
 
 func queryFirewallProperty(

--- a/src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go
+++ b/src/core/syswarden-cli/pkg/system/firewall_optimizer_test.go
@@ -822,6 +822,42 @@ func TestValidateResolvedFirewallExecutableRejectsUnsafeTargets_SW2_FWBACKEND_01
 
 func TestRunFirewallPreflightCommandIsTimeAndOutputBounded_SW2_FWBACKEND_015(t *testing.T) {
 	directory := firewallPreflightTestDirectory(t)
+	t.Run("successful-rpm-output-excludes-stderr-warning", func(t *testing.T) {
+		path := writeFirewallPreflightTestExecutable(
+			t,
+			directory,
+			"rpm-warning",
+			"printf 'systemd\\t259.5-1.fc44\\tx86_64\\t8\\n'\n"+
+				"printf 'warning: waiting for RPM database lock\\n' >&2",
+			0700,
+		)
+		output, err := runFirewallPreflightCommandWithTimeout(path, time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		const expected = "systemd\t259.5-1.fc44\tx86_64\t8\n"
+		if string(output) != expected {
+			t.Fatalf("successful output = %q, want %q", output, expected)
+		}
+	})
+	t.Run("nonzero-retains-stdout-and-stderr", func(t *testing.T) {
+		path := writeFirewallPreflightTestExecutable(
+			t,
+			directory,
+			"failed-rpm-query",
+			"printf 'partial-rpm-stdout\\n'\nprintf 'rpm-stderr-proof\\n' >&2\nexit 7",
+			0700,
+		)
+		output, err := runFirewallPreflightCommandWithTimeout(path, time.Second)
+		if err == nil || !strings.Contains(err.Error(), "exit status 7") {
+			t.Fatalf("command error = %v", err)
+		}
+		for _, proof := range []string{"partial-rpm-stdout\n", "rpm-stderr-proof\n"} {
+			if !strings.Contains(string(output), proof) {
+				t.Fatalf("failure output %q does not retain %q", output, proof)
+			}
+		}
+	})
 	t.Run("output", func(t *testing.T) {
 		path := writeFirewallPreflightTestExecutable(
 			t,
@@ -836,6 +872,28 @@ func TestRunFirewallPreflightCommandIsTimeAndOutputBounded_SW2_FWBACKEND_015(t *
 		}
 		if len(output) != maximumFirewallPreflightOutput {
 			t.Fatalf("captured output = %d bytes, want %d", len(output), maximumFirewallPreflightOutput)
+		}
+	})
+	t.Run("combined-output", func(t *testing.T) {
+		path := writeFirewallPreflightTestExecutable(
+			t,
+			directory,
+			"combined-oversized",
+			"printf 'stdout-proof\\n'\nhead -c 40000 /dev/zero\n"+
+				"printf 'stderr-proof\\n' >&2\nhead -c 40000 /dev/zero >&2",
+			0700,
+		)
+		output, err := runFirewallPreflightCommandWithTimeout(path, time.Second)
+		if err == nil || !strings.Contains(err.Error(), "output exceeds") {
+			t.Fatalf("command error = %v", err)
+		}
+		if len(output) != maximumFirewallPreflightOutput {
+			t.Fatalf("combined output = %d bytes, want %d", len(output), maximumFirewallPreflightOutput)
+		}
+		for _, proof := range []string{"stdout-proof\n", "stderr-proof\n"} {
+			if !strings.Contains(string(output), proof) {
+				t.Fatalf("combined output does not retain %q", proof)
+			}
 		}
 	})
 	t.Run("timeout", func(t *testing.T) {

--- a/src/core/syswarden-cli/pkg/system/service_linux.go
+++ b/src/core/syswarden-cli/pkg/system/service_linux.go
@@ -63,6 +63,7 @@ name="syswarden-firewall"
 description="SYSWARDEN Firewall Persistence & Engine Loader"
 
 depend() {
+	need net rsyslog cronie
 	before syswarden-core
 }
 
@@ -72,6 +73,23 @@ start() {
 	eend $?
 }
 `
+	historicalV4028OpenRCFirewallService = `#!/sbin/openrc-run
+
+name="syswarden-firewall"
+description="SYSWARDEN Firewall Persistence & Engine Loader"
+
+depend() {
+	before syswarden-core
+}
+
+start() {
+	ebegin "Loading SYSWARDEN Firewall Persistence"
+	/opt/syswarden/bin/syswarden-cli reload --no-restart
+	eend $?
+}
+`
+	historicalV4028OpenRCFirewallServiceLength = 269
+	historicalV4028OpenRCFirewallServiceSHA256 = "82a936e4f9ce394d6cc0ffd3978a1842a899570842ab5d283184384e73af5905"
 
 	systemdCoreService = `[Unit]
 Description=SYSWARDEN WAF and Core Engine
@@ -138,6 +156,21 @@ WantedBy=multi-user.target
 
 	systemdFirewallService = `[Unit]
 Description=SYSWARDEN Firewall Persistence & Engine Loader
+After=network-online.target rsyslog.service cron.service crond.service
+Wants=network-online.target
+Before=syswarden-core.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/opt/syswarden/bin/syswarden-cli reload --no-restart
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`
+	historicalV4028SystemdFirewallService = `[Unit]
+Description=SYSWARDEN Firewall Persistence & Engine Loader
 After=network-online.target
 Wants=network-online.target
 Before=syswarden-core.service
@@ -151,6 +184,8 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 `
+	historicalV4028SystemdFirewallServiceLength = 307
+	historicalV4028SystemdFirewallServiceSHA256 = "bc730793c007273a380261155b7602571c42efd93972f45ad2dd440f98251724"
 )
 
 var (
@@ -231,7 +266,20 @@ func classifyServiceManagerRuntimePaths(
 			return serviceManagerAmbiguous, fmt.Errorf("inspect systemd runtime parent %s: %w", systemdParent, err)
 		}
 	}
-	expectedPresent, err := attestRuntimeDirectory(expectedPath, hostStat.Uid, hostStat.Gid)
+	var openRCRuntimeProof *openRCRuntimeDirectoryProof
+	var expectedPresent bool
+	if alpine {
+		openRCRuntimeProof, expectedPresent, err = beginOpenRCRuntimeDirectoryAttestation(
+			expectedPath,
+			hostStat.Uid,
+			hostStat.Gid,
+		)
+		if openRCRuntimeProof != nil {
+			defer func() { _ = openRCRuntimeProof.directory.Close() }()
+		}
+	} else {
+		expectedPresent, err = attestRuntimeDirectory(expectedPath, hostStat.Uid, hostStat.Gid)
+	}
 	if err != nil {
 		return serviceManagerAmbiguous, err
 	}
@@ -245,7 +293,13 @@ func classifyServiceManagerRuntimePaths(
 	if expectedPresent {
 		pid1CommPath := filepath.Join(hostRoot, "proc", "1", "comm")
 		if alpine {
-			if err := attestOpenRCRuntime(expectedPath, pid1CommPath, hostStat.Uid, hostStat.Gid); err != nil {
+			if err := attestOpenRCRuntime(
+				expectedPath,
+				pid1CommPath,
+				hostStat.Uid,
+				hostStat.Gid,
+				openRCRuntimeProof,
+			); err != nil {
 				return serviceManagerAmbiguous, err
 			}
 		} else if err := attestSystemdRuntime(pid1CommPath, filepath.Join(hostRoot, "proc", "1", "exe"), hostStat.Uid, hostStat.Gid); err != nil {
@@ -290,6 +344,90 @@ func attestRuntimeDirectory(path string, expectedUID, expectedGID uint32) (bool,
 	return true, nil
 }
 
+type openRCRuntimeDirectoryProof struct {
+	path      string
+	directory *os.File
+	info      os.FileInfo
+}
+
+func safeOpenRCRuntimeDirectory(info os.FileInfo, expectedUID, expectedGID uint32) bool {
+	if info == nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	unsafeMode := os.ModeSymlink | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+	if !ok || !info.IsDir() || info.Mode()&unsafeMode != 0 ||
+		stat.Uid != expectedUID || stat.Gid != expectedGID {
+		return false
+	}
+	return info.Mode().Perm() == 0755 || info.Mode().Perm() == 0775
+}
+
+func sameOpenRCRuntimeDirectory(
+	first os.FileInfo,
+	second os.FileInfo,
+	expectedUID uint32,
+	expectedGID uint32,
+) bool {
+	return first != nil && second != nil && os.SameFile(first, second) &&
+		first.Mode() == second.Mode() &&
+		safeOpenRCRuntimeDirectory(first, expectedUID, expectedGID) &&
+		safeOpenRCRuntimeDirectory(second, expectedUID, expectedGID)
+}
+
+func beginOpenRCRuntimeDirectoryAttestation(
+	path string,
+	expectedUID uint32,
+	expectedGID uint32,
+) (*openRCRuntimeDirectoryProof, bool, error) {
+	if filepath.Clean(path) != path {
+		return nil, false, fmt.Errorf("refusing non-canonical service-manager runtime %s", path)
+	}
+	before, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect service-manager runtime %s: %w", path, err)
+	}
+	if !safeOpenRCRuntimeDirectory(before, expectedUID, expectedGID) {
+		return nil, false, fmt.Errorf("refusing unsafe service-manager runtime %s", path)
+	}
+	directory, err := os.Open(path) // #nosec G304 -- the expected OpenRC runtime is lstat/fstat identity attested
+	if err != nil {
+		return nil, false, fmt.Errorf("open service-manager runtime %s: %w", path, err)
+	}
+	opened, statErr := directory.Stat()
+	if statErr != nil || !sameOpenRCRuntimeDirectory(
+		before,
+		opened,
+		expectedUID,
+		expectedGID,
+	) {
+		_ = directory.Close()
+		return nil, false, fmt.Errorf("service-manager runtime %s changed while opening", path)
+	}
+	return &openRCRuntimeDirectoryProof{
+		path:      path,
+		directory: directory,
+		info:      opened,
+	}, true, nil
+}
+
+func (proof *openRCRuntimeDirectoryProof) reattest(expectedUID, expectedGID uint32) error {
+	if proof == nil || proof.directory == nil {
+		return fmt.Errorf("OpenRC service-manager runtime proof is unavailable")
+	}
+	opened, openedErr := proof.directory.Stat()
+	after, afterErr := os.Lstat(proof.path)
+	if openedErr != nil || afterErr != nil ||
+		!sameOpenRCRuntimeDirectory(proof.info, opened, expectedUID, expectedGID) ||
+		!sameOpenRCRuntimeDirectory(proof.info, after, expectedUID, expectedGID) {
+		return fmt.Errorf("OpenRC service-manager runtime %s changed while attesting", proof.path)
+	}
+	return nil
+}
+
 func readAttestedRuntimeFile(path string, expectedUID, expectedGID uint32, limit int64) (string, error) {
 	before, err := os.Lstat(path)
 	if err != nil {
@@ -317,7 +455,16 @@ func readAttestedRuntimeFile(path string, expectedUID, expectedGID uint32, limit
 	return string(content), nil
 }
 
-func attestOpenRCRuntime(runtimePath, pid1CommPath string, expectedUID, expectedGID uint32) error {
+func attestOpenRCRuntime(
+	runtimePath string,
+	pid1CommPath string,
+	expectedUID uint32,
+	expectedGID uint32,
+	runtimeProof *openRCRuntimeDirectoryProof,
+) error {
+	if runtimeProof == nil || runtimeProof.path != runtimePath {
+		return fmt.Errorf("OpenRC service-manager runtime proof does not match %s", runtimePath)
+	}
 	softlevel, err := readAttestedRuntimeFile(filepath.Join(runtimePath, "softlevel"), expectedUID, expectedGID, 64)
 	if err != nil {
 		return fmt.Errorf("attest OpenRC softlevel: %w", err)
@@ -339,7 +486,7 @@ func attestOpenRCRuntime(runtimePath, pid1CommPath string, expectedUID, expected
 	if comm != "init\n" && comm != "openrc-init\n" {
 		return fmt.Errorf("PID 1 identity %q is not coherent with OpenRC", strings.TrimSpace(comm))
 	}
-	return nil
+	return runtimeProof.reattest(expectedUID, expectedGID)
 }
 
 func attestSystemdRuntime(pid1CommPath, pid1ExecutablePath string, expectedUID, expectedGID uint32) error {
@@ -1749,7 +1896,12 @@ func publishOpenRCServices() error {
 			historicalContentLength: historicalV4028OpenRCCoreServiceLength,
 			historicalContentSHA256: historicalV4028OpenRCCoreServiceSHA256,
 		},
-		{path: filepath.Join(serviceOpenRCUnitDir, "syswarden-firewall"), content: openRCFirewallService, mode: 0755},
+		{
+			path: filepath.Join(serviceOpenRCUnitDir, "syswarden-firewall"), content: openRCFirewallService, mode: 0755,
+			historicalContent:       historicalV4028OpenRCFirewallService,
+			historicalContentLength: historicalV4028OpenRCFirewallServiceLength,
+			historicalContentSHA256: historicalV4028OpenRCFirewallServiceSHA256,
+		},
 		{path: filepath.Join(serviceOpenRCRunlevelDir, "syswarden-core"), target: "/etc/init.d/syswarden-core"},
 		{path: filepath.Join(serviceOpenRCRunlevelDir, "syswarden-firewall"), target: "/etc/init.d/syswarden-firewall"},
 	})
@@ -1765,7 +1917,12 @@ func publishSystemdServices() error {
 			historicalContentLength: historicalV4028SystemdCoreServiceLength,
 			historicalContentSHA256: historicalV4028SystemdCoreServiceSHA256,
 		},
-		{path: firewallUnitPath, content: systemdFirewallService, mode: 0600},
+		{
+			path: firewallUnitPath, content: systemdFirewallService, mode: 0600,
+			historicalContent:       historicalV4028SystemdFirewallService,
+			historicalContentLength: historicalV4028SystemdFirewallServiceLength,
+			historicalContentSHA256: historicalV4028SystemdFirewallServiceSHA256,
+		},
 		{
 			path: filepath.Join(serviceSystemdWantsDir, "syswarden-core.service"), target: "../syswarden-core.service",
 			legacyTargets:    []string{"/etc/systemd/system/syswarden-core.service"},

--- a/src/core/syswarden-cli/pkg/system/service_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/service_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -55,26 +56,74 @@ func TestClassifyServiceManagerRuntime(t *testing.T) {
 		}, want: serviceManagerActive},
 		{name: "systemd-stale-directory", packageInstall: "1", prepare: func(t *testing.T, _ string) { t.Helper(); mustMkdirAll(t, serviceSystemdRuntimePath) }, want: serviceManagerAmbiguous, wantErr: true},
 		{name: "openrc-active", alpine: true, prepare: func(t *testing.T, root string) { t.Helper(); mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath) }, want: serviceManagerActive},
+		{name: "openrc-standard-group-writable-runtime", alpine: true, prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0775)
+		}, want: serviceManagerActive},
 		{name: "openrc-stale-directory", alpine: true, packageInstall: "1", prepare: func(t *testing.T, _ string) { t.Helper(); mustMkdirAll(t, serviceOpenRCRuntimePath) }, want: serviceManagerAmbiguous, wantErr: true},
 		{name: "openrc-pid1-mismatch", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
 			t.Helper()
 			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
 			mustWriteFile(t, filepath.Join(root, "proc", "1", "comm"), "systemd\n")
 		}, want: serviceManagerAmbiguous, wantErr: true},
-		{name: "openrc-writable-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+		{name: "openrc-nonstandard-owner-only-mode", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
 			t.Helper()
 			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
-			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0775)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0700)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "openrc-nonstandard-group-mode", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0770)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "openrc-world-writable-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0777)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "openrc-sticky-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, os.ModeSticky|0775)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "openrc-setgid-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, os.ModeSetgid|0775)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "openrc-setuid-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedOpenRCRuntime(t, root, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, os.ModeSetuid|0775)
 		}, want: serviceManagerAmbiguous, wantErr: true},
 		{name: "systemd-offline-package", packageInstall: "1", want: serviceManagerOffline},
 		{name: "openrc-offline-package", alpine: true, packageInstall: "1", want: serviceManagerOffline},
 		{name: "missing-outside-package", want: serviceManagerAmbiguous, wantErr: true},
 		{name: "wrong-package-marker", packageInstall: "true", want: serviceManagerAmbiguous, wantErr: true},
 		{name: "conflicting-runtime", packageInstall: "1", prepare: func(t *testing.T, _ string) { t.Helper(); mustMkdirAll(t, serviceOpenRCRuntimePath) }, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "competing-openrc-standard-mode-remains-unsafe", packageInstall: "1", prepare: func(t *testing.T, _ string) {
+			t.Helper()
+			mustMkdirAll(t, serviceOpenRCRuntimePath)
+			mustChmodTestPath(t, serviceOpenRCRuntimePath, 0775)
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "systemd-runtime-keeps-generic-mode-policy", packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			mustSeedSystemdRuntime(t, root, serviceSystemdRuntimePath)
+			mustChmodTestPath(t, serviceSystemdRuntimePath, 0775)
+		}, want: serviceManagerAmbiguous, wantErr: true},
 		{name: "symlinked-runtime", packageInstall: "1", prepare: func(t *testing.T, root string) {
 			t.Helper()
 			mustMkdirAll(t, filepath.Dir(serviceSystemdRuntimePath))
 			if err := os.Symlink(filepath.Join(root, "run"), serviceSystemdRuntimePath); err != nil {
+				t.Fatal(err)
+			}
+		}, want: serviceManagerAmbiguous, wantErr: true},
+		{name: "symlinked-openrc-runtime", alpine: true, packageInstall: "1", prepare: func(t *testing.T, root string) {
+			t.Helper()
+			realRuntime := filepath.Join(root, "real-openrc")
+			mustSeedOpenRCRuntime(t, root, realRuntime)
+			if err := os.Symlink(realRuntime, serviceOpenRCRuntimePath); err != nil {
 				t.Fatal(err)
 			}
 		}, want: serviceManagerAmbiguous, wantErr: true},
@@ -144,7 +193,118 @@ func mustReadTestFile(t *testing.T, path string) []byte {
 func mustSeedOpenRCRuntime(t *testing.T, root, runtimePath string) {
 	t.Helper()
 	mustWriteFile(t, filepath.Join(runtimePath, "softlevel"), "default\n")
+	mustChmodTestPath(t, runtimePath, 0755)
 	mustWriteFile(t, filepath.Join(root, "proc", "1", "comm"), "init\n")
+}
+
+func TestOpenRCRuntimeDirectoryAttestationRejectsOwnershipMismatch(t *testing.T) {
+	root := t.TempDir()
+	runtimePath := filepath.Join(root, "run", "openrc")
+	mustSeedOpenRCRuntime(t, root, runtimePath)
+	info, err := os.Lstat(runtimePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("OpenRC runtime ownership is unavailable")
+	}
+	for _, test := range []struct {
+		name string
+		uid  uint32
+		gid  uint32
+	}{
+		{name: "uid", uid: stat.Uid ^ 1, gid: stat.Gid},
+		{name: "gid", uid: stat.Uid, gid: stat.Gid ^ 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			proof, present, err := beginOpenRCRuntimeDirectoryAttestation(
+				runtimePath,
+				test.uid,
+				test.gid,
+			)
+			if err == nil || present || proof != nil ||
+				!strings.Contains(err.Error(), "refusing unsafe service-manager runtime") {
+				t.Fatalf("ownership mismatch = %v, %v, %v", proof, present, err)
+			}
+		})
+	}
+}
+
+func TestOpenRCRuntimeDirectoryAttestationRejectsNonCanonicalPath(t *testing.T) {
+	root := t.TempDir()
+	runtimePath := filepath.Join(root, "run", "openrc")
+	mustSeedOpenRCRuntime(t, root, runtimePath)
+	info, err := os.Lstat(runtimePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("OpenRC runtime ownership is unavailable")
+	}
+	proof, present, err := beginOpenRCRuntimeDirectoryAttestation(
+		runtimePath+"/../openrc",
+		stat.Uid,
+		stat.Gid,
+	)
+	if err == nil || present || proof != nil ||
+		!strings.Contains(err.Error(), "refusing non-canonical service-manager runtime") {
+		t.Fatalf("non-canonical OpenRC runtime path = %v, %v, %v", proof, present, err)
+	}
+}
+
+func TestOpenRCRuntimeDirectoryAttestationRejectsMetadataAndIdentityDrift(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(t *testing.T, root, runtimePath string)
+	}{
+		{
+			name: "mode",
+			mutate: func(t *testing.T, _, runtimePath string) {
+				t.Helper()
+				mustChmodTestPath(t, runtimePath, 0770)
+			},
+		},
+		{
+			name: "replacement",
+			mutate: func(t *testing.T, root, runtimePath string) {
+				t.Helper()
+				if err := os.Rename(runtimePath, runtimePath+".original"); err != nil {
+					t.Fatal(err)
+				}
+				mustSeedOpenRCRuntime(t, root, runtimePath)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			runtimePath := filepath.Join(root, "run", "openrc")
+			mustSeedOpenRCRuntime(t, root, runtimePath)
+			rootInfo, err := os.Lstat(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rootStat, ok := rootInfo.Sys().(*syscall.Stat_t)
+			if !ok {
+				t.Fatal("test root ownership is unavailable")
+			}
+			proof, present, err := beginOpenRCRuntimeDirectoryAttestation(
+				runtimePath,
+				rootStat.Uid,
+				rootStat.Gid,
+			)
+			if err != nil || !present || proof == nil {
+				t.Fatalf("begin OpenRC runtime attestation = %v, %v, %v", proof, present, err)
+			}
+			defer func() { _ = proof.directory.Close() }()
+			test.mutate(t, root, runtimePath)
+			if err := proof.reattest(rootStat.Uid, rootStat.Gid); err == nil ||
+				!strings.Contains(err.Error(), "changed while attesting") {
+				t.Fatalf("OpenRC runtime drift was accepted: %v", err)
+			}
+		})
+	}
 }
 
 func mustSeedSystemdRuntime(t *testing.T, root, runtimePath string) {
@@ -272,7 +432,34 @@ func TestCoreServiceRequiresSuccessfulFirewallLoaderAtBoot_SW2_FWBACKEND_001(t *
 	}
 }
 
-func TestHistoricalV4028CoreServiceAnchors(t *testing.T) {
+func TestSystemdFirewallServiceWaitsForInstalledCronProviderAtBoot(t *testing.T) {
+	const ordering = "After=network-online.target rsyslog.service cron.service crond.service\n"
+	if strings.Count(systemdFirewallService, ordering) != 1 {
+		t.Fatalf("systemd firewall unit lacks exact cron provider ordering %q", ordering)
+	}
+	for _, dependency := range []string{
+		"Wants=cron.service",
+		"Wants=crond.service",
+		"Requires=cron.service",
+		"Requires=crond.service",
+	} {
+		if strings.Contains(systemdFirewallService, dependency) {
+			t.Fatalf("systemd firewall unit must not pull in an absent cron provider alias via %q", dependency)
+		}
+	}
+}
+
+func TestOpenRCFirewallServiceRequiresExactRuntimeProvidersAtBoot(t *testing.T) {
+	const dependencies = "\tneed net rsyslog cronie\n"
+	if strings.Count(openRCFirewallService, dependencies) != 1 {
+		t.Fatalf("OpenRC firewall service lacks exact runtime provider dependencies %q", dependencies)
+	}
+	if !strings.Contains(openRCFirewallService, "\tbefore syswarden-core\n") {
+		t.Fatal("OpenRC firewall service does not start before the core service")
+	}
+}
+
+func TestHistoricalV4028ServiceAnchors(t *testing.T) {
 	tests := []struct {
 		name       string
 		content    string
@@ -280,16 +467,28 @@ func TestHistoricalV4028CoreServiceAnchors(t *testing.T) {
 		wantSHA256 string
 	}{
 		{
-			name:       "systemd",
+			name:       "systemd-core",
 			content:    historicalV4028SystemdCoreService,
 			wantLength: historicalV4028SystemdCoreServiceLength,
 			wantSHA256: historicalV4028SystemdCoreServiceSHA256,
 		},
 		{
-			name:       "openrc",
+			name:       "openrc-core",
 			content:    historicalV4028OpenRCCoreService,
 			wantLength: historicalV4028OpenRCCoreServiceLength,
 			wantSHA256: historicalV4028OpenRCCoreServiceSHA256,
+		},
+		{
+			name:       "systemd-firewall",
+			content:    historicalV4028SystemdFirewallService,
+			wantLength: historicalV4028SystemdFirewallServiceLength,
+			wantSHA256: historicalV4028SystemdFirewallServiceSHA256,
+		},
+		{
+			name:       "openrc-firewall",
+			content:    historicalV4028OpenRCFirewallService,
+			wantLength: historicalV4028OpenRCFirewallServiceLength,
+			wantSHA256: historicalV4028OpenRCFirewallServiceSHA256,
 		},
 	}
 	for _, test := range tests {
@@ -365,7 +564,7 @@ func withOpenRCPublicationTestPaths(t *testing.T) (string, string) {
 func seedLegacySystemdPublication(t *testing.T, unitDirectory, wantsDirectory string) {
 	t.Helper()
 	mustWriteFile(t, filepath.Join(unitDirectory, "syswarden-core.service"), historicalV4028SystemdCoreService)
-	mustWriteFile(t, filepath.Join(unitDirectory, "syswarden-firewall.service"), systemdFirewallService)
+	mustWriteFile(t, filepath.Join(unitDirectory, "syswarden-firewall.service"), historicalV4028SystemdFirewallService)
 	mustMkdirAll(t, wantsDirectory)
 	if err := os.Symlink(
 		"/etc/systemd/system/syswarden-core.service",
@@ -386,7 +585,7 @@ func seedLegacyOpenRCPublication(t *testing.T, unitDirectory, runlevelDirectory 
 	corePath := filepath.Join(unitDirectory, "syswarden-core")
 	firewallPath := filepath.Join(unitDirectory, "syswarden-firewall")
 	mustWriteFile(t, corePath, historicalV4028OpenRCCoreService)
-	mustWriteFile(t, firewallPath, openRCFirewallService)
+	mustWriteFile(t, firewallPath, historicalV4028OpenRCFirewallService)
 	mustChmodTestPath(t, corePath, 0755)
 	mustChmodTestPath(t, firewallPath, 0755)
 	mustMkdirAll(t, runlevelDirectory)
@@ -406,11 +605,16 @@ func assertServiceEnablementTarget(t *testing.T, path, expected string) {
 	}
 }
 
-func TestPublishSystemdServicesMigratesExactV4028CoreAtomicallyAndIdempotently(t *testing.T) {
+func TestPublishSystemdServicesMigratesExactV4028UnitsAtomicallyAndIdempotently(t *testing.T) {
 	unitDirectory, wantsDirectory := withSystemdPublicationTestPaths(t)
 	seedLegacySystemdPublication(t, unitDirectory, wantsDirectory)
 	corePath := filepath.Join(unitDirectory, "syswarden-core.service")
-	historical, err := os.Lstat(corePath)
+	firewallPath := filepath.Join(unitDirectory, "syswarden-firewall.service")
+	historicalCore, err := os.Lstat(corePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	historicalFirewall, err := os.Lstat(firewallPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,36 +622,58 @@ func TestPublishSystemdServicesMigratesExactV4028CoreAtomicallyAndIdempotently(t
 	if err := publishSystemdServices(); err != nil {
 		t.Fatal(err)
 	}
-	migrated, err := os.Lstat(corePath)
+	migratedCore, err := os.Lstat(corePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if os.SameFile(historical, migrated) {
+	migratedFirewall, err := os.Lstat(firewallPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(historicalCore, migratedCore) {
 		t.Fatal("historical systemd core inode was not atomically replaced")
+	}
+	if os.SameFile(historicalFirewall, migratedFirewall) {
+		t.Fatal("historical systemd firewall inode was not atomically replaced")
 	}
 	if got := string(mustReadTestFile(t, corePath)); got != systemdCoreService {
 		t.Fatalf("migrated systemd core = %q", got)
 	}
-	if migrated.Mode().Perm() != 0600 || !serviceFileHasSingleLink(migrated) {
-		t.Fatalf("migrated systemd core metadata = %v", migrated.Mode())
+	if got := string(mustReadTestFile(t, firewallPath)); got != systemdFirewallService {
+		t.Fatalf("migrated systemd firewall = %q", got)
+	}
+	if migratedCore.Mode().Perm() != 0600 || !serviceFileHasSingleLink(migratedCore) {
+		t.Fatalf("migrated systemd core metadata = %v", migratedCore.Mode())
+	}
+	if migratedFirewall.Mode().Perm() != 0600 || !serviceFileHasSingleLink(migratedFirewall) {
+		t.Fatalf("migrated systemd firewall metadata = %v", migratedFirewall.Mode())
 	}
 	assertNoServiceMigrationArtifacts(t, unitDirectory)
 
 	if err := publishSystemdServices(); err != nil {
 		t.Fatalf("idempotent systemd publication failed: %v", err)
 	}
-	reattested, err := os.Lstat(corePath)
-	if err != nil || !os.SameFile(migrated, reattested) {
-		t.Fatalf("idempotent systemd publication replaced the current unit: %v", err)
+	reattestedCore, err := os.Lstat(corePath)
+	if err != nil || !os.SameFile(migratedCore, reattestedCore) {
+		t.Fatalf("idempotent systemd publication replaced the current core unit: %v", err)
+	}
+	reattestedFirewall, err := os.Lstat(firewallPath)
+	if err != nil || !os.SameFile(migratedFirewall, reattestedFirewall) {
+		t.Fatalf("idempotent systemd publication replaced the current firewall unit: %v", err)
 	}
 	assertNoServiceMigrationArtifacts(t, unitDirectory)
 }
 
-func TestPublishOpenRCServicesMigratesExactV4028CoreAtomicallyAndIdempotently(t *testing.T) {
+func TestPublishOpenRCServicesMigratesExactV4028UnitsAtomicallyAndIdempotently(t *testing.T) {
 	unitDirectory, runlevelDirectory := withOpenRCPublicationTestPaths(t)
 	seedLegacyOpenRCPublication(t, unitDirectory, runlevelDirectory)
 	corePath := filepath.Join(unitDirectory, "syswarden-core")
-	historical, err := os.Lstat(corePath)
+	firewallPath := filepath.Join(unitDirectory, "syswarden-firewall")
+	historicalCore, err := os.Lstat(corePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	historicalFirewall, err := os.Lstat(firewallPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,27 +681,44 @@ func TestPublishOpenRCServicesMigratesExactV4028CoreAtomicallyAndIdempotently(t 
 	if err := publishOpenRCServices(); err != nil {
 		t.Fatal(err)
 	}
-	migrated, err := os.Lstat(corePath)
+	migratedCore, err := os.Lstat(corePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if os.SameFile(historical, migrated) {
+	migratedFirewall, err := os.Lstat(firewallPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(historicalCore, migratedCore) {
 		t.Fatal("historical OpenRC core inode was not atomically replaced")
+	}
+	if os.SameFile(historicalFirewall, migratedFirewall) {
+		t.Fatal("historical OpenRC firewall inode was not atomically replaced")
 	}
 	if got := string(mustReadTestFile(t, corePath)); got != openRCCoreService {
 		t.Fatalf("migrated OpenRC core = %q", got)
 	}
-	if migrated.Mode().Perm() != 0755 || !serviceFileHasSingleLink(migrated) {
-		t.Fatalf("migrated OpenRC core metadata = %v", migrated.Mode())
+	if got := string(mustReadTestFile(t, firewallPath)); got != openRCFirewallService {
+		t.Fatalf("migrated OpenRC firewall = %q", got)
+	}
+	if migratedCore.Mode().Perm() != 0755 || !serviceFileHasSingleLink(migratedCore) {
+		t.Fatalf("migrated OpenRC core metadata = %v", migratedCore.Mode())
+	}
+	if migratedFirewall.Mode().Perm() != 0755 || !serviceFileHasSingleLink(migratedFirewall) {
+		t.Fatalf("migrated OpenRC firewall metadata = %v", migratedFirewall.Mode())
 	}
 	assertNoServiceMigrationArtifacts(t, unitDirectory)
 
 	if err := publishOpenRCServices(); err != nil {
 		t.Fatalf("idempotent OpenRC publication failed: %v", err)
 	}
-	reattested, err := os.Lstat(corePath)
-	if err != nil || !os.SameFile(migrated, reattested) {
-		t.Fatalf("idempotent OpenRC publication replaced the current unit: %v", err)
+	reattestedCore, err := os.Lstat(corePath)
+	if err != nil || !os.SameFile(migratedCore, reattestedCore) {
+		t.Fatalf("idempotent OpenRC publication replaced the current core unit: %v", err)
+	}
+	reattestedFirewall, err := os.Lstat(firewallPath)
+	if err != nil || !os.SameFile(migratedFirewall, reattestedFirewall) {
+		t.Fatalf("idempotent OpenRC publication replaced the current firewall unit: %v", err)
 	}
 	assertNoServiceMigrationArtifacts(t, unitDirectory)
 }
@@ -648,6 +891,9 @@ func TestPublishSystemdServicesRollsBackLegacyMigration(t *testing.T) {
 	if got := string(mustReadTestFile(t, filepath.Join(unitDirectory, "syswarden-core.service"))); got != historicalV4028SystemdCoreService {
 		t.Fatalf("historical systemd core was not restored after bundle failure: %q", got)
 	}
+	if got := string(mustReadTestFile(t, filepath.Join(unitDirectory, "syswarden-firewall.service"))); got != historicalV4028SystemdFirewallService {
+		t.Fatalf("historical systemd firewall was not restored after bundle failure: %q", got)
+	}
 	assertServiceEnablementTarget(
 		t,
 		filepath.Join(wantsDirectory, "syswarden-core.service"),
@@ -672,6 +918,26 @@ func TestPublishSystemdServicesKeepsFirewallUnitStrictAndRollsBackCore(t *testin
 	}
 	if got := string(mustReadTestFile(t, firewallPath)); got != "operator firewall service\n" {
 		t.Fatalf("operator firewall unit changed: %q", got)
+	}
+	assertNoServiceMigrationArtifacts(t, unitDirectory)
+}
+
+func TestPublishOpenRCServicesKeepsFirewallUnitStrictAndRollsBackCore(t *testing.T) {
+	unitDirectory, runlevelDirectory := withOpenRCPublicationTestPaths(t)
+	seedLegacyOpenRCPublication(t, unitDirectory, runlevelDirectory)
+	corePath := filepath.Join(unitDirectory, "syswarden-core")
+	firewallPath := filepath.Join(unitDirectory, "syswarden-firewall")
+	mustWriteFile(t, firewallPath, "operator firewall service\n")
+	mustChmodTestPath(t, firewallPath, 0755)
+
+	if err := publishOpenRCServices(); err == nil {
+		t.Fatal("modified OpenRC firewall service was accepted")
+	}
+	if got := string(mustReadTestFile(t, corePath)); got != historicalV4028OpenRCCoreService {
+		t.Fatalf("OpenRC core migration was not rolled back after firewall refusal: %q", got)
+	}
+	if got := string(mustReadTestFile(t, firewallPath)); got != "operator firewall service\n" {
+		t.Fatalf("operator OpenRC firewall service changed: %q", got)
 	}
 	assertNoServiceMigrationArtifacts(t, unitDirectory)
 }

--- a/src/core/syswarden-cli/pkg/system/uninstall_linux.go
+++ b/src/core/syswarden-cli/pkg/system/uninstall_linux.go
@@ -34,6 +34,7 @@ type firewallRemovalPreparationHost struct {
 	resolveWireGuardExe        func() (string, error)
 	wireGuardInterface         func() (bool, error)
 	attestSystemdUnit          func(string) error
+	attestSystemdDropIns       func(firewallManagerExecutor, string) (string, error)
 	attestOpenRCUnit           func(firewallRemovalService) error
 	openRCUnitPresent          func(firewallRemovalService) (bool, error)
 	attestOpenRCRunlevel       func(firewallRemovalService, string) error
@@ -46,6 +47,7 @@ type firewallRemovalManager struct {
 	runlevelPath               string
 	executor                   firewallManagerExecutor
 	attestSystemdUnit          func(string) error
+	attestSystemdDropIns       func(firewallManagerExecutor, string) (string, error)
 	attestOpenRCUnit           func(firewallRemovalService) error
 	openRCUnitPresent          func(firewallRemovalService) (bool, error)
 	attestOpenRCRunlevel       func(firewallRemovalService, string) error
@@ -75,6 +77,7 @@ func productionFirewallRemovalPreparationHost() firewallRemovalPreparationHost {
 		resolveWireGuardExe:        resolveWireGuardRemovalExecutable,
 		wireGuardInterface:         inspectWireGuardRemovalInterface,
 		attestSystemdUnit:          attestSystemdFirewallRemovalUnitFile,
+		attestSystemdDropIns:       attestApprovedSystemdServiceDropIns,
 		attestOpenRCUnit:           attestOpenRCFirewallRemovalUnit,
 		openRCUnitPresent:          inspectOpenRCFirewallRemovalUnitPresence,
 		attestOpenRCRunlevel:       attestOpenRCFirewallRemovalRunlevelLink,
@@ -90,6 +93,7 @@ func (host firewallRemovalPreparationHost) validate() error {
 		host.executor.output == nil || host.processScan == nil || host.attestWireGuard == nil ||
 		host.verifyWireGuardStopConfig == nil || host.resolveWireGuardExe == nil ||
 		host.wireGuardInterface == nil || host.attestSystemdUnit == nil ||
+		host.attestSystemdDropIns == nil ||
 		host.attestOpenRCUnit == nil || host.openRCUnitPresent == nil || host.attestOpenRCRunlevel == nil ||
 		host.verifyOpenRCRunlevelAbsent == nil {
 		return fmt.Errorf("firewall removal preparation dependencies are incomplete")
@@ -119,6 +123,7 @@ func (host firewallRemovalPreparationHost) resolveManager() (firewallRemovalMana
 		servicePath:                servicePath,
 		executor:                   host.executor,
 		attestSystemdUnit:          host.attestSystemdUnit,
+		attestSystemdDropIns:       host.attestSystemdDropIns,
 		attestOpenRCUnit:           host.attestOpenRCUnit,
 		openRCUnitPresent:          host.openRCUnitPresent,
 		attestOpenRCRunlevel:       host.attestOpenRCRunlevel,
@@ -213,8 +218,8 @@ func attestSystemdFirewallRemovalService(
 	if err != nil {
 		return err
 	}
-	if dropIns != "" {
-		return fmt.Errorf("refusing systemd drop-ins for firewall mutator %s", unit)
+	if _, err := manager.attestSystemdDropIns(manager.executor, dropIns); err != nil {
+		return fmt.Errorf("refusing unapproved systemd drop-ins for firewall mutator %s: %w", unit, err)
 	}
 	execStart, err := queryFirewallProperty(manager.executor, manager.servicePath, unit, "ExecStart")
 	if err != nil {

--- a/src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go
@@ -394,7 +394,13 @@ func newFirewallRemovalTestHost(
 			return state != nil && state.active, nil
 		},
 		attestSystemdUnit: func(string) error { return nil },
-		attestOpenRCUnit:  func(firewallRemovalService) error { return nil },
+		attestSystemdDropIns: func(_ firewallManagerExecutor, dropIns string) (string, error) {
+			if dropIns != "" {
+				return "", errors.New("unapproved systemd service drop-in")
+			}
+			return "", nil
+		},
+		attestOpenRCUnit: func(firewallRemovalService) error { return nil },
 		openRCUnitPresent: func(service firewallRemovalService) (bool, error) {
 			name := openRCFirewallRemovalServiceName(service)
 			state := manager.states[name]
@@ -657,6 +663,36 @@ func TestPrepareFirewallStateForRemovalSystemdStopsDisablesAndReattests_SW2_FWBA
 	}
 }
 
+func TestPrepareFirewallStateForRemovalAcceptsOnlyAttestedVendorSystemdDropIns_SW2_FWBACKEND_001(t *testing.T) {
+	states := defaultSystemdFirewallRemovalStates()
+	for _, unit := range []string{
+		"syswarden-core.service",
+		"syswarden-firewall.service",
+		"wg-quick@wg-syswarden.service",
+	} {
+		states[unit].dropInPathsOverride = approvedSystemdServiceDropInPath
+	}
+	manager := &fakeFirewallRemovalManager{states: states}
+	host := newFirewallRemovalTestHost(t, manager, true)
+	attestations := 0
+	host.attestSystemdDropIns = func(_ firewallManagerExecutor, dropIns string) (string, error) {
+		attestations++
+		if dropIns != approvedSystemdServiceDropInPath {
+			return "", errors.New("unexpected systemd service drop-in")
+		}
+		return dropIns + "#exact-vendor-provenance", nil
+	}
+	if err := host.prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if attestations != 10 {
+		t.Fatalf("vendor drop-in attestations = %d, want 10", attestations)
+	}
+	if got := manager.mutationCalls(); len(got) == 0 {
+		t.Fatal("approved vendor drop-in prevented the verified removal mutations")
+	}
+}
+
 func TestPrepareFirewallStateForRemovalSkipsAbsentAndInactiveDisabledSystemdUnits_SW2_FWBACKEND_001(t *testing.T) {
 	manager := &fakeFirewallRemovalManager{states: map[string]*fakeFirewallRemovalServiceState{
 		"syswarden-core.service":        {loaded: true},
@@ -911,7 +947,7 @@ func TestPrepareFirewallStateForRemovalAttestsUnitsAndWireGuardContentBeforeMuta
 			prepare: func(_ *firewallRemovalPreparationHost, states map[string]*fakeFirewallRemovalServiceState) {
 				states["syswarden-firewall.service"].dropInPathsOverride = "/etc/systemd/system/syswarden-firewall.service.d/operator.conf"
 			},
-			want: "refusing systemd drop-ins",
+			want: "refusing unapproved systemd drop-ins",
 		},
 		{
 			name: "unknown WireGuard ExecStop",


### PR DESCRIPTION
## Summary

- repairs the v4.03.2 package lifecycle qualification on Debian, Ubuntu, Fedora, AlmaLinux, and Alpine
- preserves exact v4.02.8 to v4.03.2 upgrade, rollback, recovery, remove, and purge evidence
- removes the Alpine OpenRC rsyslog dependency cycle while retaining full configuration validation and active-state attestation
- keeps the release-manager repair bounded to the exact reviewed 20-file diff

## Validation

- exact Package workflow Python suite: 315/315 passed
- release gate: 44/44 passed
- Go integration and security tests plus vet: passed
- reproducible DEB, RPM, and APK build from `97b7c231e3077fbbccacd8312b338463877c506c`: passed
- native amd64 lifecycle lab across all five required distributions: passed with `release_ready=true`, no blockers, no unexpected failed checks, and exact repository and SHA binding
- final amd64 lifecycle evidence SHA256: `f25dc328c108ab919d840008151370c6adc56cb7a3d53cb00bfd69202055efc8`

Package SHA256:

- DEB: `2c429dfca84556f8e8f17974169d3d374d2823861f0794fefc1f266e20565d1a`
- RPM: `2d9c67bcd923542f7e5168a04f7624cb9e4adcd33f7914fc875cd400146a70f6`
- APK: `cbbabbf91641be6c7ce4f7cbff57df51c4268f10c1576ff0ff986a7f6d31c848`
- manifest: `007797d7fb80b8589f9a62d4165c27e88f139fe015f58596645bdf3359460bbe`

## Release safety

- no version or changelog change
- no tag or GitHub release is created by this PR
- no image or diagram is changed; official SysWarden logo assets remain untouched
