### PR TITLE
Qualification : repair v4.03.2 ARM64 lab and config root handling

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,79 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_runc_parent_sha="$(git rev-parse HEAD^)"
+              v4032_local_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
+                echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2
+                exit 1
+              fi
+              v4032_local_expected_subject='Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)'
+              if [[ "${commit_subject}" != "${v4032_local_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 final qualification repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_local_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 final qualification repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 final qualification repair diff contract
+              expected_v4032_local_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/config/config_contract_test.go"
+                M "src/core/syswarden-cli/config/config_loader.go"
+              )
+              mapfile -d '' -t actual_v4032_local_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_local_diff[@]} != ${#expected_v4032_local_diff[@]} )); then
+                echo "ERROR: the v4.03.2 final qualification repair must modify exactly the six reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_local_diff[@]}; index++)); do
+                if [[ "${actual_v4032_local_diff[index]}" != "${expected_v4032_local_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 final qualification repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_local_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/config/config_contract_test.go"
+                "src/core/syswarden-cli/config/config_loader.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_local_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 final qualification repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 final qualification repair diff contract
+              v4032_runc_ref=HEAD^
+              v4032_runc_parent_sha="$(git rev-parse "${v4032_runc_ref}^")"
               if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2
                 exit 1
               fi
               v4032_runc_expected_subject='Qualification : pin v4.03.2 ARM64 runc runtime path (#99)'
-              if [[ "${commit_subject}" != "${v4032_runc_expected_subject}" ]]; then
+              v4032_runc_subject="$(git log -1 --format=%s "${v4032_runc_ref}")"
+              if [[ "${v4032_runc_subject}" != "${v4032_runc_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 "${v4032_runc_ref}")"
               if (( ${#v4032_runc_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 runc pin must be one linear commit." >&2
                 exit 1
@@ -159,7 +221,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_runc_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_runc_ref}^" "${v4032_runc_ref}"
               )
               if (( ${#actual_v4032_runc_diff[@]} != ${#expected_v4032_runc_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 runc pin must modify exactly the four reviewed files." >&2
@@ -177,7 +240,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_runc_ref}^" "${v4032_runc_ref}"; do
                 for fix_path in "${v4032_runc_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -192,7 +255,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 runc pin diff contract
-              v4032_runtime_ref=HEAD^
+              v4032_runtime_ref="${v4032_runc_ref}^"
               v4032_runtime_parent_sha="$(git rev-parse "${v4032_runtime_ref}^")"
               if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
@@ -483,6 +546,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_runc_commit_message="$(git log -1 --format=%B "${v4032_runc_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_runc_parent_sha}" \
+                --commit-message "${v4032_runc_commit_message}"
               v4032_runtime_commit_message="$(git log -1 --format=%B "${v4032_runtime_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \
@@ -987,17 +1055,79 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_runc_parent_sha="$(git rev-parse HEAD^)"
+              v4032_local_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
+                echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2
+                exit 1
+              fi
+              v4032_local_expected_subject='Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)'
+              if [[ "${commit_subject}" != "${v4032_local_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 final qualification repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_local_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 final qualification repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 final qualification repair diff contract
+              expected_v4032_local_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/config/config_contract_test.go"
+                M "src/core/syswarden-cli/config/config_loader.go"
+              )
+              mapfile -d '' -t actual_v4032_local_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_local_diff[@]} != ${#expected_v4032_local_diff[@]} )); then
+                echo "ERROR: the v4.03.2 final qualification repair must modify exactly the six reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_local_diff[@]}; index++)); do
+                if [[ "${actual_v4032_local_diff[index]}" != "${expected_v4032_local_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 final qualification repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_local_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/config/config_contract_test.go"
+                "src/core/syswarden-cli/config/config_loader.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_local_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 final qualification repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 final qualification repair diff contract
+              v4032_runc_ref=HEAD^
+              v4032_runc_parent_sha="$(git rev-parse "${v4032_runc_ref}^")"
               if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2
                 exit 1
               fi
               v4032_runc_expected_subject='Qualification : pin v4.03.2 ARM64 runc runtime path (#99)'
-              if [[ "${commit_subject}" != "${v4032_runc_expected_subject}" ]]; then
+              v4032_runc_subject="$(git log -1 --format=%s "${v4032_runc_ref}")"
+              if [[ "${v4032_runc_subject}" != "${v4032_runc_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_runc_head_line <<< "$(git rev-list --parents -n 1 "${v4032_runc_ref}")"
               if (( ${#v4032_runc_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 runc pin must be one linear commit." >&2
                 exit 1
@@ -1010,7 +1140,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_runc_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_runc_ref}^" "${v4032_runc_ref}"
               )
               if (( ${#actual_v4032_runc_diff[@]} != ${#expected_v4032_runc_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 runc pin must modify exactly the four reviewed files." >&2
@@ -1028,7 +1159,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_runc_ref}^" "${v4032_runc_ref}"; do
                 for fix_path in "${v4032_runc_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1043,7 +1174,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 runc pin diff contract
-              v4032_runtime_ref=HEAD^
+              v4032_runtime_ref="${v4032_runc_ref}^"
               v4032_runtime_parent_sha="$(git rev-parse "${v4032_runtime_ref}^")"
               if [[ "${v4032_runtime_parent_sha}" != "0e7fc0a3437d69cea8086abacd0a30e032a0579f" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 OCI runtime resolution is not based on the reviewed PR97 squash." >&2
@@ -1334,6 +1465,11 @@ jobs:
                 src/core/syswarden-cli/pkg/integration/webhook.go \
                 src/core/syswarden-core/webhook/discord.go \
                 README.md
+              v4032_runc_commit_message="$(git log -1 --format=%B "${v4032_runc_ref}")"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4032_runc_parent_sha}" \
+                --commit-message "${v4032_runc_commit_message}"
               v4032_runtime_commit_message="$(git log -1 --format=%B "${v4032_runtime_ref}")"
               ./scripts/versioning.sh validate-commit \
                 --repo "${GITHUB_WORKSPACE}" \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -497,6 +497,8 @@ jobs:
           delegate_directory="/etc/systemd/system/user@.service.d"
           delegate_drop_in="${delegate_directory}/syswarden-release-qualification.conf"
           containers_conf="${SHARD_ROOT}/containers.conf"
+          podman_info="${SHARD_ROOT}/podman-info.json"
+          podman_local="${SHARD_ROOT}/podman-local"
           delegate_drop_in_owned=false
           original_user_service_active=false
           arm_cleanup_completed=false
@@ -519,6 +521,10 @@ jobs:
           test ! -L "${SHARD_ROOT}"
           test ! -e "${containers_conf}"
           test ! -L "${containers_conf}"
+          test ! -e "${podman_info}"
+          test ! -L "${podman_info}"
+          test ! -e "${podman_local}"
+          test ! -L "${podman_local}"
           if sudo -n systemctl is-active --quiet "${user_service}"; then
             original_user_service_active=true
           fi
@@ -546,10 +552,12 @@ jobs:
                 fi
               fi
             fi
-            if ! rm -f -- "${containers_conf}"; then
+            if ! rm -f -- "${containers_conf}" "${podman_info}" "${podman_local}"; then
               cleanup_rc=1
             fi
-            if [[ -e "${containers_conf}" || -L "${containers_conf}" ]]; then
+            if [[ -e "${containers_conf}" || -L "${containers_conf}" || \
+                  -e "${podman_info}" || -L "${podman_info}" || \
+                  -e "${podman_local}" || -L "${podman_local}" ]]; then
               cleanup_rc=1
             fi
             return "${cleanup_rc}"
@@ -601,15 +609,40 @@ jobs:
             '[engine]' \
             'cgroup_manager="systemd"' \
             'conmon_path=["/usr/local/lib/podman/conmon"]' \
-            'runtime="/usr/local/bin/runc"' \
+            'remote=false' \
+            'runtime="runc"' \
+            '[engine.runtimes]' \
+            'runc=["/usr/local/bin/runc"]' \
             '[engine.platform_to_oci_runtime]' \
-            '"linux/arm64"="/usr/local/bin/runc"' > "${containers_conf}"
+            '"linux/arm64"="runc"' > "${containers_conf}"
           if [[ ! -f "${containers_conf}" || -L "${containers_conf}" || \
                 "$(stat -c '%u' "${containers_conf}")" != "${user_id}" || \
                 "$(stat -c '%a' "${containers_conf}")" != "600" ]]; then
             echo "ERROR: the isolated Podman configuration is not a private runner-owned file." >&2
             exit 1
           fi
+          printf '%s\n' \
+            '#!/usr/bin/bash' \
+            'set -euo pipefail' \
+            'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY' \
+            'exec /usr/local/bin/podman --remote=false "$@"' > "${podman_local}"
+          chmod 0700 "${podman_local}"
+          if [[ ! -f "${podman_local}" || -L "${podman_local}" || \
+                ! -x "${podman_local}" || \
+                "$(stat -c '%u' "${podman_local}")" != "${user_id}" || \
+                "$(stat -c '%a' "${podman_local}")" != "700" ]]; then
+            echo "ERROR: the local-only Podman launcher is not a private runner-owned executable." >&2
+            exit 1
+          fi
+          : > "${podman_info}"
+          chmod 0600 "${podman_info}"
+          if [[ ! -f "${podman_info}" || -L "${podman_info}" || \
+                "$(stat -c '%u' "${podman_info}")" != "${user_id}" || \
+                "$(stat -c '%a' "${podman_info}")" != "600" ]]; then
+            echo "ERROR: the native ARM64 Podman info target is not a private runner-owned file." >&2
+            exit 1
+          fi
+          podman_info_inode="$(stat -c '%d:%i' "${podman_info}")"
 
           unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           set +e
@@ -632,14 +665,17 @@ jobs:
             --setenv='PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
             --setenv='PYTHONDONTWRITEBYTECODE=1' \
             --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
+            --setenv="SYSWARDEN_PODMAN_INFO=${podman_info}" \
+            --setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}" \
+            --setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}" \
             --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
             /usr/bin/bash --noprofile --norc -e -o pipefail -c \
-            'if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if ! /usr/local/bin/runc --version >/dev/null; then echo "ERROR: native ARM64 runc is not executable inside the delegated session." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! podman_runtime="$(/usr/local/bin/podman info --format "{{.Host.Conmon.Path}}|{{.Host.OCIRuntime.Path}}|{{.Host.CgroupManager}}")"; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ "${podman_runtime}" != "/usr/local/lib/podman/conmon|/usr/local/bin/runc|systemd" ]]; then printf "ERROR: native ARM64 Podman resolved an unexpected runtime configuration: %q.\n" "${podman_runtime}" >&2; exit 1; fi; exec "$@"' \
+            'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY; if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_LOCAL:-}" || ! -f "${SYSWARDEN_PODMAN_LOCAL}" || -L "${SYSWARDEN_PODMAN_LOCAL}" || ! -x "${SYSWARDEN_PODMAN_LOCAL}" ]]; then echo "ERROR: native ARM64 local-only Podman launcher is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_INFO:-}" || -z "${SYSWARDEN_PODMAN_INFO_INODE:-}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info target is unavailable." >&2; exit 1; fi; if ! /usr/local/bin/runc --version >/dev/null; then echo "ERROR: native ARM64 runc is not executable inside the delegated session." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! "${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" info --format json; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ ! -s "${SYSWARDEN_PODMAN_INFO}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" || "$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600" || "$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != "${SYSWARDEN_PODMAN_INFO_INODE}" ]]; then echo "ERROR: native ARM64 Podman info evidence changed identity or permissions." >&2; exit 1; fi; if ! jq -e -s '\''length == 1 and .[0].host.conmon.path == "/usr/local/lib/podman/conmon" and .[0].host.ociRuntime.path == "/usr/local/bin/runc" and .[0].host.cgroupManager == "systemd" and .[0].host.security.rootless == true and .[0].host.serviceIsRemote == false and .[0].host.arch == "arm64" and .[0].host.os == "linux"'\'' "${SYSWARDEN_PODMAN_INFO}" >/dev/null; then echo "ERROR: native ARM64 Podman resolved an unexpected local runtime configuration." >&2; exit 1; fi; exec "$@"' \
             syswarden-arm64-lifecycle \
             /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
             --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \
-            --podman /usr/local/bin/podman \
+            --podman "${podman_local}" \
             --architecture-shard arm64 \
             --qualification-repository "${GITHUB_REPOSITORY}" \
             --qualification-release-sha "${RELEASE_SHA}" \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -817,7 +817,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for script in scripts:
             self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 11)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 12)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                6,
+                7,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 5)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 6)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 6)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 7)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 12,
-                "scripts/ci/release_gate_test.py": 12,
+                ".github/workflows/release-manager.yml": 14,
+                "scripts/ci/release_gate_test.py": 14,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -879,6 +879,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         pinned_contracts = (
             (
+                'if [[ "${v4032_local_parent_sha}" != '
+                '"93bb85a657d8f8927cd6617c4105653732c59114" ]]; then'
+            ),
+            (
                 'if [[ "${v4032_runc_parent_sha}" != '
                 '"d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then'
             ),
@@ -909,6 +913,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        local_subject_contract = (
+            "v4032_local_expected_subject='Qualification : repair v4.03.2 "
+            "ARM64 lab and config root handling (#101)'"
+        )
         runc_subject_contract = (
             "v4032_runc_expected_subject='Qualification : pin v4.03.2 "
             "ARM64 runc runtime path (#99)'"
@@ -934,6 +942,14 @@ class ReleaseGateTests(unittest.TestCase):
             ".github/workflows/release-qualification.yml",
             "scripts/ci/release_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
+        )
+        local_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
+            "src/core/syswarden-cli/config/config_contract_test.go",
+            "src/core/syswarden-cli/config/config_loader.go",
         )
         runc_paths = arm64_paths
         runtime_paths = arm64_paths
@@ -974,6 +990,7 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(local_subject_contract), 1)
             self.assertEqual(block.count(runc_subject_contract), 1)
             self.assertEqual(block.count(runtime_subject_contract), 1)
             self.assertEqual(block.count(arm64_subject_contract), 1)
@@ -982,18 +999,86 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_local_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('v4032_local_parent_sha="$(git rev-parse HEAD^)"'),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_local_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(block.count("${#v4032_local_head_line[@]} != 2"), 1)
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 final qualification repair diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    "# END exact v4.03.2 final qualification repair diff contract"
+                ),
+                1,
+            )
+            local_diff = block.split(
+                "# BEGIN exact v4.03.2 final qualification repair diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 final qualification repair diff contract", 1
+            )[0]
+            self.assertEqual(
+                local_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(local_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(local_diff.count('"${tree_mode}" != "100644"'), 1)
+            self.assertEqual(local_diff.count('"${tree_type}" != "blob"'), 1)
+            self.assertEqual(
+                local_diff.count(
+                    "${#actual_v4032_local_diff[@]} != "
+                    "${#expected_v4032_local_diff[@]}"
+                ),
+                1,
+            )
+            for path in local_paths:
+                self.assertEqual(local_diff.count(f'"{path}"'), 2)
+                self.assertEqual(local_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_runc_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_runc_parent_sha="$(git rev-parse '
+                    '"${v4032_runc_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runc_subject="$(git log -1 --format=%s '
+                    '"${v4032_runc_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_runc_subject}" != '
                     '"${v4032_runc_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('v4032_runc_parent_sha="$(git rev-parse HEAD^)"'),
-                1,
-            )
-            self.assertEqual(
                 block.count(
-                    'v4032_runc_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_runc_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_runc_ref}")"'
                 ),
                 1,
             )
@@ -1016,11 +1101,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 runc_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_runc_ref}^" "${v4032_runc_ref}"'
                 ),
                 1,
             )
-            self.assertEqual(runc_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(
+                runc_diff.count(
+                    'for tree_ref in "${v4032_runc_ref}^" '
+                    '"${v4032_runc_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(runc_diff.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(runc_diff.count('"${tree_type}" != "blob"'), 1)
             self.assertEqual(
@@ -1033,7 +1125,9 @@ class ReleaseGateTests(unittest.TestCase):
             for path in runc_paths:
                 self.assertEqual(runc_diff.count(f'"{path}"'), 2)
                 self.assertEqual(runc_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_runtime_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count('v4032_runtime_ref="${v4032_runc_ref}^"\n'), 1
+            )
             self.assertEqual(
                 block.count(
                     'v4032_runtime_parent_sha="$(git rev-parse '
@@ -1344,7 +1438,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                4,
+                5,
             )
             self.assertEqual(
                 block.count(
@@ -1363,12 +1457,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                5,
+                6,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 5)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 6)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1385,6 +1479,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in arm64_paths else 0
                 expected_count += 2 if path in runtime_paths else 0
                 expected_count += 2 if path in runc_paths else 0
+                expected_count += 2 if path in local_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1
@@ -1392,6 +1487,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_status_count += 1 if path in arm64_paths else 0
                 expected_status_count += 1 if path in runtime_paths else 0
                 expected_status_count += 1 if path in runc_paths else 0
+                expected_status_count += 1 if path in local_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1412,7 +1508,21 @@ class ReleaseGateTests(unittest.TestCase):
                 1,
             )
             self.assertEqual(
-                block.count('./scripts/versioning.sh validate-commit'), 6
+                block.count('./scripts/versioning.sh validate-commit'), 7
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_runc_commit_message="$(git log -1 --format=%B '
+                    '"${v4032_runc_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count('--base-ref "${v4032_runc_parent_sha}"'), 1
+            )
+            self.assertEqual(
+                block.count('--commit-message "${v4032_runc_commit_message}"'),
+                1,
             )
             self.assertEqual(
                 block.count(
@@ -1509,6 +1619,28 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_local_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.2 final qualification repair diff contract\n"
+        end = "# END exact v4.03.2 final qualification repair diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_local_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_local_expected_subject="
+        end = (
+            'read -r -a v4032_local_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_runc_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -1516,20 +1648,31 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 ARM64 runc pin diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_runc_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_runc_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_runc_expected_subject="
+        subject_assignment = (
+            'v4032_runc_subject="$(git log -1 --format=%s '
+            '"${v4032_runc_ref}")"'
+        )
         end = (
             'read -r -a v4032_runc_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 "${v4032_runc_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_runc_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_runtime_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1888,6 +2031,59 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_local_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_local_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling",
+                    False,
+                ),
+                "double pull request suffix": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling (#101) (#101)",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling (#100)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling (#102)",
+                    False,
+                ),
+                "wrong version": (
+                    "Qualification : repair v4.03.3 ARM64 lab and config root handling (#101)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : repair v4.03.2 ARM64 lab and config root handling (#101) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_local_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_local_diff_script(),
+            "v4032-local-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+                "src/core/syswarden-cli/config/config_contract_test.go",
+                "src/core/syswarden-cli/config/config_loader.go",
+            ),
+        )
+
     def test_release_manager_v4032_runc_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -2054,9 +2250,36 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "local parent resolution": workflow.replace(
+                'v4032_local_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_local_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact local parent": workflow.replace(
+                "93bb85a657d8f8927cd6617c4105653732c59114",
+                "a3bb85a657d8f8927cd6617c4105653732c59114",
+            ),
+            "local canonical subject": workflow.replace(
+                "Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)",
+                "Qualification : arbitrary v4.03.2 final repair (#101)",
+            ),
+            "local subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "local linear head": workflow.replace(
+                'v4032_local_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_local_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "runc reference": workflow.replace(
+                "v4032_runc_ref=HEAD^", "v4032_runc_ref=HEAD^^"
+            ),
             "runc parent resolution": workflow.replace(
-                'v4032_runc_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_runc_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_runc_parent_sha="$(git rev-parse '
+                '"${v4032_runc_ref}^")"',
+                'v4032_runc_parent_sha="$(git rev-parse '
+                '"${v4032_runc_ref}^^")"',
             ),
             "exact runc parent": workflow.replace(
                 "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97",
@@ -2067,17 +2290,26 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : arbitrary v4.03.2 ARM64 runc pin (#99)",
             ),
             "runc subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_runc_subject="$(git log -1 --format=%s '
+                '"${v4032_runc_ref}")"',
+                'v4032_runc_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "runc linear head": workflow.replace(
-                'v4032_runc_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
-                'v4032_runc_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_runc_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_runc_ref}")"',
+                'v4032_runc_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
+            ),
+            "runc message source": workflow.replace(
+                'v4032_runc_commit_message="$(git log -1 --format=%B '
+                '"${v4032_runc_ref}")"',
+                'v4032_runc_commit_message="$(git log -1 --format=%B HEAD)"',
+            ),
+            "runc validation base": workflow.replace(
+                '--base-ref "${v4032_runc_parent_sha}"', '--base-ref HEAD^'
             ),
             "runtime reference": workflow.replace(
-                "v4032_runtime_ref=HEAD^", "v4032_runtime_ref=HEAD^^"
+                'v4032_runtime_ref="${v4032_runc_ref}^"',
+                'v4032_runtime_ref="${v4032_runc_ref}^^"',
             ),
             "runtime parent resolution": workflow.replace(
                 'v4032_runtime_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -1067,12 +1067,26 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'sudo -n test -d "${delegate_directory}"',
             'sudo -n stat -c \'%u:%g:%a\' "${delegate_drop_in}"',
             'containers_conf="${SHARD_ROOT}/containers.conf"',
+            'podman_info="${SHARD_ROOT}/podman-info.json"',
+            'podman_local="${SHARD_ROOT}/podman-local"',
             "'cgroup_manager=\"systemd\"'",
             "'conmon_path=[\"/usr/local/lib/podman/conmon\"]'",
-            "'runtime=\"/usr/local/bin/runc\"'",
+            "'remote=false'",
+            "'runtime=\"runc\"'",
+            "'[engine.runtimes]'",
+            "'runc=[\"/usr/local/bin/runc\"]'",
             "'[engine.platform_to_oci_runtime]'",
-            "'\"linux/arm64\"=\"/usr/local/bin/runc\"'",
+            "'\"linux/arm64\"=\"runc\"'",
             '"$(stat -c \'%a\' "${containers_conf}")" != "600"',
+            "'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY'",
+            "'exec /usr/local/bin/podman --remote=false \"$@\"'",
+            'chmod 0700 "${podman_local}"',
+            '"$(stat -c \'%a\' "${podman_local}")" != "700"',
+            "local-only Podman launcher is not a private runner-owned executable",
+            ': > "${podman_info}"',
+            'chmod 0600 "${podman_info}"',
+            'podman_info_inode="$(stat -c \'%d:%i\' "${podman_info}")"',
+            "native ARM64 Podman info target is not a private runner-owned file",
             'unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             'sudo -n systemd-run',
             '--machine="${user_name}@"',
@@ -1083,28 +1097,44 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "--setenv='CONTAINERS_CONF_OVERRIDE='",
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
+            '--setenv="SYSWARDEN_PODMAN_INFO=${podman_info}"',
+            '--setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}"',
+            '--setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}"',
             "/usr/bin/bash --noprofile --norc -e -o pipefail -c",
+            "unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY;",
             '-z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}"',
             "native ARM64 Podman configuration isolation is incomplete",
+            '-z "${SYSWARDEN_PODMAN_LOCAL:-}"',
+            "native ARM64 local-only Podman launcher is unavailable",
+            '-z "${SYSWARDEN_PODMAN_INFO:-}"',
+            '-z "${SYSWARDEN_PODMAN_INFO_INODE:-}"',
+            "native ARM64 Podman info target is unavailable",
             "if ! /usr/local/bin/runc --version >/dev/null",
             "native ARM64 runc is not executable inside the delegated session",
             "if ! /usr/local/lib/podman/conmon --version >/dev/null",
             "native ARM64 conmon is not executable inside the delegated session",
-            (
-                '/usr/local/bin/podman info --format '
-                '"{{.Host.Conmon.Path}}|{{.Host.OCIRuntime.Path}}|'
-                '{{.Host.CgroupManager}}"'
-            ),
+            '"${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" '
+            "info --format json",
             "native ARM64 Podman could not attest its isolated runtime configuration",
-            '"${podman_runtime}" != "/usr/local/lib/podman/conmon|/usr/local/bin/runc|systemd"',
-            "native ARM64 Podman resolved an unexpected runtime configuration",
+            '"$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600"',
+            '"$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != '
+            '"${SYSWARDEN_PODMAN_INFO_INODE}"',
+            "native ARM64 Podman info evidence changed identity or permissions",
+            '.host.conmon.path == "/usr/local/lib/podman/conmon"',
+            '.host.ociRuntime.path == "/usr/local/bin/runc"',
+            '.host.cgroupManager == "systemd"',
+            ".host.security.rootless == true",
+            ".host.serviceIsRemote == false",
+            '.host.arch == "arm64"',
+            '.host.os == "linux"',
+            "native ARM64 Podman resolved an unexpected local runtime configuration",
             'exec "$@"',
             "syswarden-arm64-lifecycle",
             '/usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py"',
-            '--podman /usr/local/bin/podman',
+            '--podman "${podman_local}"',
             'sudo -n rm -f -- "${delegate_drop_in}"',
             'sudo -n test -e "${delegate_drop_in}"',
-            'rm -f -- "${containers_conf}"',
+            'rm -f -- "${containers_conf}" "${podman_info}" "${podman_local}"',
             'sudo -n systemctl start "${user_service}"',
             'cleanup_rc=0',
             'arm_cleanup_completed=true',
@@ -1123,24 +1153,43 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "cgroup_manager=\"cgroupfs\"",
             "runtime=\"crun\"",
             "/usr/local/bin/crun",
-            "[engine.runtimes]",
+            "runtime=\"/usr/local/bin/runc\"",
             "OCIRuntime.Name",
+            "podman_runtime=",
+            "{{.Host.Conmon.Path}}",
             'CONTAINERS_CONF_OVERRIDE=${containers_conf}',
             "containers_override",
             "loginctl enable-linger",
             "--privileged",
             "podman system reset",
             "podman system migrate",
+            "--setenv='CONTAINER_HOST='",
+            "--setenv='CONTAINER_CONNECTION='",
         ):
             self.assertNotIn(forbidden, script)
         self.assertEqual(script.count("sudo -n systemd-run"), 1)
         self.assertEqual(script.count("scripts/ci/package_lifecycle_lab.py"), 1)
         self.assertEqual(script.count("'conmon_path=[\"/usr/local/lib/podman/conmon\"]'"), 1)
-        self.assertEqual(script.count("'runtime=\"/usr/local/bin/runc\"'"), 1)
+        self.assertEqual(script.count("'remote=false'"), 1)
+        self.assertEqual(script.count("'runtime=\"runc\"'"), 1)
+        self.assertEqual(script.count("'[engine.runtimes]'"), 1)
+        self.assertEqual(script.count("'runc=[\"/usr/local/bin/runc\"]'"), 1)
         self.assertEqual(script.count("'[engine.platform_to_oci_runtime]'"), 1)
         self.assertEqual(
-            script.count("'\"linux/arm64\"=\"/usr/local/bin/runc\"'"), 1
+            script.count("'\"linux/arm64\"=\"runc\"'"), 1
         )
+        self.assertEqual(
+            script.count("'exec /usr/local/bin/podman --remote=false \"$@\"'"), 1
+        )
+        self.assertEqual(
+            script.count(
+                '"${SYSWARDEN_PODMAN_LOCAL}" --out '
+                '"${SYSWARDEN_PODMAN_INFO}" info --format json'
+            ),
+            1,
+        )
+        self.assertEqual(script.count(".host.serviceIsRemote == false"), 1)
+        self.assertEqual(script.count(".host.security.rootless == true"), 1)
         self.assertEqual(
             script.count('--setenv="CONTAINERS_CONF=${containers_conf}"'), 1
         )
@@ -1148,6 +1197,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             script.count("--setenv='CONTAINERS_CONF_OVERRIDE='"), 1
         )
         self.assertNotIn("--podman /usr/bin/podman", self.workflow)
+        self.assertNotIn("--podman /usr/local/bin/podman", script)
         ownership_guard = script.index(
             'if sudo -n test -e "${delegate_drop_in}"'
         )
@@ -1156,28 +1206,52 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
         mark_owned = script.index("delegate_drop_in_owned=true")
         conmon_pin = script.index("'conmon_path=[\"/usr/local/lib/podman/conmon\"]'")
-        runtime_pin = script.index("'runtime=\"/usr/local/bin/runc\"'")
+        remote_pin = script.index("'remote=false'")
+        runtime_pin = script.index("'runtime=\"runc\"'")
+        runtime_table = script.index("'[engine.runtimes]'")
+        runtime_path = script.index("'runc=[\"/usr/local/bin/runc\"]'")
         platform_table = script.index("'[engine.platform_to_oci_runtime]'")
-        platform_pin = script.index("'\"linux/arm64\"=\"/usr/local/bin/runc\"'")
+        platform_pin = script.index("'\"linux/arm64\"=\"runc\"'")
+        wrapper_unset = script.index(
+            "'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY'"
+        )
+        wrapper_exec = script.index(
+            "'exec /usr/local/bin/podman --remote=false \"$@\"'"
+        )
         systemd_run = script.index("sudo -n systemd-run")
         configuration_guard = script.index(
             "native ARM64 Podman configuration isolation is incomplete"
         )
         runc_probe = script.index("/usr/local/bin/runc --version")
         conmon_probe = script.index("/usr/local/lib/podman/conmon --version")
-        podman_probe = script.index("/usr/local/bin/podman info --format")
+        info_target = script.index(': > "${podman_info}"')
+        podman_probe = script.index(
+            '"${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" '
+            "info --format json"
+        )
+        podman_verdict = script.index(".host.serviceIsRemote == false")
         lifecycle_lab = script.index("scripts/ci/package_lifecycle_lab.py")
         self.assertLess(ownership_guard, mark_owned)
         self.assertLess(mark_owned, create_drop_in)
         self.assertLess(create_drop_in, conmon_pin)
-        self.assertLess(conmon_pin, runtime_pin)
+        self.assertLess(conmon_pin, remote_pin)
+        self.assertLess(remote_pin, runtime_pin)
+        self.assertLess(runtime_pin, runtime_table)
+        self.assertLess(runtime_table, runtime_path)
+        self.assertLess(runtime_path, platform_table)
         self.assertLess(runtime_pin, platform_table)
         self.assertLess(platform_table, platform_pin)
+        self.assertLess(platform_pin, wrapper_unset)
+        self.assertLess(wrapper_unset, wrapper_exec)
+        self.assertLess(wrapper_exec, info_target)
+        self.assertLess(info_target, systemd_run)
         self.assertLess(platform_pin, systemd_run)
         self.assertLess(systemd_run, configuration_guard)
         self.assertLess(configuration_guard, runc_probe)
         self.assertLess(runc_probe, conmon_probe)
         self.assertLess(conmon_probe, podman_probe)
+        self.assertLess(podman_probe, podman_verdict)
+        self.assertLess(podman_verdict, lifecycle_lab)
         self.assertLess(podman_probe, lifecycle_lab)
 
     def test_premerge_package_workflow_runs_every_qualification_validator(self) -> None:

--- a/src/core/syswarden-cli/config/config_contract_test.go
+++ b/src/core/syswarden-cli/config/config_contract_test.go
@@ -525,6 +525,38 @@ func TestEnsureDefaultsCompletesPartialConfigWithoutOverwritingOperatorState_SW_
 	}
 }
 
+func TestParseConfigRejectsSymlinkedConfigurationRoot_SW_CFG_001(t *testing.T) {
+	target := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config")
+	if err := os.Symlink(target, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := GlobalConfig
+	previousState := CurrentLoadState()
+	active := &Config{SSHPort: "2222", FirewallBackend: "keep"}
+	GlobalConfig = active
+	t.Cleanup(func() {
+		GlobalConfig = previous
+		loadStateMu.Lock()
+		loadState = previousState
+		loadStateMu.Unlock()
+	})
+
+	want := fmt.Sprintf("configuration path %s is a symbolic link", configPath)
+	err := ParseConfig(configPath)
+	if err == nil || err.Error() != want {
+		t.Fatalf("ParseConfig() error = %v, want %q", err, want)
+	}
+	if GlobalConfig != active {
+		t.Fatal("rejected symlinked configuration root replaced the active configuration")
+	}
+	state := CurrentLoadState()
+	if !state.Degraded || state.Source != configPath || state.Error != want {
+		t.Fatalf("load state = %#v, want rejected symlink source and exact error", state)
+	}
+}
+
 func TestEnsureDefaultsRejectsSymlinkedOperatorModule_SW_CFG_001(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "config")
 	modules := filepath.Join(root, "modules")

--- a/src/core/syswarden-cli/config/config_loader.go
+++ b/src/core/syswarden-cli/config/config_loader.go
@@ -21,15 +21,22 @@ type modularConfigSource struct {
 }
 
 // ParseConfig is the entrypoint for loading configuration. A real directory is
-// treated as a modular TOML root; any other path is parsed as the deprecated
-// flat syswarden-auto.conf format.
+// treated as a modular TOML root, a symbolic link is rejected explicitly, and
+// any other path is parsed as the deprecated flat syswarden-auto.conf format.
 func ParseConfig(configPath string) error {
-	if info, err := os.Lstat(configPath); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
-		if err := loadModularConfig(configPath); err != nil {
+	if info, err := os.Lstat(configPath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			err := fmt.Errorf("configuration path %s is a symbolic link", configPath)
+			recordConfigLoadFailure(configPath, err)
 			return err
 		}
-		log.Println("[INFO] Using new modular TOML configuration format")
-		return nil
+		if info.IsDir() {
+			if err := loadModularConfig(configPath); err != nil {
+				return err
+			}
+			log.Println("[INFO] Using new modular TOML configuration format")
+			return nil
+		}
 	}
 
 	if err := loadOldConfig(configPath); err != nil {


### PR DESCRIPTION
## Summary

- Force every native ARM64 lifecycle Podman invocation through a private local-only launcher that removes inherited remote selectors and supplies `--remote=false`.
- Replace the failed stdout attestation channel with a precreated private JSON evidence file, then validate its inode, owner, mode, exact runtime paths, cgroup manager, rootless state, local service state, OS, and architecture.
- Use the explicit Podman 5.8.4 named `runc` runtime table and bind `linux/arm64` to the checksum-sealed runc v1.4.3 binary.
- Reject a symlinked configuration root explicitly before loader selection, retain the active configuration, and report the exact degraded source instead of routing the directory to the legacy flat-file loader.
- Extend the immutable v4.03.2 Release Manager recovery chain through the exact PR101 squash and semantically revalidate PR99 from its own parent.

## Root cause

Qualification run 32746387834 reached the delegated native ARM64 user session, but its Podman preflight returned success with an empty captured stdout value before the Python lifecycle lab could start.

Podman 5.8.4 selects remote mode when `CONTAINER_HOST` or `CONTAINER_CONNECTION` exists, even when its value is empty. The launcher now removes every remote selector and explicitly forces local mode for the preflight and all later lifecycle calls. Podman writes the preflight through its global `--out` option so the verdict no longer depends on the failed stdout capture path.

`ParseConfig()` used `Lstat()` and tested `IsDir()` before handling symbolic links. Because `Lstat()` describes the link itself, a symlink to a modular configuration directory was misclassified as a legacy flat file. The secure legacy reader still rejected it, so this was a fail-closed diagnostic and compatibility defect rather than a symlink traversal. The explicit root policy now matches the rest of the configuration subsystem.

## Validation

- Full package and release validator matrix: 325 tests passed, including Unix-socket cases.
- Release qualification workflow suite: 31 tests passed.
- Release Manager gate suite: 52 tests passed.
- Version controller Go tests passed.
- Both modified workflow YAML files parsed successfully and all 58 workflow shell bodies passed Bash syntax validation.
- ShellCheck passed for the modified ARM64 lifecycle body and both identical Release Manager validation bodies.
- Exact Podman 5.8.4 local test passed with empty inherited remote selectors, strict JSON validation, mode 0600, and a stable precreated inode.
- The new configuration-root regression test reproduced the legacy-loader misclassification before the fix, then passed with exact explicit rejection, active-state preservation, and degraded-state attribution. The complete `config` package test suite passed.
- Three independent adversarial reviews found no blocking defect.
- A synthetic future PR101 squash passed the complete PR101 through PR93 v4.03.2 Release Manager chain.
- The diff is limited to six reviewed 100644 files and `git diff --check` passes.

This pull request creates no release tag or GitHub Release and changes no documentation, branding, or GitHub image assets.

Fixes #100
