### PR TITLE
Qualification : pin v4.03.2 ARM64 runc runtime path

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_runtime_parent_sha="$(git rev-parse HEAD^)"
+              v4032_runc_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2
+                exit 1
+              fi
+              v4032_runc_expected_subject='Qualification : pin v4.03.2 ARM64 runc runtime path (#99)'
+              if [[ "${commit_subject}" != "${v4032_runc_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 runc pin requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_runc_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 runc pin must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 runc pin diff contract
+              expected_v4032_runc_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_runc_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_runc_diff[@]} != ${#expected_v4032_runc_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 runc pin must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_runc_diff[@]}; index++)); do
+                if [[ "${actual_v4032_runc_diff[index]}" != "${expected_v4032_runc_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 runc pin contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_runc_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_runc_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 runc pin ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 runc pin diff contract
+              v4032_runtime_ref=HEAD^
+              v4032_runtime_parent_sha="$(git rev-parse "${v4032_runtime_ref}^")"
               if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
                 exit 1
               fi
               v4032_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)'
-              if [[ "${commit_subject}" != "${v4032_runtime_expected_subject}" ]]; then
+              v4032_runtime_subject="$(git log -1 --format=%s "${v4032_runtime_ref}")"
+              if [[ "${v4032_runtime_subject}" != "${v4032_runtime_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 "${v4032_runtime_ref}")"
               if (( ${#v4032_runtime_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must be one linear commit." >&2
                 exit 1
@@ -159,7 +217,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_runtime_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_runtime_ref}^" "${v4032_runtime_ref}"
               )
               if (( ${#actual_v4032_runtime_diff[@]} != ${#expected_v4032_runtime_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must modify exactly the four reviewed files." >&2
@@ -177,7 +236,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_runtime_ref}^" "${v4032_runtime_ref}"; do
                 for fix_path in "${v4032_runtime_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -192,7 +251,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 OCI runtime resolution diff contract
-              v4032_arm64_ref=HEAD^
+              v4032_arm64_ref="${v4032_runtime_ref}^"
               v4032_arm64_parent_sha="$(git rev-parse "${v4032_arm64_ref}^")"
               if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
@@ -424,6 +483,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_runtime_commit_message="$(git log -1 --format=%B "${v4032_runtime_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_runtime_parent_sha}" \
+                --commit-message "${v4032_runtime_commit_message}"
               v4032_arm64_commit_message="$(git log -1 --format=%B "${v4032_arm64_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
@@ -923,17 +987,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_runtime_parent_sha="$(git rev-parse HEAD^)"
+              v4032_runc_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2
+                exit 1
+              fi
+              v4032_runc_expected_subject='Qualification : pin v4.03.2 ARM64 runc runtime path (#99)'
+              if [[ "${commit_subject}" != "${v4032_runc_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 runc pin requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_runc_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 runc pin must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 runc pin diff contract
+              expected_v4032_runc_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_runc_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_runc_diff[@]} != ${#expected_v4032_runc_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 runc pin must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_runc_diff[@]}; index++)); do
+                if [[ "${actual_v4032_runc_diff[index]}" != "${expected_v4032_runc_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 runc pin contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_runc_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_runc_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 runc pin ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 runc pin diff contract
+              v4032_runtime_ref=HEAD^
+              v4032_runtime_parent_sha="$(git rev-parse "${v4032_runtime_ref}^")"
               if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
                 exit 1
               fi
               v4032_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 OCI runtime resolution (#98)'
-              if [[ "${commit_subject}" != "${v4032_runtime_expected_subject}" ]]; then
+              v4032_runtime_subject="$(git log -1 --format=%s "${v4032_runtime_ref}")"
+              if [[ "${v4032_runtime_subject}" != "${v4032_runtime_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 "${v4032_runtime_ref}")"
               if (( ${#v4032_runtime_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must be one linear commit." >&2
                 exit 1
@@ -946,7 +1068,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_runtime_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_runtime_ref}^" "${v4032_runtime_ref}"
               )
               if (( ${#actual_v4032_runtime_diff[@]} != ${#expected_v4032_runtime_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution must modify exactly the four reviewed files." >&2
@@ -964,7 +1087,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_runtime_ref}^" "${v4032_runtime_ref}"; do
                 for fix_path in "${v4032_runtime_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -979,7 +1102,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 OCI runtime resolution diff contract
-              v4032_arm64_ref=HEAD^
+              v4032_arm64_ref="${v4032_runtime_ref}^"
               v4032_arm64_parent_sha="$(git rev-parse "${v4032_arm64_ref}^")"
               if [[ "${v4032_arm64_parent_sha}" != "8387b3e8b96a3778b333504dc9c948dfe06777d5" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 Podman path repair is not based on the reviewed PR96 squash." >&2
@@ -1211,6 +1334,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_runtime_commit_message="$(git log -1 --format=%B "${v4032_runtime_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_runtime_parent_sha}" \
+                --commit-message "${v4032_runtime_commit_message}"
               v4032_arm64_commit_message="$(git log -1 --format=%B "${v4032_arm64_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -158,6 +158,26 @@ jobs:
             '844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95  /usr/local/lib/podman/aardvark-dns' | \
             /usr/bin/sha256sum --check --strict
           test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"
+          runc_version="$(/usr/local/bin/runc --version)"
+          if [[ "${runc_version%%$'\n'*}" != "runc version 1.4.3" ]]; then
+            echo "ERROR: native ARM64 runc does not match the sealed v1.4.3 contract." >&2
+            exit 1
+          fi
+          runc_help="$(/usr/local/bin/runc --help)"
+          if [[ "${runc_help}" != *"--systemd-cgroup"* ]]; then
+            echo "ERROR: native ARM64 runc does not expose systemd cgroup support." >&2
+            exit 1
+          fi
+          conmon_version="$(/usr/local/lib/podman/conmon --version)"
+          if [[ "${conmon_version%%$'\n'*}" != "conmon version 2.2.1" ]]; then
+            echo "ERROR: native ARM64 conmon does not match the sealed v2.2.1 contract." >&2
+            exit 1
+          fi
+          conmon_help="$(/usr/local/lib/podman/conmon --help)"
+          if [[ "${conmon_help}" != *"--systemd-cgroup"* ]]; then
+            echo "ERROR: native ARM64 conmon does not expose systemd cgroup forwarding." >&2
+            exit 1
+          fi
           expected_native_runtime="/usr/local/bin/crun"
           if ! native_runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; then
             echo "ERROR: native ARM64 Podman could not resolve its OCI runtime before checkout." >&2
@@ -476,7 +496,7 @@ jobs:
           runtime_dir="/run/user/${user_id}"
           delegate_directory="/etc/systemd/system/user@.service.d"
           delegate_drop_in="${delegate_directory}/syswarden-release-qualification.conf"
-          containers_override="${SHARD_ROOT}/containers-override.conf"
+          containers_conf="${SHARD_ROOT}/containers.conf"
           delegate_drop_in_owned=false
           original_user_service_active=false
           arm_cleanup_completed=false
@@ -497,8 +517,8 @@ jobs:
           test ! -L "${RUNNER_TEMP}"
           test -d "${SHARD_ROOT}"
           test ! -L "${SHARD_ROOT}"
-          test ! -e "${containers_override}"
-          test ! -L "${containers_override}"
+          test ! -e "${containers_conf}"
+          test ! -L "${containers_conf}"
           if sudo -n systemctl is-active --quiet "${user_service}"; then
             original_user_service_active=true
           fi
@@ -526,10 +546,10 @@ jobs:
                 fi
               fi
             fi
-            if ! rm -f -- "${containers_override}"; then
+            if ! rm -f -- "${containers_conf}"; then
               cleanup_rc=1
             fi
-            if [[ -e "${containers_override}" || -L "${containers_override}" ]]; then
+            if [[ -e "${containers_conf}" || -L "${containers_conf}" ]]; then
               cleanup_rc=1
             fi
             return "${cleanup_rc}"
@@ -580,13 +600,14 @@ jobs:
           printf '%s\n' \
             '[engine]' \
             'cgroup_manager="systemd"' \
-            'runtime="crun"' \
-            '[engine.runtimes]' \
-            'crun = ["/usr/local/bin/crun"]' > "${containers_override}"
-          if [[ ! -f "${containers_override}" || -L "${containers_override}" || \
-                "$(stat -c '%u' "${containers_override}")" != "${user_id}" || \
-                "$(stat -c '%a' "${containers_override}")" != "600" ]]; then
-            echo "ERROR: the isolated Podman override is not a private runner-owned file." >&2
+            'conmon_path=["/usr/local/lib/podman/conmon"]' \
+            'runtime="/usr/local/bin/runc"' \
+            '[engine.platform_to_oci_runtime]' \
+            '"linux/arm64"="/usr/local/bin/runc"' > "${containers_conf}"
+          if [[ ! -f "${containers_conf}" || -L "${containers_conf}" || \
+                "$(stat -c '%u' "${containers_conf}")" != "${user_id}" || \
+                "$(stat -c '%a' "${containers_conf}")" != "600" ]]; then
+            echo "ERROR: the isolated Podman configuration is not a private runner-owned file." >&2
             exit 1
           fi
 
@@ -604,7 +625,8 @@ jobs:
             --property='Type=exec' \
             --property='Delegate=cpu io memory pids' \
             --property='UMask=0077' \
-            --setenv="CONTAINERS_CONF_OVERRIDE=${containers_override}" \
+            --setenv="CONTAINERS_CONF=${containers_conf}" \
+            --setenv='CONTAINERS_CONF_OVERRIDE=' \
             --setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus" \
             --setenv="HOME=${HOME}" \
             --setenv='PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
@@ -612,7 +634,7 @@ jobs:
             --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
             --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
             /usr/bin/bash --noprofile --norc -e -o pipefail -c \
-            'if ! runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"; then echo "ERROR: native ARM64 Podman could not resolve its OCI runtime." >&2; exit 1; fi; if [[ "${runtime_path}" != "/usr/local/bin/crun" ]]; then printf "ERROR: native ARM64 Podman resolved an unexpected OCI runtime path: %q.\n" "${runtime_path}" >&2; exit 1; fi; exec "$@"' \
+            'if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if ! /usr/local/bin/runc --version >/dev/null; then echo "ERROR: native ARM64 runc is not executable inside the delegated session." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! podman_runtime="$(/usr/local/bin/podman info --format "{{.Host.Conmon.Path}}|{{.Host.OCIRuntime.Path}}|{{.Host.CgroupManager}}")"; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ "${podman_runtime}" != "/usr/local/lib/podman/conmon|/usr/local/bin/runc|systemd" ]]; then printf "ERROR: native ARM64 Podman resolved an unexpected runtime configuration: %q.\n" "${podman_runtime}" >&2; exit 1; fi; exec "$@"' \
             syswarden-arm64-lifecycle \
             /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
             --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -817,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 10)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 11)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                5,
+                6,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 4)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 5)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 5)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 6)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 10,
-                "scripts/ci/release_gate_test.py": 10,
+                ".github/workflows/release-manager.yml": 12,
+                "scripts/ci/release_gate_test.py": 12,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -869,9 +869,19 @@ class ReleaseGateTests(unittest.TestCase):
     ) -> None:
         blocks = self.v4032_recovery_blocks(workflow)
         self.assertEqual(
+            workflow.count(
+                'commit_subject="$(git log -1 --format=%s HEAD)"'
+            ),
+            2,
+        )
+        self.assertEqual(
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         pinned_contracts = (
+            (
+                'if [[ "${v4032_runc_parent_sha}" != '
+                '"d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then'
+            ),
             (
                 'if [[ "${v4032_runtime_parent_sha}" != '
                 '"0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then'
@@ -899,6 +909,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        runc_subject_contract = (
+            "v4032_runc_expected_subject='Qualification : pin v4.03.2 "
+            "ARM64 runc runtime path (#99)'"
+        )
         runtime_subject_contract = (
             "v4032_runtime_expected_subject='Qualification : repair v4.03.2 "
             "ARM64 OCI runtime resolution (#98)'"
@@ -921,6 +935,7 @@ class ReleaseGateTests(unittest.TestCase):
             "scripts/ci/release_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
         )
+        runc_paths = arm64_paths
         runtime_paths = arm64_paths
         merge_paths = (
             ".github/workflows/release-manager.yml",
@@ -959,6 +974,7 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(runc_subject_contract), 1)
             self.assertEqual(block.count(runtime_subject_contract), 1)
             self.assertEqual(block.count(arm64_subject_contract), 1)
             self.assertEqual(block.count(merge_subject_contract), 1)
@@ -966,18 +982,83 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_runc_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('v4032_runc_parent_sha="$(git rev-parse HEAD^)"'),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runc_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_runc_head_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 ARM64 runc pin diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("# END exact v4.03.2 ARM64 runc pin diff contract"),
+                1,
+            )
+            runc_diff = block.split(
+                "# BEGIN exact v4.03.2 ARM64 runc pin diff contract\n", 1
+            )[1].split(
+                "# END exact v4.03.2 ARM64 runc pin diff contract", 1
+            )[0]
+            self.assertEqual(
+                runc_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(runc_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(runc_diff.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(runc_diff.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(
+                runc_diff.count(
+                    "${#actual_v4032_runc_diff[@]} != "
+                    "${#expected_v4032_runc_diff[@]}"
+                ),
+                1,
+            )
+            for path in runc_paths:
+                self.assertEqual(runc_diff.count(f'"{path}"'), 2)
+                self.assertEqual(runc_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_runtime_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_runtime_parent_sha="$(git rev-parse '
+                    '"${v4032_runtime_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runtime_subject="$(git log -1 --format=%s '
+                    '"${v4032_runtime_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_runtime_subject}" != '
                     '"${v4032_runtime_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('v4032_runtime_parent_sha="$(git rev-parse HEAD^)"'),
-                1,
-            )
-            self.assertEqual(
                 block.count(
-                    'v4032_runtime_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_runtime_ref}")"'
                 ),
                 1,
             )
@@ -1007,11 +1088,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 runtime_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_runtime_ref}^" "${v4032_runtime_ref}"'
                 ),
                 1,
             )
-            self.assertEqual(runtime_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(
+                runtime_diff.count(
+                    'for tree_ref in "${v4032_runtime_ref}^" '
+                    '"${v4032_runtime_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(runtime_diff.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(runtime_diff.count('"${tree_type}" != "blob"'), 1)
             self.assertEqual(
@@ -1024,7 +1112,9 @@ class ReleaseGateTests(unittest.TestCase):
             for path in runtime_paths:
                 self.assertEqual(runtime_diff.count(f'"{path}"'), 2)
                 self.assertEqual(runtime_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_arm64_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count('v4032_arm64_ref="${v4032_runtime_ref}^"\n'), 1
+            )
             self.assertEqual(
                 block.count(
                     'v4032_arm64_parent_sha="$(git rev-parse '
@@ -1254,7 +1344,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                3,
+                4,
             )
             self.assertEqual(
                 block.count(
@@ -1273,12 +1363,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                4,
+                5,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 4)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 5)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1294,12 +1384,14 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in merge_paths else 0
                 expected_count += 2 if path in arm64_paths else 0
                 expected_count += 2 if path in runtime_paths else 0
+                expected_count += 2 if path in runc_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1
                 expected_status_count += 1 if path in merge_paths else 0
                 expected_status_count += 1 if path in arm64_paths else 0
                 expected_status_count += 1 if path in runtime_paths else 0
+                expected_status_count += 1 if path in runc_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1320,7 +1412,23 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 5
+                block.count('./scripts/versioning.sh validate-commit'), 6
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runtime_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_runtime_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('--base-ref "${v4032_runtime_parent_sha}"'), 1
+            )
+            self.assertEqual(
+                block.count(
+                    '--commit-message "${v4032_runtime_commit_message}"'
+                ),
+                1,
             )
             self.assertEqual(
                 block.count(
@@ -1401,6 +1509,28 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_runc_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.2 ARM64 runc pin diff contract\n"
+        end = "# END exact v4.03.2 ARM64 runc pin diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_runc_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_runc_expected_subject="
+        end = (
+            'read -r -a v4032_runc_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_runtime_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -1410,20 +1540,31 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 ARM64 OCI runtime resolution diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_runtime_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_runtime_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_runtime_expected_subject="
+        subject_assignment = (
+            'v4032_runtime_subject="$(git log -1 --format=%s '
+            '"${v4032_runtime_ref}")"'
+        )
         end = (
             'read -r -a v4032_runtime_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 "${v4032_runtime_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_runtime_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_arm64_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1747,6 +1888,57 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_runc_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_runc_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path (#99)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path",
+                    False,
+                ),
+                "double pull request suffix": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path (#99) (#99)",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path (#98)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path (#100)",
+                    False,
+                ),
+                "wrong version": (
+                    "Qualification : pin v4.03.3 ARM64 runc runtime path (#99)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : pin v4.03.2 ARM64 runc runtime path (#99) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_runc_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_runc_diff_script(),
+            "v4032-runc-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+            ),
+        )
+
     def test_release_manager_v4032_runtime_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -1862,9 +2054,36 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "runc parent resolution": workflow.replace(
+                'v4032_runc_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_runc_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact runc parent": workflow.replace(
+                "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97",
+                "e025f5ee7b1d453a64d11ea2f5afcab13fc01a97",
+            ),
+            "runc canonical subject": workflow.replace(
+                "Qualification : pin v4.03.2 ARM64 runc runtime path (#99)",
+                "Qualification : arbitrary v4.03.2 ARM64 runc pin (#99)",
+            ),
+            "runc subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "runc linear head": workflow.replace(
+                'v4032_runc_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_runc_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "runtime reference": workflow.replace(
+                "v4032_runtime_ref=HEAD^", "v4032_runtime_ref=HEAD^^"
+            ),
             "runtime parent resolution": workflow.replace(
-                'v4032_runtime_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_runtime_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_runtime_parent_sha="$(git rev-parse '
+                '"${v4032_runtime_ref}^")"',
+                'v4032_runtime_parent_sha="$(git rev-parse '
+                '"${v4032_runtime_ref}^^")"',
             ),
             "exact runtime parent": workflow.replace(
                 "0e7fc0a3437d69cea8086abacd0a30e032a0579f",
@@ -1875,13 +2094,26 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : arbitrary v4.03.2 ARM64 OCI repair (#98)",
             ),
             "runtime linear head": workflow.replace(
-                'v4032_runtime_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
-                'v4032_runtime_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_runtime_ref}")"',
+                'v4032_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
+            ),
+            "runtime subject source": workflow.replace(
+                'v4032_runtime_subject="$(git log -1 --format=%s '
+                '"${v4032_runtime_ref}")"',
+                'v4032_runtime_subject="$(git log -1 --format=%s HEAD)"',
+            ),
+            "runtime message source": workflow.replace(
+                'v4032_runtime_commit_message="$(git log -1 --format=%B '
+                '"${v4032_runtime_ref}")"',
+                'v4032_runtime_commit_message="$(git log -1 --format=%B HEAD)"',
+            ),
+            "runtime validation base": workflow.replace(
+                '--base-ref "${v4032_runtime_parent_sha}"', '--base-ref HEAD^'
             ),
             "ARM64 reference": workflow.replace(
-                "v4032_arm64_ref=HEAD^", "v4032_arm64_ref=HEAD^^"
+                'v4032_arm64_ref="${v4032_runtime_ref}^"',
+                'v4032_arm64_ref="${v4032_runtime_ref}^^"',
             ),
             "ARM64 parent resolution": workflow.replace(
                 'v4032_arm64_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -803,6 +803,14 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "844e4d8900fd6856d3f8f03a81599d6add195b69015de6b040c2da3b99bb7b95",
             "/usr/bin/sha256sum --check --strict",
             'test "$(/usr/local/bin/podman --version)" = "podman version 5.8.4"',
+            'runc_version="$(/usr/local/bin/runc --version)"',
+            '"${runc_version%%$\'\\n\'*}" != "runc version 1.4.3"',
+            'runc_help="$(/usr/local/bin/runc --help)"',
+            '"${runc_help}" != *"--systemd-cgroup"*',
+            'conmon_version="$(/usr/local/lib/podman/conmon --version)"',
+            '"${conmon_version%%$\'\\n\'*}" != "conmon version 2.2.1"',
+            'conmon_help="$(/usr/local/lib/podman/conmon --help)"',
+            '"${conmon_help}" != *"--systemd-cgroup"*',
             'expected_native_runtime="/usr/local/bin/crun"',
             'if ! native_runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
             "native ARM64 Podman could not resolve its OCI runtime before checkout",
@@ -820,13 +828,21 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
         digest = script.index("/usr/bin/sha256sum --check --strict")
         version = script.index('/usr/local/bin/podman --version')
+        runc_version = script.index('/usr/local/bin/runc --version')
+        runc_help = script.index('/usr/local/bin/runc --help')
+        conmon_version = script.index('/usr/local/lib/podman/conmon --version')
+        conmon_help = script.index('/usr/local/lib/podman/conmon --help')
         runtime_probe = script.index('/usr/local/bin/podman info --format')
         self.assertLess(structure_guard, tool_guard)
         self.assertLess(tool_guard, seal)
         self.assertLess(seal, attestation)
         self.assertLess(attestation, digest)
         self.assertLess(digest, version)
-        self.assertLess(version, runtime_probe)
+        self.assertLess(version, runc_version)
+        self.assertLess(runc_version, runc_help)
+        self.assertLess(runc_help, conmon_version)
+        self.assertLess(conmon_version, conmon_help)
+        self.assertLess(conmon_help, runtime_probe)
         seal_step = self.workflow.index(f"      - name: {step_name}\n")
         checkout_step = self.workflow.index(
             "      - name: Checkout Exact ARM64 Candidate Commit\n"
@@ -1050,32 +1066,45 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'sudo -n test -L "${delegate_directory}"',
             'sudo -n test -d "${delegate_directory}"',
             'sudo -n stat -c \'%u:%g:%a\' "${delegate_drop_in}"',
+            'containers_conf="${SHARD_ROOT}/containers.conf"',
             "'cgroup_manager=\"systemd\"'",
-            "'runtime=\"crun\"'",
-            "'[engine.runtimes]'",
-            "'crun = [\"/usr/local/bin/crun\"]'",
-            '"$(stat -c \'%a\' "${containers_override}")" != "600"',
+            "'conmon_path=[\"/usr/local/lib/podman/conmon\"]'",
+            "'runtime=\"/usr/local/bin/runc\"'",
+            "'[engine.platform_to_oci_runtime]'",
+            "'\"linux/arm64\"=\"/usr/local/bin/runc\"'",
+            '"$(stat -c \'%a\' "${containers_conf}")" != "600"',
             'unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             'sudo -n systemd-run',
             '--machine="${user_name}@"',
             '--property=\'Type=exec\'',
             "--property='Delegate=cpu io memory pids'",
             "--property='UMask=0077'",
-            '--setenv="CONTAINERS_CONF_OVERRIDE=${containers_override}"',
+            '--setenv="CONTAINERS_CONF=${containers_conf}"',
+            "--setenv='CONTAINERS_CONF_OVERRIDE='",
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
             "/usr/bin/bash --noprofile --norc -e -o pipefail -c",
-            'if ! runtime_path="$(/usr/local/bin/podman info --format "{{.Host.OCIRuntime.Path}}")"',
-            '"${runtime_path}" != "/usr/local/bin/crun"',
-            "native ARM64 Podman could not resolve its OCI runtime",
-            "native ARM64 Podman resolved an unexpected OCI runtime path",
+            '-z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}"',
+            "native ARM64 Podman configuration isolation is incomplete",
+            "if ! /usr/local/bin/runc --version >/dev/null",
+            "native ARM64 runc is not executable inside the delegated session",
+            "if ! /usr/local/lib/podman/conmon --version >/dev/null",
+            "native ARM64 conmon is not executable inside the delegated session",
+            (
+                '/usr/local/bin/podman info --format '
+                '"{{.Host.Conmon.Path}}|{{.Host.OCIRuntime.Path}}|'
+                '{{.Host.CgroupManager}}"'
+            ),
+            "native ARM64 Podman could not attest its isolated runtime configuration",
+            '"${podman_runtime}" != "/usr/local/lib/podman/conmon|/usr/local/bin/runc|systemd"',
+            "native ARM64 Podman resolved an unexpected runtime configuration",
             'exec "$@"',
             "syswarden-arm64-lifecycle",
             '/usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py"',
             '--podman /usr/local/bin/podman',
             'sudo -n rm -f -- "${delegate_drop_in}"',
             'sudo -n test -e "${delegate_drop_in}"',
-            'rm -f -- "${containers_override}"',
+            'rm -f -- "${containers_conf}"',
             'sudo -n systemctl start "${user_service}"',
             'cleanup_rc=0',
             'arm_cleanup_completed=true',
@@ -1092,6 +1121,12 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         for forbidden in (
             "apt-get",
             "cgroup_manager=\"cgroupfs\"",
+            "runtime=\"crun\"",
+            "/usr/local/bin/crun",
+            "[engine.runtimes]",
+            "OCIRuntime.Name",
+            'CONTAINERS_CONF_OVERRIDE=${containers_conf}',
+            "containers_override",
             "loginctl enable-linger",
             "--privileged",
             "podman system reset",
@@ -1100,6 +1135,18 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             self.assertNotIn(forbidden, script)
         self.assertEqual(script.count("sudo -n systemd-run"), 1)
         self.assertEqual(script.count("scripts/ci/package_lifecycle_lab.py"), 1)
+        self.assertEqual(script.count("'conmon_path=[\"/usr/local/lib/podman/conmon\"]'"), 1)
+        self.assertEqual(script.count("'runtime=\"/usr/local/bin/runc\"'"), 1)
+        self.assertEqual(script.count("'[engine.platform_to_oci_runtime]'"), 1)
+        self.assertEqual(
+            script.count("'\"linux/arm64\"=\"/usr/local/bin/runc\"'"), 1
+        )
+        self.assertEqual(
+            script.count('--setenv="CONTAINERS_CONF=${containers_conf}"'), 1
+        )
+        self.assertEqual(
+            script.count("--setenv='CONTAINERS_CONF_OVERRIDE='"), 1
+        )
         self.assertNotIn("--podman /usr/bin/podman", self.workflow)
         ownership_guard = script.index(
             'if sudo -n test -e "${delegate_drop_in}"'
@@ -1108,8 +1155,30 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'sudo -n tee "${delegate_drop_in}" >/dev/null'
         )
         mark_owned = script.index("delegate_drop_in_owned=true")
+        conmon_pin = script.index("'conmon_path=[\"/usr/local/lib/podman/conmon\"]'")
+        runtime_pin = script.index("'runtime=\"/usr/local/bin/runc\"'")
+        platform_table = script.index("'[engine.platform_to_oci_runtime]'")
+        platform_pin = script.index("'\"linux/arm64\"=\"/usr/local/bin/runc\"'")
+        systemd_run = script.index("sudo -n systemd-run")
+        configuration_guard = script.index(
+            "native ARM64 Podman configuration isolation is incomplete"
+        )
+        runc_probe = script.index("/usr/local/bin/runc --version")
+        conmon_probe = script.index("/usr/local/lib/podman/conmon --version")
+        podman_probe = script.index("/usr/local/bin/podman info --format")
+        lifecycle_lab = script.index("scripts/ci/package_lifecycle_lab.py")
         self.assertLess(ownership_guard, mark_owned)
         self.assertLess(mark_owned, create_drop_in)
+        self.assertLess(create_drop_in, conmon_pin)
+        self.assertLess(conmon_pin, runtime_pin)
+        self.assertLess(runtime_pin, platform_table)
+        self.assertLess(platform_table, platform_pin)
+        self.assertLess(platform_pin, systemd_run)
+        self.assertLess(systemd_run, configuration_guard)
+        self.assertLess(configuration_guard, runc_probe)
+        self.assertLess(runc_probe, conmon_probe)
+        self.assertLess(conmon_probe, podman_probe)
+        self.assertLess(podman_probe, lifecycle_lab)
 
     def test_premerge_package_workflow_runs_every_qualification_validator(self) -> None:
         step = workflow_step(


### PR DESCRIPTION
## Summary

- Pin the protected native ARM64 lifecycle lab to the checksum-sealed runc v1.4.3 runtime and conmon v2.2.1 monitor supplied by the exact Podman 5.8.4 runner bundle.
- Isolate Podman from ambient system and user containers.conf files, neutralize the final override layer, and bind linux/arm64 image creation to the absolute runc path.
- Attest the resolved conmon path, OCI runtime path, and systemd cgroup manager inside the delegated user session before any lifecycle command executes.
- Extend the immutable v4.03.2 Release Manager recovery chain through this exact four-file squash while semantically revalidating PR98 through PR93.

## Root cause

Protected qualification run 32738274786 reached the delegated ARM64 systemd session, where Podman returned an empty OCI runtime path before the Python lifecycle lab could start. The exact podman-static v5.8.4 archive contains crun 1.28 compiled without systemd support, while its sealed runc v1.4.3 and conmon v2.2.1 binaries expose the required systemd cgroup support.

Direct Podman 5.8.4 adversarial testing also confirmed that a last-loaded runtime-only override can retain an inherited platform runtime and an earlier conmon path. The new full configuration isolation closes both precedence paths and fails before the lab if Podman silently falls back from systemd to cgroupfs.

This pull request changes no SysWarden runtime code, packages, documentation, branding, or GitHub image assets.

## Validation

- Full package and release validator matrix: 323 tests passed, including Unix-socket cases.
- Release qualification workflow suite: 31 tests passed.
- Release Manager gate suite: 50 tests passed.
- Version controller Go tests passed.
- Both workflow YAML files parsed successfully and all 58 workflow shell bodies passed bash syntax validation.
- Exact Podman 5.8.4 systemd test resolved the sealed conmon and absolute runc paths, ran a networkless Alpine container successfully, and left no container residue.
- Adversarial configuration test reproduced the inherited-runtime bypass and proved the isolated configuration selects the absolute runc path.
- Future PR99 squash and local v4.03.2 tag simulation passed the complete PR98 through PR93 Release Manager chain.
- The diff is limited to four reviewed 100644 files and git diff --check passes.
- Commit 0b23e5b174ae966189ec8042af68e5daf64a1d4d has a verified ED25519 SSH signature.

No release tag or GitHub Release is created by this pull request.