### PR TITLE
Qualification : repair v4.03.2 ARM64 OCI runtime resolution

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_arm64_parent_sha="$(git rev-parse HEAD^)"
+              v4032_runtime_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
+                exit 1
+              fi
+              v4032_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)'
+              if [[ "${commit_subject}" != "${v4032_runtime_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_runtime_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 OCI runtime resolution diff contract
+              expected_v4032_runtime_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_runtime_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_runtime_diff[@]} != ${#expected_v4032_runtime_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_runtime_diff[@]}; index++)); do
+                if [[ "${actual_v4032_runtime_diff[index]}" != "${expected_v4032_runtime_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_runtime_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_runtime_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 OCI runtime resolution ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 OCI runtime resolution diff contract
+              v4032_arm64_ref=HEAD^
+              v4032_arm64_parent_sha="$(git rev-parse "${v4032_arm64_ref}^")"
               if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
                 exit 1
               fi
               v4032_arm64_expected_subject='Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)'
-              if [[ "${commit_subject}" != "${v4032_arm64_expected_subject}" ]]; then
+              v4032_arm64_subject="$(git log -1 --format=%s "${v4032_arm64_ref}")"
+              if [[ "${v4032_arm64_subject}" != "${v4032_arm64_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 "${v4032_arm64_ref}")"
               if (( ${#v4032_arm64_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair must be one linear commit." >&2
                 exit 1
@@ -159,7 +217,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_arm64_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_arm64_ref}^" "${v4032_arm64_ref}"
               )
               if (( ${#actual_v4032_arm64_diff[@]} != ${#expected_v4032_arm64_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair must modify exactly the four reviewed files." >&2
@@ -177,7 +236,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_arm64_ref}^" "${v4032_arm64_ref}"; do
                 for fix_path in "${v4032_arm64_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -192,7 +251,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 Podman path repair diff contract
-              v4032_merge_ref=HEAD^
+              v4032_merge_ref="${v4032_arm64_ref}^"
               v4032_merge_parent_sha="$(git rev-parse "${v4032_merge_ref}^")"
               if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
@@ -365,6 +424,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_arm64_commit_message="$(git log -1 --format=%B "${v4032_arm64_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_arm64_parent_sha}" \
+                --commit-message "${v4032_arm64_commit_message}"
               v4032_merge_commit_message="$(git log -1 --format=%B "${v4032_merge_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
@@ -859,17 +923,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_arm64_parent_sha="$(git rev-parse HEAD^)"
+              v4032_runtime_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
+                exit 1
+              fi
+              v4032_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)'
+              if [[ "${commit_subject}" != "${v4032_runtime_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_runtime_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 OCI runtime resolution diff contract
+              expected_v4032_runtime_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_runtime_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_runtime_diff[@]} != ${#expected_v4032_runtime_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_runtime_diff[@]}; index++)); do
+                if [[ "${actual_v4032_runtime_diff[index]}" != "${expected_v4032_runtime_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_runtime_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_runtime_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 OCI runtime resolution ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 OCI runtime resolution diff contract
+              v4032_arm64_ref=HEAD^
+              v4032_arm64_parent_sha="$(git rev-parse "${v4032_arm64_ref}^")"
               if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
                 exit 1
               fi
               v4032_arm64_expected_subject='Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)'
-              if [[ "${commit_subject}" != "${v4032_arm64_expected_subject}" ]]; then
+              v4032_arm64_subject="$(git log -1 --format=%s "${v4032_arm64_ref}")"
+              if [[ "${v4032_arm64_subject}" != "${v4032_arm64_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 "${v4032_arm64_ref}")"
               if (( ${#v4032_arm64_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair must be one linear commit." >&2
                 exit 1
@@ -882,7 +1004,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_arm64_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_arm64_ref}^" "${v4032_arm64_ref}"
               )
               if (( ${#actual_v4032_arm64_diff[@]} != ${#expected_v4032_arm64_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair must modify exactly the four reviewed files." >&2
@@ -900,7 +1023,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_arm64_ref}^" "${v4032_arm64_ref}"; do
                 for fix_path in "${v4032_arm64_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -915,7 +1038,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 Podman path repair diff contract
-              v4032_merge_ref=HEAD^
+              v4032_merge_ref="${v4032_arm64_ref}^"
               v4032_merge_parent_sha="$(git rev-parse "${v4032_merge_ref}^")"
               if [[ "${v4032_merge_parent_sha}" != "14ccbf1d32c221ee1e430dbad5eac40b1c5bd2c1" ]]; then
                 echo "ERROR: the v4.03.2 merge-subject repair is not based on the reviewed PR95 squash." >&2
@@ -1088,6 +1211,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_arm64_commit_message="$(git log -1 --format=%B "${v4032_arm64_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_arm64_parent_sha}" \
+                --commit-message "${v4032_arm64_commit_message}"
               v4032_merge_commit_message="$(git log -1 --format=%B "${v4032_merge_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -158,6 +158,16 @@ jobs:
             '844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95  /usr/local/lib/podman/aardvark-dns' | \
             /usr/bin/sha256sum --check --strict
           test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"
+          expected_native_runtime="/usr/local/bin/crun"
+          if ! native_runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; then
+            echo "ERROR: native ARM64 Podman could not resolve its OCI runtime before checkout." >&2
+            exit 1
+          fi
+          if [[ "${native_runtime_path}" != "${expected_native_runtime}" ]]; then
+            printf 'ERROR: native ARM64 Podman resolved an unexpected OCI runtime path: %q.\n' \
+              "${native_runtime_path}" >&2
+            exit 1
+          fi
 
       - name: Checkout Exact ARM64 Candidate Commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -570,9 +580,9 @@ jobs:
           printf '%s\n' \
             '[engine]' \
             'cgroup_manager="systemd"' \
-            'runtime="runc"' \
+            'runtime="crun"' \
             '[engine.runtimes]' \
-            'runc = ["/usr/local/bin/runc"]' > "${containers_override}"
+            'crun = ["/usr/local/bin/crun"]' > "${containers_override}"
           if [[ ! -f "${containers_override}" || -L "${containers_override}" || \
                 "$(stat -c '%u' "${containers_override}")" != "${user_id}" || \
                 "$(stat -c '%a' "${containers_override}")" != "600" ]]; then
@@ -602,7 +612,7 @@ jobs:
             --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
             --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
             /usr/bin/bash --noprofile --norc -e -o pipefail -c \
-            'runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; test "${runtime_path}" = "/usr/local/bin/runc"; exec "$@"' \
+            'if ! runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; then echo "ERROR: native ARM64 Podman could not resolve its OCI runtime." >&2; exit 1; fi; if [[ "${runtime_path}" != "/usr/local/bin/crun" ]]; then printf "ERROR: native ARM64 Podman resolved an unexpected OCI runtime path: %q.\n" "${runtime_path}" >&2; exit 1; fi; exec "$@"' \
             syswarden-arm64-lifecycle \
             /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
             --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
@@ -636,6 +646,25 @@ jobs:
               shard_rc=1
             fi
           fi
+          report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"
+          if [[ ! -e "${report}" && ! -L "${report}" ]]; then
+            error_message="native ARM64 lifecycle command exited before producing its canonical report (rc=${shard_rc})"
+            generated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            jq -n \
+              --arg error "${error_message}" \
+              --arg generated_at "${generated_at}" \
+              '{
+                schema_version: 4,
+                generated_at: $generated_at,
+                status: "fail",
+                harness_complete: false,
+                release_ready: false,
+                blocker_ids: [],
+                unexpected_failed_checks: ["harness:" + $error],
+                error: $error
+              }' > "${report}"
+            chmod 0600 "${report}"
+          fi
           printf '%s\n' "${shard_rc}" > \
             "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
           chmod 0600 "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
@@ -651,9 +680,10 @@ jobs:
           report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"
           status="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.rc"
           for path in "${report}" "${status}"; do
-            test -s "${path}"
-            test -f "${path}"
-            test ! -L "${path}"
+            if [[ ! -s "${path}" || ! -f "${path}" || -L "${path}" ]]; then
+              echo "ERROR: the native ARM64 lifecycle evidence file is absent or invalid: ${path}." >&2
+              exit 1
+            fi
           done
           report_sha256="$(sha256sum "${report}")"
           report_sha256="${report_sha256%% *}"

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -817,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 9)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 10)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                4,
+                5,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 3)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 4)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 4)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 5)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 8,
-                "scripts/ci/release_gate_test.py": 8,
+                ".github/workflows/release-manager.yml": 10,
+                "scripts/ci/release_gate_test.py": 10,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -873,6 +873,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         pinned_contracts = (
             (
+                'if [[ "${v4032_runtime_parent_sha}" != '
+                '"0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then'
+            ),
+            (
                 'if [[ "${v4032_arm64_parent_sha}" != '
                 '"8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then'
             ),
@@ -895,6 +899,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        runtime_subject_contract = (
+            "v4032_runtime_expected_subject='Qualification : repair v4.03.2 "
+            "ARM64 OCI runtime resolution (#98)'"
+        )
         arm64_subject_contract = (
             "v4032_arm64_expected_subject='Qualification : repair v4.03.2 "
             "native ARM64 Podman path contract (#97)'"
@@ -913,6 +921,7 @@ class ReleaseGateTests(unittest.TestCase):
             "scripts/ci/release_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
         )
+        runtime_paths = arm64_paths
         merge_paths = (
             ".github/workflows/release-manager.yml",
             "scripts/ci/release_gate_test.py",
@@ -950,24 +959,97 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(runtime_subject_contract), 1)
             self.assertEqual(block.count(arm64_subject_contract), 1)
             self.assertEqual(block.count(merge_subject_contract), 1)
             self.assertEqual(block.count(repair_subject_contract), 1)
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_runtime_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('v4032_runtime_parent_sha="$(git rev-parse HEAD^)"'),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runtime_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_runtime_head_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 ARM64 OCI runtime resolution "
+                    "diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    "# END exact v4.03.2 ARM64 OCI runtime resolution "
+                    "diff contract"
+                ),
+                1,
+            )
+            runtime_diff = block.split(
+                "# BEGIN exact v4.03.2 ARM64 OCI runtime resolution "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 ARM64 OCI runtime resolution diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                runtime_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(runtime_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(runtime_diff.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(runtime_diff.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(
+                runtime_diff.count(
+                    "${#actual_v4032_runtime_diff[@]} != "
+                    "${#expected_v4032_runtime_diff[@]}"
+                ),
+                1,
+            )
+            for path in runtime_paths:
+                self.assertEqual(runtime_diff.count(f'"{path}"'), 2)
+                self.assertEqual(runtime_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_arm64_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_parent_sha="$(git rev-parse '
+                    '"${v4032_arm64_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_subject="$(git log -1 --format=%s '
+                    '"${v4032_arm64_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_arm64_subject}" != '
                     '"${v4032_arm64_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('v4032_arm64_parent_sha="$(git rev-parse HEAD^)"'),
-                1,
-            )
-            self.assertEqual(
                 block.count(
-                    'v4032_arm64_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_arm64_ref}")"'
                 ),
                 1,
             )
@@ -993,11 +1075,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 arm64_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_arm64_ref}^" "${v4032_arm64_ref}"'
                 ),
                 1,
             )
-            self.assertEqual(arm64_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(
+                arm64_diff.count(
+                    'for tree_ref in "${v4032_arm64_ref}^" '
+                    '"${v4032_arm64_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(arm64_diff.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(arm64_diff.count('"${tree_type}" != "blob"'), 1)
             self.assertEqual(
@@ -1010,7 +1099,9 @@ class ReleaseGateTests(unittest.TestCase):
             for path in arm64_paths:
                 self.assertEqual(arm64_diff.count(f'"{path}"'), 2)
                 self.assertEqual(arm64_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_merge_ref=HEAD^"), 1)
+            self.assertEqual(
+                block.count('v4032_merge_ref="${v4032_arm64_ref}^"'), 1
+            )
             self.assertEqual(
                 block.count(
                     'v4032_merge_parent_sha="$(git rev-parse '
@@ -1163,7 +1254,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                2,
+                3,
             )
             self.assertEqual(
                 block.count(
@@ -1182,12 +1273,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                3,
+                4,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 3)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 4)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1202,11 +1293,13 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count = 2
                 expected_count += 2 if path in merge_paths else 0
                 expected_count += 2 if path in arm64_paths else 0
+                expected_count += 2 if path in runtime_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1
                 expected_status_count += 1 if path in merge_paths else 0
                 expected_status_count += 1 if path in arm64_paths else 0
+                expected_status_count += 1 if path in runtime_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1227,7 +1320,23 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 4
+                block.count('./scripts/versioning.sh validate-commit'), 5
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_arm64_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('--base-ref "${v4032_arm64_parent_sha}"'), 1
+            )
+            self.assertEqual(
+                block.count(
+                    '--commit-message "${v4032_arm64_commit_message}"'
+                ),
+                1,
             )
             self.assertEqual(
                 block.count(
@@ -1292,6 +1401,30 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_runtime_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 ARM64 OCI runtime resolution diff contract\n"
+        )
+        end = "# END exact v4.03.2 ARM64 OCI runtime resolution diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_runtime_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_runtime_expected_subject="
+        end = (
+            'read -r -a v4032_runtime_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_arm64_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -1299,17 +1432,31 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 ARM64 Podman path repair diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_arm64_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_arm64_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_arm64_expected_subject="
-        end = 'read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
+        subject_assignment = (
+            'v4032_arm64_subject="$(git log -1 --format=%s '
+            '"${v4032_arm64_ref}")"'
+        )
+        end = (
+            'read -r -a v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 '
+            '"${v4032_arm64_ref}")"'
+        )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_arm64_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def make_v4032_regular_diff_repository(
         self,
@@ -1600,6 +1747,57 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_runtime_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_runtime_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution",
+                    False,
+                ),
+                "double pull request suffix": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98) (#98)",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#97)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#99)",
+                    False,
+                ),
+                "wrong version": (
+                    "Qualification : repair v4.03.3 ARM64 OCI runtime resolution (#98)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_runtime_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_runtime_diff_script(),
+            "v4032-runtime-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+            ),
+        )
+
     def test_release_manager_v4032_arm64_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -1663,6 +1861,54 @@ class ReleaseGateTests(unittest.TestCase):
             "release tag": workflow.replace(
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
+            ),
+            "runtime parent resolution": workflow.replace(
+                'v4032_runtime_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_runtime_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact runtime parent": workflow.replace(
+                "0e7fc0a3437d69cea8086abacd0a30e032a0579f",
+                "1e7fc0a3437d69cea8086abacd0a30e032a0579f",
+            ),
+            "runtime canonical subject": workflow.replace(
+                "Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)",
+                "Qualification : arbitrary v4.03.2 ARM64 OCI repair (#98)",
+            ),
+            "runtime linear head": workflow.replace(
+                'v4032_runtime_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_runtime_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "ARM64 reference": workflow.replace(
+                "v4032_arm64_ref=HEAD^", "v4032_arm64_ref=HEAD^^"
+            ),
+            "ARM64 parent resolution": workflow.replace(
+                'v4032_arm64_parent_sha="$(git rev-parse '
+                '"${v4032_arm64_ref}^")"',
+                'v4032_arm64_parent_sha="$(git rev-parse '
+                '"${v4032_arm64_ref}^^")"',
+            ),
+            "exact ARM64 parent": workflow.replace(
+                "8387b3e8b96a3778b333504dc9c948dfe06777d5",
+                "9387b3e8b96a3778b333504dc9c948dfe06777d5",
+            ),
+            "ARM64 canonical subject": workflow.replace(
+                "Qualification : repair v4.03.2 native ARM64 Podman path contract (#97)",
+                "Qualification : arbitrary v4.03.2 ARM64 Podman repair (#97)",
+            ),
+            "ARM64 subject source": workflow.replace(
+                'v4032_arm64_subject="$(git log -1 --format=%s '
+                '"${v4032_arm64_ref}")"',
+                'v4032_arm64_subject="$(git log -1 --format=%s HEAD)"',
+            ),
+            "ARM64 linear head": workflow.replace(
+                'v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_arm64_ref}")"',
+                'v4032_arm64_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
+            ),
+            "ARM64 validation base": workflow.replace(
+                '--base-ref "${v4032_arm64_parent_sha}"', '--base-ref HEAD^'
             ),
             "parent resolution": workflow.replace(
                 'v4032_parent_sha="$(git rev-parse "${v4032_repair_ref}^")"',

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -254,6 +254,47 @@ def run_arm_verdict(
         )
 
 
+def run_arm_seal(
+    script: str,
+    report: dict[str, object] | None,
+    status: str = "0\n",
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        evidence_directory = Path(temporary) / "evidence"
+        evidence_directory.mkdir()
+        if report is not None:
+            (evidence_directory / "package-lifecycle-arm64.json").write_text(
+                json.dumps(report, separators=(",", ":")),
+                encoding="utf-8",
+            )
+        (evidence_directory / "package-lifecycle-arm64.rc").write_text(
+            status,
+            encoding="utf-8",
+        )
+        github_output = Path(temporary) / "github-output"
+        process_environment = os.environ.copy()
+        process_environment.update(
+            {
+                "ARM_EVIDENCE_DIR": str(evidence_directory),
+                "GITHUB_OUTPUT": str(github_output),
+                "GITHUB_RUN_ATTEMPT": "1",
+                "GITHUB_RUN_ID": "123456",
+                "RELEASE_SHA": "a" * 40,
+            }
+        )
+        result = subprocess.run(
+            ["/bin/bash", "-c", script],
+            cwd=REPOSITORY,
+            env=process_environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        output = github_output.read_text(encoding="utf-8") if github_output.exists() else ""
+        return result, output
+
+
 def run_unsigned_artifact_resolver(
     script: str,
     artifacts: list[dict[str, object]],
@@ -762,6 +803,11 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95",
             "/usr/bin/sha256sum --check --strict",
             'test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"',
+            'expected_native_runtime="/usr/local/bin/crun"',
+            'if ! native_runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
+            "native ARM64 Podman could not resolve its OCI runtime before checkout",
+            '"${native_runtime_path}" != "${expected_native_runtime}"',
+            "native ARM64 Podman resolved an unexpected OCI runtime path",
         ):
             self.assertIn(contract, script)
         structure_guard = script.index(
@@ -774,11 +820,13 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
         digest = script.index("/usr/bin/sha256sum --check --strict")
         version = script.index('/usr/local/bin/podman --version')
+        runtime_probe = script.index('/usr/local/bin/podman info --format')
         self.assertLess(structure_guard, tool_guard)
         self.assertLess(tool_guard, seal)
         self.assertLess(seal, attestation)
         self.assertLess(attestation, digest)
         self.assertLess(digest, version)
+        self.assertLess(version, runtime_probe)
         seal_step = self.workflow.index(f"      - name: {step_name}\n")
         checkout_step = self.workflow.index(
             "      - name: Checkout Exact ARM64 Candidate Commit\n"
@@ -1003,9 +1051,9 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'sudo -n test -d "${delegate_directory}"',
             'sudo -n stat -c \'%u:%g:%a\' "${delegate_drop_in}"',
             "'cgroup_manager=\"systemd\"'",
-            "'runtime=\"runc\"'",
+            "'runtime=\"crun\"'",
             "'[engine.runtimes]'",
-            "'runc = [\"/usr/local/bin/runc\"]'",
+            "'crun = [\"/usr/local/bin/crun\"]'",
             '"$(stat -c \'%a\' "${containers_override}")" != "600"',
             'unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             'sudo -n systemd-run',
@@ -1017,8 +1065,11 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
             "/usr/bin/bash --noprofile --norc -e -o pipefail -c",
-            'runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
-            'test "${runtime_path}" = "/usr/local/bin/runc"; exec "$@"',
+            'if ! runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
+            '"${runtime_path}" != "/usr/local/bin/crun"',
+            "native ARM64 Podman could not resolve its OCI runtime",
+            "native ARM64 Podman resolved an unexpected OCI runtime path",
+            'exec "$@"',
             "syswarden-arm64-lifecycle",
             '/usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py"',
             '--podman /usr/local/bin/podman',
@@ -1030,6 +1081,12 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'arm_cleanup_completed=true',
             'trap - EXIT',
             'ARM64 delegated session cleanup or restoration failed.',
+            'report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"',
+            'if [[ ! -e "${report}" && ! -L "${report}" ]]',
+            "native ARM64 lifecycle command exited before producing its canonical report",
+            "schema_version: 4",
+            'unexpected_failed_checks: ["harness:" + $error]',
+            'chmod 0600 "${report}"',
         ):
             self.assertIn(contract, script)
         for forbidden in (
@@ -1219,6 +1276,72 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
                 self.assertNotEqual(rejected.returncode, 0)
         rejected_rc = run_arm_verdict(verdict_script, valid_report, "1\n")
         self.assertNotEqual(rejected_rc.returncode, 0)
+
+    def test_arm64_missing_report_recovery_and_seal_failure_evidence(self) -> None:
+        lifecycle_script = workflow_step_script(
+            self.workflow, "Run Native ARM64 Package Lifecycle Shard"
+        )
+        recovery_marker = 'report="${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json"'
+        self.assertEqual(lifecycle_script.count(recovery_marker), 1)
+        recovery_script = (
+            "set -euo pipefail\nshard_rc=1\n"
+            + recovery_marker
+            + lifecycle_script.split(recovery_marker, 1)[1]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            process_environment = os.environ.copy()
+            process_environment["ARM_EVIDENCE_DIR"] = temporary
+            recovered = subprocess.run(
+                ["/bin/bash", "-c", recovery_script],
+                cwd=REPOSITORY,
+                env=process_environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            recovered_report_path = Path(temporary) / "package-lifecycle-arm64.json"
+            recovered_report = json.loads(
+                recovered_report_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(recovered_report["schema_version"], 4)
+            self.assertEqual(recovered_report["status"], "fail")
+            self.assertFalse(recovered_report["harness_complete"])
+            self.assertFalse(recovered_report["release_ready"])
+            self.assertIn("rc=1", recovered_report["error"])
+            self.assertEqual(recovered_report_path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(
+                (Path(temporary) / "package-lifecycle-arm64.rc").read_text(
+                    encoding="utf-8"
+                ),
+                "1\n",
+            )
+
+        seal_script = workflow_step_script(
+            self.workflow, "Seal Native ARM64 Package Lifecycle Shard"
+        )
+        valid_report: dict[str, object] = {
+            "status": "pass",
+            "harness_complete": True,
+            "release_ready": True,
+            "blocker_ids": [],
+            "unexpected_failed_checks": [],
+        }
+        accepted, github_output = run_arm_seal(seal_script, valid_report)
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+        self.assertIn("artifact_name=syswarden-package-lifecycle-arm64-", github_output)
+        self.assertRegex(github_output, r"(?m)^report_sha256=[0-9a-f]{64}$")
+
+        missing, _ = run_arm_seal(seal_script, None)
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("lifecycle evidence file is absent or invalid", missing.stderr)
+
+        failure_evidence, github_output = run_arm_seal(
+            seal_script, valid_report, "1\n"
+        )
+        self.assertEqual(failure_evidence.returncode, 0, failure_evidence.stderr)
+        self.assertRegex(github_output, r"(?m)^report_sha256=[0-9a-f]{64}$")
 
     def test_unsigned_inventory_diff_uses_supported_gnu_invocation(self) -> None:
         inventory = workflow_step_script(


### PR DESCRIPTION
## Summary

- Align the native ARM64 Podman OCI runtime contract with the exact GitHub-hosted runner image, using the checksum-pinned static `crun` at `/usr/local/bin/crun`.
- Add explicit OCI runtime resolution diagnostics before checkout and inside the delegated user service.
- Preserve a sealed failure report when the runtime wrapper exits before the Python lifecycle lab can emit its canonical report.
- Extend the v4.03.2 Release Manager recovery chain through the exact PR98 squash contract while preserving PR97 through PR93.

## Root cause

Qualification run 32732147138 passed the Podman trust-path seal, exact checkout, package resolution, candidate inventory, and previous-release download. The delegated wrapper then exited before the Python lifecycle lab produced `package-lifecycle-arm64.json`, and the following seal failed on the missing report.

The exact ARM64 runner image installs a trusted containers.conf drop-in that maps `crun` to `/usr/local/bin/crun`. This change follows that immutable image contract instead of attempting to select a different runtime.

## Validation

- Full package and release validator matrix: 321 tests passed outside the sandbox, including Unix-socket cases.
- Release qualification workflow suite: 31 tests passed.
- Release gate suite: 48 tests passed.
- Version controller Go tests passed.
- Both workflow YAML files parsed successfully.
- Modified workflow shell bodies passed `bash -n`.
- `git diff --check` passed.
- Future PR98 squash and local `v4.03.2` tag simulation passed the complete Release Manager validation chain.
- Diff is limited to four reviewed `100644` files.

No release tag or GitHub Release is created by this pull request.
