### PR TITLE
Qualification : repair v4.03.2 merged squash subject contract

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,31 +136,85 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_parent_sha="$(git rev-parse HEAD^)"
+              v4032_merge_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
+                echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
+                exit 1
+              fi
+              v4032_merge_expected_subject='Qualification : repair v4.03.2 merged squash subject contract (#96)'
+              if [[ "${commit_subject}" != "${v4032_merge_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 merge-subject repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_merge_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 merge-subject repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 merge-subject repair diff contract
+              expected_v4032_merge_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "scripts/ci/release_gate_test.py"
+              )
+              mapfile -d '' -t actual_v4032_merge_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_merge_diff[@]} != ${#expected_v4032_merge_diff[@]} )); then
+                echo "ERROR: the v4.03.2 merge-subject repair must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_merge_diff[@]}; index++)); do
+                if [[ "${actual_v4032_merge_diff[index]}" != "${expected_v4032_merge_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 merge-subject repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_merge_paths=(
+                ".github/workflows/release-manager.yml"
+                "scripts/ci/release_gate_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_merge_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 merge-subject repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 merge-subject repair diff contract
+              v4032_repair_ref=HEAD^
+              v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"
               if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
                 exit 1
               fi
-              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95)'
-              if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
+              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95) (#95)'
+              v4032_repair_subject="$(git log -1 --format=%s "${v4032_repair_ref}")"
+              if [[ "${v4032_repair_subject}" != "${v4032_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-              read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}")"
+              read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}^")"
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}^^")"
               if (( ${#v4032_head_line[@]} != 2 || \
                     ${#v4032_parent_line[@]} != 2 || \
                     ${#v4032_release_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 package lifecycle repair requires the reviewed three-commit linear chain." >&2
                 exit 1
               fi
-              v4032_grandparent_sha="$(git rev-parse HEAD^^)"
+              v4032_grandparent_sha="$(git rev-parse "${v4032_repair_ref}^^")"
               if [[ "${v4032_grandparent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
                 echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
                 exit 1
               fi
-              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
+              v4032_release_base_sha="$(git rev-parse "${v4032_repair_ref}^^^")"
               if [[ "${v4032_release_base_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
                 echo "ERROR: the v4.03.2 release commit does not have the reviewed Patch baseline." >&2
                 exit 1
@@ -189,7 +243,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_repair_ref}^" "${v4032_repair_ref}"
               )
               if (( ${#actual_v4032_diff[@]} != ${#expected_v4032_diff[@]} )); then
                 echo "ERROR: the v4.03.2 package lifecycle repair must modify exactly the twenty reviewed files." >&2
@@ -223,7 +278,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
                 "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_repair_ref}^" "${v4032_repair_ref}"; do
                 for fix_path in "${v4032_fix_paths[@]}"; do
                   expected_mode="100644"
                   if [[ "${fix_path}" == "build_packages.sh" ]]; then
@@ -242,7 +297,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 preserved-version recovery diff contract
-              git diff --quiet HEAD^ HEAD -- \
+              git diff --quiet "${v4032_repair_ref}^" "${v4032_repair_ref}" -- \
                 changelog.md \
                 src/core/syswarden-cli/pkg/system/upgrade.go \
                 src/core/syswarden-tui/main.go \
@@ -251,12 +306,17 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
-              v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"
+              v4032_repair_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_parent_sha}" \
+                --commit-message "${v4032_repair_commit_message}"
+              v4032_parent_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}^")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_grandparent_sha}" \
                 --commit-message "${v4032_parent_commit_message}"
-              v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"
+              v4032_release_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}^^")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_release_base_sha}" \
@@ -735,31 +795,85 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_parent_sha="$(git rev-parse HEAD^)"
+              v4032_merge_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
+                echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
+                exit 1
+              fi
+              v4032_merge_expected_subject='Qualification : repair v4.03.2 merged squash subject contract (#96)'
+              if [[ "${commit_subject}" != "${v4032_merge_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 merge-subject repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_merge_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 merge-subject repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 merge-subject repair diff contract
+              expected_v4032_merge_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "scripts/ci/release_gate_test.py"
+              )
+              mapfile -d '' -t actual_v4032_merge_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_merge_diff[@]} != ${#expected_v4032_merge_diff[@]} )); then
+                echo "ERROR: the v4.03.2 merge-subject repair must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_merge_diff[@]}; index++)); do
+                if [[ "${actual_v4032_merge_diff[index]}" != "${expected_v4032_merge_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 merge-subject repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_merge_paths=(
+                ".github/workflows/release-manager.yml"
+                "scripts/ci/release_gate_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_merge_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 merge-subject repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 merge-subject repair diff contract
+              v4032_repair_ref=HEAD^
+              v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"
               if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
                 exit 1
               fi
-              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95)'
-              if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
+              v4032_expected_subject='Qualification : repair v4.03.2 package lifecycle qualification (#95) (#95)'
+              v4032_repair_subject="$(git log -1 --format=%s "${v4032_repair_ref}")"
+              if [[ "${v4032_repair_subject}" != "${v4032_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-              read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}")"
+              read -r -a v4032_parent_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}^")"
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 "${v4032_repair_ref}^^")"
               if (( ${#v4032_head_line[@]} != 2 || \
                     ${#v4032_parent_line[@]} != 2 || \
                     ${#v4032_release_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 package lifecycle repair requires the reviewed three-commit linear chain." >&2
                 exit 1
               fi
-              v4032_grandparent_sha="$(git rev-parse HEAD^^)"
+              v4032_grandparent_sha="$(git rev-parse "${v4032_repair_ref}^^")"
               if [[ "${v4032_grandparent_sha}" != "3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then
                 echo "ERROR: the v4.03.2 qualification repair is not based on the reviewed release commit." >&2
                 exit 1
               fi
-              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
+              v4032_release_base_sha="$(git rev-parse "${v4032_repair_ref}^^^")"
               if [[ "${v4032_release_base_sha}" != "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then
                 echo "ERROR: the v4.03.2 release commit does not have the reviewed Patch baseline." >&2
                 exit 1
@@ -788,7 +902,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_repair_ref}^" "${v4032_repair_ref}"
               )
               if (( ${#actual_v4032_diff[@]} != ${#expected_v4032_diff[@]} )); then
                 echo "ERROR: the v4.03.2 package lifecycle repair must modify exactly the twenty reviewed files." >&2
@@ -822,7 +937,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/system/uninstall_linux.go"
                 "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_repair_ref}^" "${v4032_repair_ref}"; do
                 for fix_path in "${v4032_fix_paths[@]}"; do
                   expected_mode="100644"
                   if [[ "${fix_path}" == "build_packages.sh" ]]; then
@@ -841,7 +956,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 preserved-version recovery diff contract
-              git diff --quiet HEAD^ HEAD -- \
+              git diff --quiet "${v4032_repair_ref}^" "${v4032_repair_ref}" -- \
                 changelog.md \
                 src/core/syswarden-cli/pkg/system/upgrade.go \
                 src/core/syswarden-tui/main.go \
@@ -850,12 +965,17 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
-              v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"
+              v4032_repair_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_parent_sha}" \
+                --commit-message "${v4032_repair_commit_message}"
+              v4032_parent_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}^")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_grandparent_sha}" \
                 --commit-message "${v4032_parent_commit_message}"
-              v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"
+              v4032_release_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}^^")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
                 --base-ref "${v4032_release_base_sha}" \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -776,7 +776,7 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count("git rev-list --parents -n 1 HEAD)"), 6
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD^)"), 6
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 4
         )
         self.assertEqual(
             workflow.count(
@@ -791,7 +791,7 @@ class ReleaseGateTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 6)
+        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 4)
         self.assertEqual(
             workflow.count(
                 '\n                parent_commit_message="$(git log -1 --format=%B HEAD^)"'
@@ -817,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 7)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 8)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                2,
+                3,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 1)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 2)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 2)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 3)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 4,
-                "scripts/ci/release_gate_test.py": 4,
+                ".github/workflows/release-manager.yml": 6,
+                "scripts/ci/release_gate_test.py": 6,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -871,30 +871,37 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
-        self.assertEqual(
-            workflow.count(
+        pinned_contracts = (
+            (
+                'if [[ "${v4032_merge_parent_sha}" != '
+                '"14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then'
+            ),
+            (
                 'if [[ "${v4032_parent_sha}" != '
                 '"3839d592467a4f92f24b613412d8d89bb6905251" ]]; then'
             ),
-            2,
-        )
-        self.assertEqual(
-            workflow.count(
+            (
                 'if [[ "${v4032_grandparent_sha}" != '
                 '"3655abe045deffc669e0ba9c11a6e4cf17a317a5" ]]; then'
             ),
-            2,
-        )
-        self.assertEqual(
-            workflow.count(
+            (
                 'if [[ "${v4032_release_base_sha}" != '
                 '"f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa" ]]; then'
             ),
-            2,
         )
-        subject_contract = (
+        for contract in pinned_contracts:
+            self.assertEqual(workflow.count(contract), 2)
+        merge_subject_contract = (
+            "v4032_merge_expected_subject='Qualification : repair v4.03.2 "
+            "merged squash subject contract (#96)'"
+        )
+        repair_subject_contract = (
             "v4032_expected_subject='Qualification : repair v4.03.2 "
-            "package lifecycle qualification (#95)'"
+            "package lifecycle qualification (#95) (#95)'"
+        )
+        merge_paths = (
+            ".github/workflows/release-manager.yml",
+            "scripts/ci/release_gate_test.py",
         )
         expected_paths = (
             ".github/workflows/package.yml",
@@ -929,34 +936,104 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
-            self.assertEqual(block.count(subject_contract), 1)
+            self.assertEqual(block.count(merge_subject_contract), 1)
+            self.assertEqual(block.count(repair_subject_contract), 1)
             self.assertEqual(
                 block.count(
-                    '[[ "${commit_subject}" != "${v4032_expected_subject}" ]]'
+                    '[[ "${commit_subject}" != '
+                    '"${v4032_merge_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('v4032_merge_parent_sha="$(git rev-parse HEAD^)"'),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_merge_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_merge_head_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 merge-subject repair diff contract"
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_parent_sha="$(git rev-parse HEAD^)"'
+                    "# END exact v4.03.2 merge-subject repair diff contract"
+                ),
+                1,
+            )
+            merge_diff = block.split(
+                "# BEGIN exact v4.03.2 merge-subject repair diff contract\n", 1
+            )[1].split(
+                "# END exact v4.03.2 merge-subject repair diff contract", 1
+            )[0]
+            self.assertEqual(
+                merge_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(merge_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(merge_diff.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(merge_diff.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(
+                merge_diff.count(
+                    "${#actual_v4032_merge_diff[@]} != "
+                    "${#expected_v4032_merge_diff[@]}"
+                ),
+                1,
+            )
+            for path in merge_paths:
+                self.assertEqual(merge_diff.count(f'"{path}"'), 2)
+                self.assertEqual(merge_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_repair_ref=HEAD^"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_parent_sha="$(git rev-parse '
+                    '"${v4032_repair_ref}^")"'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_repair_subject="$(git log -1 --format=%s '
+                    '"${v4032_repair_ref}")"'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"'
+                    '[[ "${v4032_repair_subject}" != '
+                    '"${v4032_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"'
+                    'v4032_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_repair_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_parent_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_repair_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_release_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_repair_ref}^^")"'
                 ),
                 1,
             )
@@ -965,13 +1042,15 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(block.count("${#v4032_release_line[@]} != 2"), 1)
             self.assertEqual(
                 block.count(
-                    'v4032_grandparent_sha="$(git rev-parse HEAD^^)"'
+                    'v4032_grandparent_sha="$(git rev-parse '
+                    '"${v4032_repair_ref}^^")"'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_release_base_sha="$(git rev-parse HEAD^^^)"'
+                    'v4032_release_base_sha="$(git rev-parse '
+                    '"${v4032_repair_ref}^^^")"'
                 ),
                 1,
             )
@@ -990,21 +1069,33 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\"
                 ),
                 1,
             )
-            self.assertEqual(block.count('for tree_ref in HEAD^ HEAD; do'), 1)
+            self.assertEqual(
+                block.count(
+                    '"${v4032_repair_ref}^" "${v4032_repair_ref}"'
+                ),
+                3,
+            )
+            self.assertEqual(
+                block.count(
+                    'for tree_ref in "${v4032_repair_ref}^" '
+                    '"${v4032_repair_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                1,
+                2,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 2)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1016,27 +1107,57 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             for path in expected_paths:
-                expected_count = 3 if path == "build_packages.sh" else 2
+                if path == "build_packages.sh":
+                    expected_count = 3
+                elif path in merge_paths:
+                    expected_count = 4
+                else:
+                    expected_count = 2
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
-                self.assertEqual(block.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("git diff --quiet HEAD^ HEAD --"), 1)
+                expected_status_count = 2 if path in merge_paths else 1
+                self.assertEqual(
+                    block.count(f'M "{path}"'), expected_status_count
+                )
+            self.assertEqual(
+                block.count(
+                    'git diff --quiet "${v4032_repair_ref}^" '
+                    '"${v4032_repair_ref}" --'
+                ),
+                1,
+            )
             for path in unchanged_targets:
                 self.assertEqual(block.count(path), 1)
             self.assertEqual(
                 block.count(
-                    'v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"'
+                    'v4032_parent_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_repair_ref}^")"'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 2
+                block.count('./scripts/versioning.sh validate-commit'), 3
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_repair_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_repair_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count('--base-ref "${v4032_parent_sha}"'), 1)
+            self.assertEqual(
+                block.count(
+                    '--commit-message "${v4032_repair_commit_message}"'
+                ),
+                1,
             )
             self.assertEqual(
                 block.count('--base-ref "${v4032_grandparent_sha}"'), 1
             )
             self.assertEqual(
                 block.count(
-                    'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"'
+                    'v4032_release_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_repair_ref}^^")"'
                 ),
                 1,
             )
@@ -1053,10 +1174,12 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             parent_validation = block.split(
-                'v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"',
+                'v4032_parent_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}^")"',
                 1,
             )[1].split(
-                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"',
+                'v4032_release_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}^^")"',
                 1,
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
@@ -1068,17 +1191,28 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 preserved-version recovery diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_repair_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_expected_subject="
-        end = 'read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
+        end = (
+            'read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 '
+            '"${v4032_repair_ref}")"'
+        )
         self.assertEqual(block.count(start), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            'v4032_repair_subject="$(git log -1 --format=%s '
+            '"${v4032_repair_ref}")"',
+            'v4032_repair_subject="${COMMIT_SUBJECT:?}"',
+        )
+        return "set -euo pipefail\n" + fragment
 
     def make_v4032_fix_diff_repository(
         self, name: str, mutation: str | None
@@ -1249,8 +1383,8 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
             "parent resolution": workflow.replace(
-                'v4032_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"',
+                'v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^^")"',
             ),
             "exact parent": workflow.replace(
                 "3839d592467a4f92f24b613412d8d89bb6905251",
@@ -1261,28 +1395,38 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : arbitrary v4.03.2 repair (#95)",
             ),
             "linear head": workflow.replace(
-                'v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
-                'v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}")"',
+                'v4032_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}^")"',
             ),
             "linear parent": workflow.replace(
-                'v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
-                'v4032_parent_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
+                'v4032_parent_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}^")"',
+                'v4032_parent_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}^^")"',
             ),
             "linear release": workflow.replace(
-                'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
-                'v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_release_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}^^")"',
+                'v4032_release_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_repair_ref}^")"',
             ),
             "grandparent resolution": workflow.replace(
-                'v4032_grandparent_sha="$(git rev-parse HEAD^^)"',
-                'v4032_grandparent_sha="$(git rev-parse HEAD^)"',
+                'v4032_grandparent_sha="$(git rev-parse '
+                '"${v4032_repair_ref}^^")"',
+                'v4032_grandparent_sha="$(git rev-parse '
+                '"${v4032_repair_ref}^")"',
             ),
             "exact grandparent": workflow.replace(
                 "3655abe045deffc669e0ba9c11a6e4cf17a317a5",
                 "4655abe045deffc669e0ba9c11a6e4cf17a317a5",
             ),
             "release base resolution": workflow.replace(
-                'v4032_release_base_sha="$(git rev-parse HEAD^^^)"',
-                'v4032_release_base_sha="$(git rev-parse HEAD^^)"',
+                'v4032_release_base_sha="$(git rev-parse '
+                '"${v4032_repair_ref}^^^")"',
+                'v4032_release_base_sha="$(git rev-parse '
+                '"${v4032_repair_ref}^^")"',
             ),
             "exact release base": workflow.replace(
                 "f2270a2a8138f1f2b72a6200f6febbdc83fa5eaa",
@@ -1320,15 +1464,27 @@ class ReleaseGateTests(unittest.TestCase):
                 "src/core/syswarden-cli/pkg/system/upgrade_rewritten.go",
             ),
             "parent message": workflow.replace(
-                'v4032_parent_commit_message="$(git log -1 --format=%B HEAD^)"',
-                'v4032_parent_commit_message="$(git log -1 --format=%B HEAD)"',
+                'v4032_parent_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}^")"',
+                'v4032_parent_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}")"',
             ),
             "parent validation base": workflow.replace(
                 '--base-ref "${v4032_grandparent_sha}"', '--base-ref HEAD^'
             ),
+            "repair message": workflow.replace(
+                'v4032_repair_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}")"',
+                'v4032_repair_commit_message="$(git log -1 --format=%B HEAD)"',
+            ),
+            "repair validation base": workflow.replace(
+                '--base-ref "${v4032_parent_sha}"', '--base-ref HEAD^'
+            ),
             "release message": workflow.replace(
-                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^^)"',
-                'v4032_release_commit_message="$(git log -1 --format=%B HEAD^)"',
+                'v4032_release_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}^^")"',
+                'v4032_release_commit_message="$(git log -1 --format=%B '
+                '"${v4032_repair_ref}^")"',
             ),
             "release validation base": workflow.replace(
                 '--base-ref "${v4032_release_base_sha}"', '--base-ref HEAD^^'
@@ -1345,8 +1501,12 @@ class ReleaseGateTests(unittest.TestCase):
         script = self.v4032_subject_gate_script()
         cases = {
             "valid": (
-                "Qualification : repair v4.03.2 package lifecycle qualification (#95)",
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95) (#95)",
                 True,
+            ),
+            "single pull request suffix": (
+                "Qualification : repair v4.03.2 package lifecycle qualification (#95)",
+                False,
             ),
             "bare": (
                 "Qualification : repair v4.03.2 package lifecycle qualification",


### PR DESCRIPTION
## Summary

- binds the v4.03.2 publisher to the exact signed PR95 squash commit created by GitHub
- preserves the complete reviewed PR95, PR94, PR93, and release-base ancestry contract
- restricts this recovery commit to the two release-governance files required for the repair

## Root cause

GitHub created the signed PR95 squash subject as:

`Qualification : repair v4.03.2 package lifecycle qualification (#95) (#95)`

The existing Release Manager expected the single-suffix form and would therefore reject an otherwise valid release commit.

## Contract

- exact parent: `14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1`
- exact PR96 squash subject: `Qualification : repair v4.03.2 merged squash subject contract (#96)`
- exact PR95 signed subject and SHA
- exact two-file PR96 diff with regular `100644` blobs and no renames
- exact twenty-file PR95 diff and modes
- exact linear ancestry through PR94, PR93, and the reviewed release base
- ordinary commit validation for PR96, PR95, and PR94, plus tag-phase validation for PR93

## Validation

- Release Manager gate suite: 44/44 passed
- YAML parse: passed
- Python compile: passed
- `git diff --check`: passed
- live gate simulation reached the expected pre-tag boundary after validating PR96 and PR95; it stopped only because `v4.03.2` does not yet exist

## Release safety

- no product source, package, version, changelog, image, diagram, or official SysWarden logo asset is changed
- no tag, qualification run, or GitHub Release is created by this PR
- merge with the PR title exactly as written so GitHub creates the required single `(#96)` suffix
