### PR TITLE
Qualification : repair v4.03.2 native ARM64 Podman path contract

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_merge_parent_sha="$(git rev-parse HEAD^)"
+              v4032_arm64_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
+                exit 1
+              fi
+              v4032_arm64_expected_subject='Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)'
+              if [[ "${commit_subject}" != "${v4032_arm64_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_arm64_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 Podman path repair diff contract
+              expected_v4032_arm64_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_arm64_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_arm64_diff[@]} != ${#expected_v4032_arm64_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_arm64_diff[@]}; index++)); do
+                if [[ "${actual_v4032_arm64_diff[index]}" != "${expected_v4032_arm64_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 Podman path repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_arm64_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_arm64_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 Podman path repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 Podman path repair diff contract
+              v4032_merge_ref=HEAD^
+              v4032_merge_parent_sha="$(git rev-parse "${v4032_merge_ref}^")"
               if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
                 exit 1
               fi
               v4032_merge_expected_subject='Qualification : repair v4.03.2 merged squash subject contract (#96)'
-              if [[ "${commit_subject}" != "${v4032_merge_expected_subject}" ]]; then
+              v4032_merge_subject="$(git log -1 --format=%s "${v4032_merge_ref}")"
+              if [[ "${v4032_merge_subject}" != "${v4032_merge_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 "${v4032_merge_ref}")"
               if (( ${#v4032_merge_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 merge-subject repair must be one linear commit." >&2
                 exit 1
@@ -157,7 +215,8 @@ jobs:
                 M "scripts/ci/release_gate_test.py"
               )
               mapfile -d '' -t actual_v4032_merge_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_merge_ref}^" "${v4032_merge_ref}"
               )
               if (( ${#actual_v4032_merge_diff[@]} != ${#expected_v4032_merge_diff[@]} )); then
                 echo "ERROR: the v4.03.2 merge-subject repair must modify exactly the two reviewed files." >&2
@@ -173,7 +232,7 @@ jobs:
                 ".github/workflows/release-manager.yml"
                 "scripts/ci/release_gate_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_merge_ref}^" "${v4032_merge_ref}"; do
                 for fix_path in "${v4032_merge_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -188,7 +247,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 merge-subject repair diff contract
-              v4032_repair_ref=HEAD^
+              v4032_repair_ref="${v4032_merge_ref}^"
               v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"
               if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
@@ -306,6 +365,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_merge_commit_message="$(git log -1 --format=%B "${v4032_merge_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_merge_parent_sha}" \
+                --commit-message "${v4032_merge_commit_message}"
               v4032_repair_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
@@ -795,17 +859,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_merge_parent_sha="$(git rev-parse HEAD^)"
+              v4032_arm64_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
+                exit 1
+              fi
+              v4032_arm64_expected_subject='Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)'
+              if [[ "${commit_subject}" != "${v4032_arm64_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_arm64_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 Podman path repair diff contract
+              expected_v4032_arm64_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_arm64_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_arm64_diff[@]} != ${#expected_v4032_arm64_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 Podman path repair must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_arm64_diff[@]}; index++)); do
+                if [[ "${actual_v4032_arm64_diff[index]}" != "${expected_v4032_arm64_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 Podman path repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_arm64_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_arm64_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 Podman path repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 Podman path repair diff contract
+              v4032_merge_ref=HEAD^
+              v4032_merge_parent_sha="$(git rev-parse "${v4032_merge_ref}^")"
               if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
                 exit 1
               fi
               v4032_merge_expected_subject='Qualification : repair v4.03.2 merged squash subject contract (#96)'
-              if [[ "${commit_subject}" != "${v4032_merge_expected_subject}" ]]; then
+              v4032_merge_subject="$(git log -1 --format=%s "${v4032_merge_ref}")"
+              if [[ "${v4032_merge_subject}" != "${v4032_merge_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_merge_head_line <<< "$(git rev-list --parents -n 1 "${v4032_merge_ref}")"
               if (( ${#v4032_merge_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 merge-subject repair must be one linear commit." >&2
                 exit 1
@@ -816,7 +938,8 @@ jobs:
                 M "scripts/ci/release_gate_test.py"
               )
               mapfile -d '' -t actual_v4032_merge_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_merge_ref}^" "${v4032_merge_ref}"
               )
               if (( ${#actual_v4032_merge_diff[@]} != ${#expected_v4032_merge_diff[@]} )); then
                 echo "ERROR: the v4.03.2 merge-subject repair must modify exactly the two reviewed files." >&2
@@ -832,7 +955,7 @@ jobs:
                 ".github/workflows/release-manager.yml"
                 "scripts/ci/release_gate_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_merge_ref}^" "${v4032_merge_ref}"; do
                 for fix_path in "${v4032_merge_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -847,7 +970,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 merge-subject repair diff contract
-              v4032_repair_ref=HEAD^
+              v4032_repair_ref="${v4032_merge_ref}^"
               v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"
               if [[ "${v4032_parent_sha}" != "3839d592467a4f92f24b613412d8d89bb6905251" ]]; then
                 echo "ERROR: the v4.03.2 package lifecycle repair is not based on the reviewed qualification repair." >&2
@@ -965,6 +1088,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_merge_commit_message="$(git log -1 --format=%B "${v4032_merge_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_merge_parent_sha}" \
+                --commit-message "${v4032_merge_commit_message}"
               v4032_repair_commit_message="$(git log -1 --format=%B "${v4032_repair_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -44,6 +44,121 @@ jobs:
       previous_release_id: ${{ steps.previous.outputs.release_id }}
 
     steps:
+      - name: Seal Native ARM64 Podman Trust Path
+        shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          set -euo pipefail
+          podman_parent="/usr/local/bin"
+          for trusted_parent in /usr /usr/bin /usr/local; do
+            if [[ ! -d "${trusted_parent}" || -L "${trusted_parent}" || \
+                  "$(/usr/bin/stat -c '%u:%g' "${trusted_parent}")" != "0:0" ]]; then
+              echo "ERROR: the native ARM64 Podman ancestor is not a trusted root-owned directory: ${trusted_parent}." >&2
+              exit 1
+            fi
+            trusted_parent_mode="$(/usr/bin/stat -c '%a' "${trusted_parent}")"
+            if [[ ! "${trusted_parent_mode}" =~ ^[0-7]{3,4}$ ]] || \
+               (( (8#${trusted_parent_mode} & 0022) != 0 )); then
+              echo "ERROR: the native ARM64 Podman ancestor is writable by an untrusted account: ${trusted_parent}." >&2
+              exit 1
+            fi
+          done
+          trusted_system_tools=(
+            /usr/bin/bash
+            /usr/bin/chmod
+            /usr/bin/sha256sum
+            /usr/bin/stat
+            /usr/bin/sudo
+          )
+          for trusted_system_tool in "${trusted_system_tools[@]}"; do
+            if [[ ! -f "${trusted_system_tool}" || -L "${trusted_system_tool}" || \
+                  ! -x "${trusted_system_tool}" || \
+                  "$(/usr/bin/stat -c '%u:%g' "${trusted_system_tool}")" != "0:0" ]]; then
+              echo "ERROR: the native ARM64 trust-path tool is not an exact root-owned executable: ${trusted_system_tool}." >&2
+              exit 1
+            fi
+            trusted_system_tool_mode="$(/usr/bin/stat -c '%a' "${trusted_system_tool}")"
+            if [[ ! "${trusted_system_tool_mode}" =~ ^[0-7]{3,4}$ ]] || \
+               (( (8#${trusted_system_tool_mode} & 0022) != 0 )); then
+              echo "ERROR: the native ARM64 trust-path tool is writable by an untrusted account: ${trusted_system_tool}." >&2
+              exit 1
+            fi
+          done
+          if [[ ! -d "${podman_parent}" || -L "${podman_parent}" || \
+                "$(/usr/bin/stat -c '%u:%g' "${podman_parent}")" != "0:0" ]]; then
+            echo "ERROR: the native ARM64 Podman parent is not the expected root-owned directory." >&2
+            exit 1
+          fi
+          podman_bin_tools=(
+            /usr/local/bin/podman
+            /usr/local/bin/crun
+            /usr/local/bin/runc
+            /usr/local/bin/pasta
+            /usr/local/bin/fuse-overlayfs
+          )
+          for podman_tool in "${podman_bin_tools[@]}"; do
+            if [[ ! -f "${podman_tool}" || -L "${podman_tool}" || \
+                  ! -x "${podman_tool}" || \
+                  "$(/usr/bin/stat -c '%u:%g' "${podman_tool}")" != "0:0" ]]; then
+              echo "ERROR: the native ARM64 Podman bundle tool is not an exact root-owned executable: ${podman_tool}." >&2
+              exit 1
+            fi
+          done
+          /usr/bin/sudo -n /usr/bin/chmod 0755 -- \
+            "${podman_parent}" "${podman_bin_tools[@]}"
+          if [[ "$(/usr/bin/stat -c '%u:%g:%a' "${podman_parent}")" != "0:0:755" ]]; then
+            echo "ERROR: the native ARM64 Podman parent could not be sealed." >&2
+            exit 1
+          fi
+          for podman_tool in "${podman_bin_tools[@]}"; do
+            if [[ "$(/usr/bin/stat -c '%u:%g:%a' "${podman_tool}")" != "0:0:755" ]]; then
+              echo "ERROR: the native ARM64 Podman bundle tool could not be sealed: ${podman_tool}." >&2
+              exit 1
+            fi
+          done
+          for podman_library_parent in /usr/local/lib /usr/local/lib/podman; do
+            if [[ ! -d "${podman_library_parent}" || -L "${podman_library_parent}" || \
+                  "$(/usr/bin/stat -c '%u:%g' "${podman_library_parent}")" != "0:0" ]]; then
+              echo "ERROR: the native ARM64 Podman library path is not a trusted root-owned directory: ${podman_library_parent}." >&2
+              exit 1
+            fi
+            podman_library_parent_mode="$(/usr/bin/stat -c '%a' "${podman_library_parent}")"
+            if [[ ! "${podman_library_parent_mode}" =~ ^[0-7]{3,4}$ ]] || \
+               (( (8#${podman_library_parent_mode} & 0022) != 0 )); then
+              echo "ERROR: the native ARM64 Podman library path is writable by an untrusted account: ${podman_library_parent}." >&2
+              exit 1
+            fi
+          done
+          podman_library_tools=(
+            /usr/local/lib/podman/conmon
+            /usr/local/lib/podman/rootlessport
+            /usr/local/lib/podman/netavark
+            /usr/local/lib/podman/catatonit
+            /usr/local/lib/podman/aardvark-dns
+          )
+          for podman_tool in "${podman_library_tools[@]}"; do
+            if [[ ! -f "${podman_tool}" || -L "${podman_tool}" || \
+                  ! -x "${podman_tool}" || \
+                  "$(/usr/bin/stat -c '%u:%g:%a' "${podman_tool}")" != "0:0:755" ]]; then
+              echo "ERROR: the native ARM64 Podman library tool is not an exact sealed executable: ${podman_tool}." >&2
+              exit 1
+            fi
+          done
+          # These hashes are derived from the podman-static v5.8.4 ARM64 archive
+          # used and checksum-pinned by actions/runner-images at SHA256 a2f6b73cc0f7018e2e8518338a4ec27db70148e1af86e16719235605aefd1df3.
+          printf '%s\n' \
+            '5884e882b252f4a8073fc22c66633993fb8e0adf79ecd1631b4d3e1f382f6f90  /usr/local/bin/podman' \
+            'eb61412faa7ea9ee395b21f3a70def43238de0d7e120ae5e93f4f9528af5f5f4  /usr/local/bin/crun' \
+            '4efb64a7a1125462cec5023c09384651654c15f294b3c59e0753e8e1536c068b  /usr/local/bin/runc' \
+            '54461fe89d55222cde826b917e96b92c450031446841eeab672c6c70fcdc9822  /usr/local/bin/pasta' \
+            '36c2f2886f132e568636d018e491570c36364d9984f4df30a4616133f89c0119  /usr/local/bin/fuse-overlayfs' \
+            'dcc03958b573a8ddc189f5cd87b78913df129384cba59cb03093f1ff03417c53  /usr/local/lib/podman/conmon' \
+            'b0fa7e4a1aacaed6dffe28131cff7d1d295f2d7653bc963d507f6a67009225d9  /usr/local/lib/podman/rootlessport' \
+            '2d80e408dd2d393673e8970f201165df96f84e0dd91976d64b9c1cc77fde6bf9  /usr/local/lib/podman/netavark' \
+            '75e90ba96e3fbe6c9ed9f994f821fc4e7af89273acb5022790b682674b6911df  /usr/local/lib/podman/catatonit' \
+            '844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95  /usr/local/lib/podman/aardvark-dns' | \
+            /usr/bin/sha256sum --check --strict
+          test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"
+
       - name: Checkout Exact ARM64 Candidate Commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -455,7 +570,9 @@ jobs:
           printf '%s\n' \
             '[engine]' \
             'cgroup_manager="systemd"' \
-            'runtime="runc"' > "${containers_override}"
+            'runtime="runc"' \
+            '[engine.runtimes]' \
+            'runc = ["/usr/local/bin/runc"]' > "${containers_override}"
           if [[ ! -f "${containers_override}" || -L "${containers_override}" || \
                 "$(stat -c '%u' "${containers_override}")" != "${user_id}" || \
                 "$(stat -c '%a' "${containers_override}")" != "600" ]]; then
@@ -484,6 +601,9 @@ jobs:
             --setenv='PYTHONDONTWRITEBYTECODE=1' \
             --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
             --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
+            /usr/bin/bash --noprofile --norc -e -o pipefail -c \
+            'runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; test "${runtime_path}" = "/usr/local/bin/runc"; exec "$@"' \
+            syswarden-arm64-lifecycle \
             /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
             --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -817,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 8)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 9)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                3,
+                4,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 2)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 3)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 3)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 4)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 6,
-                "scripts/ci/release_gate_test.py": 6,
+                ".github/workflows/release-manager.yml": 8,
+                "scripts/ci/release_gate_test.py": 8,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -873,6 +873,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         pinned_contracts = (
             (
+                'if [[ "${v4032_arm64_parent_sha}" != '
+                '"8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then'
+            ),
+            (
                 'if [[ "${v4032_merge_parent_sha}" != '
                 '"14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then'
             ),
@@ -891,6 +895,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        arm64_subject_contract = (
+            "v4032_arm64_expected_subject='Qualification : repair v4.03.2 "
+            "native ARM64 Podman path contract (#97)'"
+        )
         merge_subject_contract = (
             "v4032_merge_expected_subject='Qualification : repair v4.03.2 "
             "merged squash subject contract (#96)'"
@@ -898,6 +906,12 @@ class ReleaseGateTests(unittest.TestCase):
         repair_subject_contract = (
             "v4032_expected_subject='Qualification : repair v4.03.2 "
             "package lifecycle qualification (#95) (#95)'"
+        )
+        arm64_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
         )
         merge_paths = (
             ".github/workflows/release-manager.yml",
@@ -936,23 +950,92 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(arm64_subject_contract), 1)
             self.assertEqual(block.count(merge_subject_contract), 1)
             self.assertEqual(block.count(repair_subject_contract), 1)
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_arm64_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('v4032_arm64_parent_sha="$(git rev-parse HEAD^)"'),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_arm64_head_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 ARM64 Podman path repair diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    "# END exact v4.03.2 ARM64 Podman path repair diff contract"
+                ),
+                1,
+            )
+            arm64_diff = block.split(
+                "# BEGIN exact v4.03.2 ARM64 Podman path repair diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 ARM64 Podman path repair diff contract", 1
+            )[0]
+            self.assertEqual(
+                arm64_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(arm64_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(arm64_diff.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(arm64_diff.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(
+                arm64_diff.count(
+                    "${#actual_v4032_arm64_diff[@]} != "
+                    "${#expected_v4032_arm64_diff[@]}"
+                ),
+                1,
+            )
+            for path in arm64_paths:
+                self.assertEqual(arm64_diff.count(f'"{path}"'), 2)
+                self.assertEqual(arm64_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_merge_ref=HEAD^"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_merge_parent_sha="$(git rev-parse '
+                    '"${v4032_merge_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_merge_subject="$(git log -1 --format=%s '
+                    '"${v4032_merge_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_merge_subject}" != '
                     '"${v4032_merge_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('v4032_merge_parent_sha="$(git rev-parse HEAD^)"'),
-                1,
-            )
-            self.assertEqual(
                 block.count(
-                    'v4032_merge_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_merge_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_merge_ref}")"'
                 ),
                 1,
             )
@@ -977,11 +1060,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 merge_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_merge_ref}^" "${v4032_merge_ref}"'
                 ),
                 1,
             )
-            self.assertEqual(merge_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(
+                merge_diff.count(
+                    'for tree_ref in "${v4032_merge_ref}^" '
+                    '"${v4032_merge_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(merge_diff.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(merge_diff.count('"${tree_type}" != "blob"'), 1)
             self.assertEqual(
@@ -994,7 +1084,9 @@ class ReleaseGateTests(unittest.TestCase):
             for path in merge_paths:
                 self.assertEqual(merge_diff.count(f'"{path}"'), 2)
                 self.assertEqual(merge_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_repair_ref=HEAD^"), 1)
+            self.assertEqual(
+                block.count('v4032_repair_ref="${v4032_merge_ref}^"'), 1
+            )
             self.assertEqual(
                 block.count(
                     'v4032_parent_sha="$(git rev-parse '
@@ -1071,7 +1163,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                1,
+                2,
             )
             self.assertEqual(
                 block.count(
@@ -1090,12 +1182,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                2,
+                3,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 2)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 3)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1107,14 +1199,14 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             for path in expected_paths:
-                if path == "build_packages.sh":
-                    expected_count = 3
-                elif path in merge_paths:
-                    expected_count = 4
-                else:
-                    expected_count = 2
+                expected_count = 2
+                expected_count += 2 if path in merge_paths else 0
+                expected_count += 2 if path in arm64_paths else 0
+                expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
-                expected_status_count = 2 if path in merge_paths else 1
+                expected_status_count = 1
+                expected_status_count += 1 if path in merge_paths else 0
+                expected_status_count += 1 if path in arm64_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1135,7 +1227,23 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 3
+                block.count('./scripts/versioning.sh validate-commit'), 4
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_merge_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_merge_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('--base-ref "${v4032_merge_parent_sha}"'), 1
+            )
+            self.assertEqual(
+                block.count(
+                    '--commit-message "${v4032_merge_commit_message}"'
+                ),
+                1,
             )
             self.assertEqual(
                 block.count(
@@ -1183,6 +1291,129 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
+
+    def exact_v4032_arm64_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.2 ARM64 Podman path repair diff contract\n"
+        end = "# END exact v4.03.2 ARM64 Podman path repair diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_arm64_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_arm64_expected_subject="
+        end = 'read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
+    def make_v4032_regular_diff_repository(
+        self,
+        name: str,
+        relative_paths: tuple[str, ...],
+        mutation: str | None,
+    ) -> Path:
+        repository = self.root / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        paths = [repository / relative_path for relative_path in relative_paths]
+        for path in paths:
+            self.write_file(path, b"reviewed parent\n")
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed parent"],
+            check=True,
+        )
+        for path in paths:
+            path.write_bytes(b"reviewed repair\n")
+        if mutation == "extra file":
+            self.write_file(repository / "unauthorized.txt", b"unexpected\n")
+        elif mutation == "unchanged file":
+            paths[-1].write_bytes(b"reviewed parent\n")
+        elif mutation == "mode":
+            paths[0].chmod(0o755)
+        elif mutation == "symlink":
+            paths[1].unlink()
+            paths[1].symlink_to("unauthorized-target")
+        elif mutation == "rename":
+            paths[-1].rename(paths[-1].with_name("renamed-" + paths[-1].name))
+        elif mutation == "delete":
+            paths[-1].unlink()
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed repair"],
+            check=True,
+        )
+        return repository
+
+    def assert_exact_subject_gate(
+        self, script: str, cases: dict[str, tuple[str, bool]]
+    ) -> None:
+        for name, (subject, accepted) in cases.items():
+            with self.subTest(name=name):
+                environment = dict(os.environ)
+                environment["COMMIT_SUBJECT"] = subject
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=REPOSITORY,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def assert_regular_diff_gate(
+        self, script: str, name_prefix: str, relative_paths: tuple[str, ...]
+    ) -> None:
+        mutations = (
+            None,
+            "extra file",
+            "unchanged file",
+            "mode",
+            "symlink",
+            "rename",
+            "delete",
+        )
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=mutation or "exact"):
+                repository = self.make_v4032_regular_diff_repository(
+                    f"{name_prefix}-{index}", relative_paths, mutation
+                )
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=repository,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if mutation is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(
+                        result.returncode, 0, result.stdout + result.stderr
+                    )
 
     def exact_v4032_fix_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1369,6 +1600,57 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_arm64_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_arm64_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract",
+                    False,
+                ),
+                "double pull request suffix": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract (#97) (#97)",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract (#96)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract (#98)",
+                    False,
+                ),
+                "wrong version": (
+                    "Qualification : repair v4.03.3 native ARM64 Podman path contract (#97)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : repair v4.03.2 native ARM64 Podman path contract (#97) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_arm64_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_arm64_diff_script(),
+            "v4032-arm64-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+            ),
+        )
+
     def test_release_manager_bounds_v4032_repair_to_exact_reviewed_chain(
         self,
     ) -> None:
@@ -1494,8 +1776,10 @@ class ReleaseGateTests(unittest.TestCase):
             ),
         }
         for name, mutation in mutations.items():
-            with self.subTest(name=name), self.assertRaises(AssertionError):
-                self.assert_v4032_preserved_version_recovery_contract(mutation)
+            with self.subTest(name=name):
+                self.assertNotEqual(mutation, workflow)
+                with self.assertRaises(AssertionError):
+                    self.assert_v4032_preserved_version_recovery_contract(mutation)
 
     def test_release_manager_v4032_subject_is_exact_github_squash(self) -> None:
         script = self.v4032_subject_gate_script()

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -716,6 +716,89 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertNotIn("--tag-phase", self.workflow)
         self.assertNotIn("--require-tag", self.workflow)
 
+    def test_arm64_podman_trust_path_is_sealed_before_checkout(self) -> None:
+        step_name = "Seal Native ARM64 Podman Trust Path"
+        step = workflow_step(self.workflow, step_name)
+        self.assertIn(
+            "shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}", step
+        )
+        script = workflow_step_script(self.workflow, step_name)
+        for contract in (
+            'podman_parent="/usr/local/bin"',
+            "for trusted_parent in /usr /usr/bin /usr/local; do",
+            '"$(/usr/bin/stat -c \'%u:%g\' "${trusted_parent}")" != "0:0"',
+            "(( (8#${trusted_parent_mode} & 0022) != 0 ))",
+            "/usr/bin/bash",
+            "/usr/bin/chmod",
+            "/usr/bin/sha256sum",
+            "/usr/bin/stat",
+            "/usr/bin/sudo",
+            'podman_bin_tools=(',
+            "/usr/local/bin/podman",
+            "/usr/local/bin/crun",
+            "/usr/local/bin/runc",
+            "/usr/local/bin/pasta",
+            "/usr/local/bin/fuse-overlayfs",
+            "for podman_library_parent in /usr/local/lib /usr/local/lib/podman; do",
+            'podman_library_tools=(',
+            "/usr/local/lib/podman/conmon",
+            "/usr/local/lib/podman/rootlessport",
+            "/usr/local/lib/podman/netavark",
+            "/usr/local/lib/podman/catatonit",
+            "/usr/local/lib/podman/aardvark-dns",
+            "/usr/bin/sudo -n /usr/bin/chmod 0755 --",
+            '"${podman_parent}" "${podman_bin_tools[@]}"',
+            '"$(/usr/bin/stat -c \'%u:%g:%a\' "${podman_parent}")" != "0:0:755"',
+            "a2f6b73cc0f7018e2e8518338a4ec27db70148e1af86e16719235605aefd1df3",
+            "5884e882b252f4a8073fc22c66633993fb8e0adf79ecd1631b4d3e1f382f6f90",
+            "eb61412faa7ea9ee395b21f3a70def43238de0d7e120ae5e93f4f9528af5f5f4",
+            "4efb64a7a1125462cec5023c09384651654c15f294b3c59e0753e8e1536c068b",
+            "54461fe89d55222cde826b917e96b92c450031446841eeab672c6c70fcdc9822",
+            "36c2f2886f132e568636d018e491570c36364d9984f4df30a4616133f89c0119",
+            "dcc03958b573a8ddc189f5cd87b78913df129384cba59cb03093f1ff03417c53",
+            "b0fa7e4a1aacaed6dffe28131cff7d1d295f2d7653bc963d507f6a67009225d9",
+            "2d80e408dd2d393673e8970f201165df96f84e0dd91976d64b9c1cc77fde6bf9",
+            "75e90ba96e3fbe6c9ed9f994f821fc4e7af89273acb5022790b682674b6911df",
+            "844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95",
+            "/usr/bin/sha256sum --check --strict",
+            'test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"',
+        ):
+            self.assertIn(contract, script)
+        structure_guard = script.index(
+            'if [[ ! -d "${podman_parent}" || -L "${podman_parent}"'
+        )
+        tool_guard = script.index('for podman_tool in "${podman_bin_tools[@]}"; do')
+        seal = script.index("/usr/bin/sudo -n /usr/bin/chmod 0755 --")
+        attestation = script.index(
+            '"$(/usr/bin/stat -c \'%u:%g:%a\' "${podman_parent}")" != "0:0:755"'
+        )
+        digest = script.index("/usr/bin/sha256sum --check --strict")
+        version = script.index('/usr/local/bin/podman --version')
+        self.assertLess(structure_guard, tool_guard)
+        self.assertLess(tool_guard, seal)
+        self.assertLess(seal, attestation)
+        self.assertLess(attestation, digest)
+        self.assertLess(digest, version)
+        seal_step = self.workflow.index(f"      - name: {step_name}\n")
+        checkout_step = self.workflow.index(
+            "      - name: Checkout Exact ARM64 Candidate Commit\n"
+        )
+        context_step = self.workflow.index(
+            "      - name: Validate Native ARM64 Shard Context\n"
+        )
+        self.assertLess(seal_step, checkout_step)
+        self.assertLess(checkout_step, context_step)
+        for forbidden in (
+            "./scripts/",
+            "git ",
+            "curl ",
+            "apt-get",
+            "command -v",
+            "chmod -R",
+            "|| true",
+        ):
+            self.assertNotIn(forbidden, script)
+
     def test_package_main_is_independently_resolved_on_hosted_runner(self) -> None:
         for step_name in (
             "Resolve Unique Successful Main Package Artifact",
@@ -921,6 +1004,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'sudo -n stat -c \'%u:%g:%a\' "${delegate_drop_in}"',
             "'cgroup_manager=\"systemd\"'",
             "'runtime=\"runc\"'",
+            "'[engine.runtimes]'",
+            "'runc = [\"/usr/local/bin/runc\"]'",
             '"$(stat -c \'%a\' "${containers_override}")" != "600"',
             'unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             'sudo -n systemd-run',
@@ -931,6 +1016,10 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--setenv="CONTAINERS_CONF_OVERRIDE=${containers_override}"',
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
+            "/usr/bin/bash --noprofile --norc -e -o pipefail -c",
+            'runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
+            'test "${runtime_path}" = "/usr/local/bin/runc"; exec "$@"',
+            "syswarden-arm64-lifecycle",
             '/usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py"',
             '--podman /usr/local/bin/podman',
             'sudo -n rm -f -- "${delegate_drop_in}"',


### PR DESCRIPTION
## Summary

- seals the GitHub-hosted ARM64 Podman trust path before checkout or repository code execution
- restores the reviewed Podman bundle tools to root-owned 0755 files and verifies ten exact SHA256 identities
- pins the lifecycle shard to the verified /usr/local/bin/runc and attests the effective OCI runtime in the delegated session
- extends the v4.03.2 Release Manager contract through the exact PR97, PR96, PR95, PR94, and PR93 chain

## Root cause

The current GitHub ARM64 runner image installs the checksum-pinned podman-static v5.8.4 bundle and later applies mode 0777 recursively to /usr/local/bin. The protected qualification correctly rejected that writable parent before starting the lifecycle lab.

## Validation

- exact package and release validator suite: 318/318 passed
- Release Manager gate suite: 48/48 passed
- release qualification workflow suite: 30/30 passed
- YAML parsing, Python compilation, Bash syntax, Go versionctl, and git diff checks passed
- independent future squash and v4.03.2 tag simulation passed the complete reviewed ancestry contract

## Scope

- exactly four reviewed workflow and validator files are modified
- no product source, package payload, version, changelog, release asset, image, diagram, or official SysWarden logo is changed
- no tag, qualification run, runner registration, or GitHub Release is created by this PR

## Merge contract

Squash with the PR title exactly as written. Do not append a pull request number manually; GitHub must create the single expected (#97) suffix.