### PR TITLE
Qualification : stabilize v4.03.2 ARM64 lifecycle evidence

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,83 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_local_parent_sha="$(git rev-parse HEAD^)"
+              v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_stabilization_parent_sha}" != "41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization is not based on the reviewed PR101 squash." >&2
+                exit 1
+              fi
+              v4032_stabilization_expected_subject='Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)'
+              if [[ "${commit_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_stabilization_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 lifecycle stabilization diff contract
+              expected_v4032_stabilization_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              mapfile -d '' -t actual_v4032_stabilization_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_stabilization_diff[@]} != ${#expected_v4032_stabilization_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must modify exactly the eight reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_stabilization_diff[@]}; index++)); do
+                if [[ "${actual_v4032_stabilization_diff[index]}" != "${expected_v4032_stabilization_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_stabilization_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_stabilization_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 lifecycle stabilization ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 lifecycle stabilization diff contract
+              v4032_local_ref=HEAD^
+              v4032_local_parent_sha="$(git rev-parse "${v4032_local_ref}^")"
               if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2
                 exit 1
               fi
               v4032_local_expected_subject='Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)'
-              if [[ "${commit_subject}" != "${v4032_local_expected_subject}" ]]; then
+              v4032_local_subject="$(git log -1 --format=%s "${v4032_local_ref}")"
+              if [[ "${v4032_local_subject}" != "${v4032_local_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 "${v4032_local_ref}")"
               if (( ${#v4032_local_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 final qualification repair must be one linear commit." >&2
                 exit 1
@@ -161,7 +227,8 @@ jobs:
                 M "src/core/syswarden-cli/config/config_loader.go"
               )
               mapfile -d '' -t actual_v4032_local_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_local_ref}^" "${v4032_local_ref}"
               )
               if (( ${#actual_v4032_local_diff[@]} != ${#expected_v4032_local_diff[@]} )); then
                 echo "ERROR: the v4.03.2 final qualification repair must modify exactly the six reviewed files." >&2
@@ -181,7 +248,7 @@ jobs:
                 "src/core/syswarden-cli/config/config_contract_test.go"
                 "src/core/syswarden-cli/config/config_loader.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_local_ref}^" "${v4032_local_ref}"; do
                 for fix_path in "${v4032_local_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -196,7 +263,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 final qualification repair diff contract
-              v4032_runc_ref=HEAD^
+              v4032_runc_ref="${v4032_local_ref}^"
               v4032_runc_parent_sha="$(git rev-parse "${v4032_runc_ref}^")"
               if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2
@@ -1055,17 +1122,83 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_local_parent_sha="$(git rev-parse HEAD^)"
+              v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_stabilization_parent_sha}" != "41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization is not based on the reviewed PR101 squash." >&2
+                exit 1
+              fi
+              v4032_stabilization_expected_subject='Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)'
+              if [[ "${commit_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_stabilization_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 lifecycle stabilization diff contract
+              expected_v4032_stabilization_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              mapfile -d '' -t actual_v4032_stabilization_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_stabilization_diff[@]} != ${#expected_v4032_stabilization_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must modify exactly the eight reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_stabilization_diff[@]}; index++)); do
+                if [[ "${actual_v4032_stabilization_diff[index]}" != "${expected_v4032_stabilization_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_stabilization_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_stabilization_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 lifecycle stabilization ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 lifecycle stabilization diff contract
+              v4032_local_ref=HEAD^
+              v4032_local_parent_sha="$(git rev-parse "${v4032_local_ref}^")"
               if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2
                 exit 1
               fi
               v4032_local_expected_subject='Qualification : repair v4.03.2 ARM64 lab and config root handling (#101)'
-              if [[ "${commit_subject}" != "${v4032_local_expected_subject}" ]]; then
+              v4032_local_subject="$(git log -1 --format=%s "${v4032_local_ref}")"
+              if [[ "${v4032_local_subject}" != "${v4032_local_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_local_head_line <<< "$(git rev-list --parents -n 1 "${v4032_local_ref}")"
               if (( ${#v4032_local_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 final qualification repair must be one linear commit." >&2
                 exit 1
@@ -1080,7 +1213,8 @@ jobs:
                 M "src/core/syswarden-cli/config/config_loader.go"
               )
               mapfile -d '' -t actual_v4032_local_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_local_ref}^" "${v4032_local_ref}"
               )
               if (( ${#actual_v4032_local_diff[@]} != ${#expected_v4032_local_diff[@]} )); then
                 echo "ERROR: the v4.03.2 final qualification repair must modify exactly the six reviewed files." >&2
@@ -1100,7 +1234,7 @@ jobs:
                 "src/core/syswarden-cli/config/config_contract_test.go"
                 "src/core/syswarden-cli/config/config_loader.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_local_ref}^" "${v4032_local_ref}"; do
                 for fix_path in "${v4032_local_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1115,7 +1249,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 final qualification repair diff contract
-              v4032_runc_ref=HEAD^
+              v4032_runc_ref="${v4032_local_ref}^"
               v4032_runc_parent_sha="$(git rev-parse "${v4032_runc_ref}^")"
               if [[ "${v4032_runc_parent_sha}" != "d025f5ee7b1d453a64d11ea2f5afcab13fc01a97" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 runc pin is not based on the reviewed PR98 squash." >&2

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -657,6 +657,8 @@ jobs:
             --working-directory="${GITHUB_WORKSPACE}" \
             --property='Type=exec' \
             --property='Delegate=cpu io memory pids' \
+            --property='MemoryMax=1G' \
+            --property='TasksMax=512' \
             --property='UMask=0077' \
             --setenv="CONTAINERS_CONF=${containers_conf}" \
             --setenv='CONTAINERS_CONF_OVERRIDE=' \

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -32,6 +32,7 @@ from typing import Sequence
 
 SCHEMA_VERSION = 4
 LOG_TAIL_LIMIT = 12_000
+NAMESPACE_DIAGNOSTIC_PREFIX_BYTES = 256
 MAX_VERSION_COMPONENT = 2_147_483_647
 SYS_ADMIN_CAPABILITY_BIT = 21
 SYS_PTRACE_CAPABILITY_BIT = 19
@@ -218,7 +219,7 @@ stop() {
 """
 ALPINE_OPENRC_VERSION = "0.62.6-r0"
 ALPINE_OPENRC_SYS_ATTESTATION_HEX = (
-    "504f444d414e0a73797377617264656e2d6f70656e72632d72633d30"
+    "504f444d414e0a"
 )
 ALPINE_RC_CONF_PRE_SHA256 = (
     "87799a1b4fa5e3941276e695e8525fcd2c1a08f551d02d1c0b1bdfdd67a71dce"
@@ -254,20 +255,34 @@ FEDORA_LAB_MASKED_UNITS = tuple(
         )
     )
 )
+# A delegated rootless cgroup namespace may expose its own cgroup2 mount as rw.
+# The caller separately proves the non-host-root ID map, private cgroup namespace,
+# exact non-SYS_ADMIN capabilities, and NoNewPrivs. The Alpine runtime additionally
+# pins legacy OpenRC cgroup mode and rejects every openrc.* cgroup residue.
 ALPINE_CGROUP_MOUNTINFO_AWK = (
     '$5 == "/sys/fs/cgroup" { '
     "count++; separator = 0; "
     "for (field_number = 7; field_number <= NF; field_number++) "
     'if ($field_number == "-") { separator = field_number; break } '
-    'if (!separator || $(separator + 1) != "cgroup2") bad = 1; '
-    'split($6, options, ","); readonly = 0; '
-    'for (option in options) if (options[option] == "ro") readonly = 1; '
-    "if (!readonly) bad = 1 "
-    "} END { exit !(count == 1 && !bad) }"
+    'if ($4 != "/" || !separator || $(separator + 1) != "cgroup2") bad = 1; '
+    'split($6, options, ","); readonly = 0; readwrite = 0; '
+    "nosuid = 0; nodev = 0; noexec = 0; "
+    "for (option in options) { "
+    'if (options[option] == "ro") readonly++; '
+    'else if (options[option] == "rw") readwrite++; '
+    'else if (options[option] == "nosuid") nosuid++; '
+    'else if (options[option] == "nodev") nodev++; '
+    'else if (options[option] == "noexec") noexec++ '
+    "} "
+    "if (readonly + readwrite != 1 || nosuid != 1 || nodev != 1 || "
+    "noexec != 1) bad = 1; "
+    'access = readonly == 1 ? "ro" : "rw" '
+    "} END { if (count != 1 || bad) exit 1; print access }"
 )
 NAMESPACE_ATTESTATION_HELPERS = f"""set -eu
-syswarden_namespace_hex() {{
-    LC_ALL=C od -An -v -tx1 | tr -d ' \\n'
+syswarden_namespace_hex_prefix() {{
+    LC_ALL=C dd bs={NAMESPACE_DIAGNOSTIC_PREFIX_BYTES} count=1 2>/dev/null | \\
+        od -An -v -tx1 | tr -d ' \\n'
 }}
 syswarden_namespace_fail() {{
     syswarden_namespace_predicate="$1"
@@ -282,16 +297,24 @@ syswarden_namespace_fail() {{
         ''|*[!0-9]*) exit 97 ;;
     esac
     [ "${{syswarden_namespace_status}}" -le 255 ] || exit 97
-    syswarden_namespace_actual_hex="$(
-        printf '%s' "${{syswarden_namespace_actual}}" | syswarden_namespace_hex
+    syswarden_namespace_actual_bytes="$(
+        printf '%s' "${{syswarden_namespace_actual}}" | LC_ALL=C wc -c | tr -d ' '
     )" || exit 97
-    syswarden_namespace_expected_hex="$(
-        printf '%s' "${{syswarden_namespace_expected}}" | syswarden_namespace_hex
+    syswarden_namespace_expected_bytes="$(
+        printf '%s' "${{syswarden_namespace_expected}}" | LC_ALL=C wc -c | tr -d ' '
     )" || exit 97
-    printf '%s\\tpredicate=%s\\trc=%s\\tactual_hex=%s\\texpected_hex=%s\\n' \\
+    syswarden_namespace_actual_hex_prefix="$(
+        printf '%s' "${{syswarden_namespace_actual}}" | syswarden_namespace_hex_prefix
+    )" || exit 97
+    syswarden_namespace_expected_hex_prefix="$(
+        printf '%s' "${{syswarden_namespace_expected}}" | syswarden_namespace_hex_prefix
+    )" || exit 97
+    printf '%s\\tpredicate=%s\\trc=%s\\tactual_bytes=%s\\tactual_hex_prefix=%s\\texpected_bytes=%s\\texpected_hex_prefix=%s\\n' \\
         '{NAMESPACE_FAILURE_MARKER}' "${{syswarden_namespace_predicate}}" \\
-        "${{syswarden_namespace_status}}" "${{syswarden_namespace_actual_hex}}" \\
-        "${{syswarden_namespace_expected_hex}}" >&2
+        "${{syswarden_namespace_status}}" "${{syswarden_namespace_actual_bytes}}" \\
+        "${{syswarden_namespace_actual_hex_prefix}}" \\
+        "${{syswarden_namespace_expected_bytes}}" \\
+        "${{syswarden_namespace_expected_hex_prefix}}" >&2
     exit 1
 }}
 syswarden_namespace_expect_equal() {{
@@ -306,6 +329,23 @@ syswarden_namespace_expect_equal() {{
             "${{syswarden_namespace_expected}}"
     fi
 }}
+syswarden_namespace_expect_integer() {{
+    syswarden_namespace_predicate="$1"
+    syswarden_namespace_status="$2"
+    syswarden_namespace_actual="$3"
+    syswarden_namespace_expected="$4"
+    if [ "${{syswarden_namespace_status}}" -ne 0 ]; then
+        syswarden_namespace_fail "${{syswarden_namespace_predicate}}" \\
+            "${{syswarden_namespace_status}}" "${{syswarden_namespace_actual}}" \\
+            "${{syswarden_namespace_expected}}"
+    fi
+    if ! [ "${{syswarden_namespace_actual}}" -eq \\
+           "${{syswarden_namespace_expected}}" ] 2>/dev/null; then
+        syswarden_namespace_fail "${{syswarden_namespace_predicate}}" \\
+            "${{syswarden_namespace_status}}" "${{syswarden_namespace_actual}}" \\
+            "${{syswarden_namespace_expected}}"
+    fi
+}}
 syswarden_namespace_expect_status() {{
     syswarden_namespace_predicate="$1"
     syswarden_namespace_status="$2"
@@ -314,6 +354,33 @@ syswarden_namespace_expect_status() {{
         syswarden_namespace_fail "${{syswarden_namespace_predicate}}" \\
             "${{syswarden_namespace_status}}" "${{syswarden_namespace_actual}}" ''
     fi
+}}
+syswarden_namespace_file_record() {{
+    syswarden_namespace_record_path="$1"
+    syswarden_namespace_record_bytes="$(
+        LC_ALL=C wc -c < "${{syswarden_namespace_record_path}}" 2>&1
+    )" || {{
+        syswarden_namespace_record_status=$?
+        printf 'wc=%s' "${{syswarden_namespace_record_bytes}}"
+        return "${{syswarden_namespace_record_status}}"
+    }}
+    syswarden_namespace_record_od="$(
+        LC_ALL=C od -An -N {NAMESPACE_DIAGNOSTIC_PREFIX_BYTES} -v -tx1 \\
+            "${{syswarden_namespace_record_path}}" 2>&1
+    )" || {{
+        syswarden_namespace_record_status=$?
+        printf 'od=%s' "${{syswarden_namespace_record_od}}"
+        return "${{syswarden_namespace_record_status}}"
+    }}
+    syswarden_namespace_record_hex="$(
+        printf '%s' "${{syswarden_namespace_record_od}}" | tr -d ' \\n'
+    )" || {{
+        syswarden_namespace_record_status=$?
+        printf 'tr=%s' "${{syswarden_namespace_record_hex}}"
+        return "${{syswarden_namespace_record_status}}"
+    }}
+    printf 'bytes=%s;hex=%s' "${{syswarden_namespace_record_bytes}}" \\
+        "${{syswarden_namespace_record_hex}}"
 }}
 """
 
@@ -5196,8 +5263,6 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
     ).hexdigest()
     return (
         common
-        + f"[ \"$(sha256sum /etc/init.d/syswarden-lab-net | awk '{{ print $1 }}')\" = \"{provider_sha256}\" ]\n"
-        + "[ \"$(stat -c '%u:%g:%a' /etc/init.d/syswarden-lab-net)\" = 0:0:755 ]\n"
         + "syswarden_apk_info_actual=\"$(\n"
         + "    syswarden_apk_info_status=0\n"
         + f"    apk info -e 'openrc={ALPINE_OPENRC_VERSION}' 2>&1 || syswarden_apk_info_status=$?\n"
@@ -5205,33 +5270,151 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
         + ")\"\n"
         + "syswarden_apk_info_expected=\"$(printf 'openrc\\nsyswarden-apk-info-rc=0')\"\n"
         + "syswarden_namespace_expect_equal NS15_OPENRC_PACKAGE 0 \"${syswarden_apk_info_actual}\" \"${syswarden_apk_info_expected}\"\n"
-        + "[ -f /etc/rc.conf ] && [ ! -L /etc/rc.conf ]\n"
-        + f"[ \"$(sha256sum /etc/rc.conf | awk '{{ print $1 }}')\" = \"{ALPINE_RC_CONF_POST_SHA256}\" ]\n"
-        + "[ \"$(grep -Fxc 'rc_sys=\"podman\"' /etc/rc.conf)\" -eq 1 ]\n"
-        + "[ \"$(grep -Fxc 'rc_cgroup_mode=\"legacy\"' /etc/rc.conf)\" -eq 1 ]\n"
-        + "[ \"$(awk '/^[[:space:]]*rc_sys[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf)\" -eq 1 ]\n"
-        + "[ \"$(awk '/^[[:space:]]*rc_cgroup_mode[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf)\" -eq 1 ]\n"
-        + "syswarden_openrc_sys_hex=\"$(\n"
-        + "    { openrc --sys; printf 'syswarden-openrc-rc=%s' \"$?\"; } |\n"
-        + "        od -An -v -tx1 | tr -d ' \\n'\n"
-        + ")\"\n"
-        + f"[ \"${{syswarden_openrc_sys_hex}}\" = \"{ALPINE_OPENRC_SYS_ATTESTATION_HEX}\" ]\n"
-        + "[ -f /etc/init.d/hostname ] && [ ! -L /etc/init.d/hostname ]\n"
-        + f"[ \"$(sha256sum /etc/init.d/hostname | awk '{{ print $1 }}')\" = \"{ALPINE_HOSTNAME_INIT_POST_SHA256}\" ]\n"
-        + "[ \"$(grep -Ec '^[[:space:]]*keyword -prefix -lxc -docker -podman$' /etc/init.d/hostname)\" -eq 1 ]\n"
-        + "[ \"$(tr '\\000' '\\n' < /proc/1/environ | grep -Fxc 'container=podman')\" -eq 1 ]\n"
-        + "awk "
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(sha256sum /etc/init.d/syswarden-lab-net 2>&1)\" || syswarden_namespace_status=$?\n"
+        + f"syswarden_namespace_expect_equal NS16_APK_PROVIDER_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{provider_sha256}  /etc/init.d/syswarden-lab-net\"\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(stat -c '%F:%u:%g:%a' /etc/init.d/syswarden-lab-net 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_equal NS17_APK_PROVIDER_STAT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 'regular file:0:0:755'\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(stat -c '%F:%u:%g:%a' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_equal NS18_APK_RC_CONF_STAT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 'regular file:0:0:644'\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(sha256sum /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + f"syswarden_namespace_expect_equal NS19_APK_RC_CONF_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{ALPINE_RC_CONF_POST_SHA256}  /etc/rc.conf\"\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(grep -Fxc 'rc_sys=\"podman\"' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS20_APK_RC_SYS_LINE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(grep -Fxc 'rc_cgroup_mode=\"legacy\"' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS21_APK_RC_CGROUP_LINE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(awk '/^[[:space:]]*rc_sys[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS22_APK_RC_SYS_COUNT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(awk '/^[[:space:]]*rc_cgroup_mode[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS23_APK_RC_CGROUP_COUNT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_openrc_file=\"$(mktemp /tmp/syswarden-openrc-sys.XXXXXX 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "if [ \"${syswarden_namespace_status}\" -eq 0 ]; then\n"
+        + "    openrc --sys > \"${syswarden_namespace_openrc_file}\" 2>&1 || syswarden_namespace_status=$?\n"
+        + "    syswarden_namespace_record_status=0\n"
+        + "    syswarden_namespace_actual=\"$(syswarden_namespace_file_record \"${syswarden_namespace_openrc_file}\")\" || syswarden_namespace_record_status=$?\n"
+        + "    if [ \"${syswarden_namespace_status}\" -eq 0 ]; then\n"
+        + "        syswarden_namespace_status=\"${syswarden_namespace_record_status}\"\n"
+        + "    fi\n"
+        + "    syswarden_namespace_cleanup_status=0\n"
+        + "    syswarden_namespace_cleanup=\"$(rm -f \"${syswarden_namespace_openrc_file}\" 2>&1)\" || syswarden_namespace_cleanup_status=$?\n"
+        + "    if [ \"${syswarden_namespace_cleanup_status}\" -ne 0 ]; then\n"
+        + "        syswarden_namespace_actual=\"${syswarden_namespace_actual};cleanup=${syswarden_namespace_cleanup}\"\n"
+        + "        if [ \"${syswarden_namespace_status}\" -eq 0 ]; then\n"
+        + "            syswarden_namespace_status=\"${syswarden_namespace_cleanup_status}\"\n"
+        + "        fi\n"
+        + "    fi\n"
+        + "else\n"
+        + "    syswarden_namespace_actual=\"mktemp=${syswarden_namespace_openrc_file}\"\n"
+        + "fi\n"
+        + f"syswarden_namespace_expect_equal NS24_APK_OPENRC_SYS \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" 'bytes=7;hex={ALPINE_OPENRC_SYS_ATTESTATION_HEX}'\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(stat -c '%F:%u:%g:%a' /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_equal NS25_APK_HOSTNAME_STAT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 'regular file:0:0:755'\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(sha256sum /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
+        + f"syswarden_namespace_expect_equal NS26_APK_HOSTNAME_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{ALPINE_HOSTNAME_INIT_POST_SHA256}  /etc/init.d/hostname\"\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(grep -Ec '^[[:space:]]*keyword -prefix -lxc -docker -podman$' /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS27_APK_HOSTNAME_KEYWORD \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_pid1_environment=\"$(tr '\\000' '\\n' < /proc/1/environ 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "if [ \"${syswarden_namespace_status}\" -eq 0 ]; then\n"
+        + "    syswarden_namespace_actual=\"$(printf '%s\\n' \"${syswarden_namespace_pid1_environment}\" | grep -Fxc 'container=podman')\" || syswarden_namespace_status=$?\n"
+        + "else\n"
+        + "    syswarden_namespace_actual=\"${syswarden_namespace_pid1_environment}\"\n"
+        + "fi\n"
+        + "syswarden_namespace_expect_integer NS28_APK_PID1_ENV \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(awk "
         + shlex.quote(ALPINE_CGROUP_MOUNTINFO_AWK)
-        + " /proc/self/mountinfo\n"
-        + "for openrc_cgroup_path in /sys/fs/cgroup/openrc.*; do\n"
-        + "    [ ! -e \"${openrc_cgroup_path}\" ] && [ ! -L \"${openrc_cgroup_path}\" ] || exit 1\n"
-        + "done\n"
-        + "[ \"$(rc-update show -v | awk '$1 == \"syswarden-lab-net\" && $2 == \"|\" && $3 == \"default\" { count++ } END { print count + 0 }')\" -eq 1 ]\n"
-        + "[ \"$(rc-update show -v | awk '$1 == \"cronie\" && $2 == \"|\" && $3 == \"default\" { count++ } END { print count + 0 }')\" -eq 1 ]\n"
-        + "[ \"$(rc-update show -v | awk '$1 == \"rsyslog\" && $2 == \"|\" && $3 == \"default\" { count++ } END { print count + 0 }')\" -eq 1 ]\n"
-        + "rc-service syswarden-lab-net status >/dev/null 2>&1\n"
-        + "rc-service cronie status >/dev/null 2>&1\n"
-        + "rc-service rsyslog status >/dev/null 2>&1\n"
+        + " /proc/self/mountinfo 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "case \"${syswarden_namespace_actual}\" in\n"
+        + "    ro|rw) syswarden_namespace_cgroup_access=\"${syswarden_namespace_actual}\"; syswarden_namespace_cgroup_contract=delegated-cgroup2 ;;\n"
+        + "    *) syswarden_namespace_cgroup_contract=\"${syswarden_namespace_actual}\" ;;\n"
+        + "esac\n"
+        + "syswarden_namespace_expect_equal NS29_APK_CGROUP_MOUNT \"${syswarden_namespace_status}\" \"${syswarden_namespace_cgroup_contract}\" delegated-cgroup2\n"
+        + "syswarden_namespace_cgroup_boundary() {\n"
+        + "    syswarden_namespace_cgroup_access=\"$1\"\n"
+        + "    syswarden_namespace_children_status=0\n"
+        + "    syswarden_namespace_children=\"$(find /sys/fs/cgroup -mindepth 1 -maxdepth 1 '(' -type d -o -type l ')' -print 2>&1)\" || syswarden_namespace_children_status=$?\n"
+        + "    if [ \"${syswarden_namespace_children_status}\" -ne 0 ]; then\n"
+        + "        printf 'find=%s' \"${syswarden_namespace_children}\"\n"
+        + "        return \"${syswarden_namespace_children_status}\"\n"
+        + "    fi\n"
+        + "    if [ -n \"${syswarden_namespace_children}\" ]; then\n"
+        + "        printf 'children=%s' \"${syswarden_namespace_children}\"\n"
+        + "        return 1\n"
+        + "    fi\n"
+        + "    if [ \"${syswarden_namespace_cgroup_access}\" = ro ]; then\n"
+        + "        printf 'ro;children='\n"
+        + "        return 0\n"
+        + "    fi\n"
+        + "    syswarden_namespace_cgroup_status=0\n"
+        + "    syswarden_namespace_cgroup=\"$(cat /proc/self/cgroup 2>&1)\" || syswarden_namespace_cgroup_status=$?\n"
+        + "    if [ \"${syswarden_namespace_cgroup_status}\" -ne 0 ]; then\n"
+        + "        printf 'cgroup=%s' \"${syswarden_namespace_cgroup}\"\n"
+        + "        return \"${syswarden_namespace_cgroup_status}\"\n"
+        + "    fi\n"
+        + "    syswarden_namespace_memory_status=0\n"
+        + "    syswarden_namespace_memory=\"$(cat /sys/fs/cgroup/memory.max 2>&1)\" || syswarden_namespace_memory_status=$?\n"
+        + "    if [ \"${syswarden_namespace_memory_status}\" -ne 0 ]; then\n"
+        + "        printf 'memory.max=%s' \"${syswarden_namespace_memory}\"\n"
+        + "        return \"${syswarden_namespace_memory_status}\"\n"
+        + "    fi\n"
+        + "    syswarden_namespace_pids_status=0\n"
+        + "    syswarden_namespace_pids=\"$(cat /sys/fs/cgroup/pids.max 2>&1)\" || syswarden_namespace_pids_status=$?\n"
+        + "    if [ \"${syswarden_namespace_pids_status}\" -ne 0 ]; then\n"
+        + "        printf 'pids.max=%s' \"${syswarden_namespace_pids}\"\n"
+        + "        return \"${syswarden_namespace_pids_status}\"\n"
+        + "    fi\n"
+        + "    printf 'rw;cgroup=%s;memory.max=%s;pids.max=%s;children=' \\\n"
+        + "        \"${syswarden_namespace_cgroup}\" \"${syswarden_namespace_memory}\" \\\n"
+        + "        \"${syswarden_namespace_pids}\"\n"
+        + "}\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(syswarden_namespace_cgroup_boundary \"${syswarden_namespace_cgroup_access}\")\" || syswarden_namespace_status=$?\n"
+        + "case \"${syswarden_namespace_cgroup_access}\" in\n"
+        + "    ro) syswarden_namespace_expected='ro;children=' ;;\n"
+        + "    rw) syswarden_namespace_expected='rw;cgroup=0::/;memory.max=1073741824;pids.max=512;children=' ;;\n"
+        + "    *) syswarden_namespace_expected=delegated-cgroup2 ;;\n"
+        + "esac\n"
+        + "syswarden_namespace_expect_equal NS30_APK_CGROUP_BOUNDARY \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" \"${syswarden_namespace_expected}\"\n"
+        + "syswarden_namespace_runlevel_count() {\n"
+        + "    syswarden_namespace_service=\"$1\"\n"
+        + "    syswarden_namespace_runlevel_status=0\n"
+        + "    syswarden_namespace_runlevels=\"$(rc-update show -v 2>&1)\" || syswarden_namespace_runlevel_status=$?\n"
+        + "    if [ \"${syswarden_namespace_runlevel_status}\" -ne 0 ]; then\n"
+        + "        printf '%s' \"${syswarden_namespace_runlevels}\"\n"
+        + "        return \"${syswarden_namespace_runlevel_status}\"\n"
+        + "    fi\n"
+        + "    printf '%s\\n' \"${syswarden_namespace_runlevels}\" | awk -v wanted=\"${syswarden_namespace_service}\" '$1 == wanted && $2 == \"|\" && $3 == \"default\" { count++ } END { print count + 0 }'\n"
+        + "}\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(syswarden_namespace_runlevel_count syswarden-lab-net)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS31_APK_NET_RUNLEVEL \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(syswarden_namespace_runlevel_count cronie)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS32_APK_CRON_RUNLEVEL \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(syswarden_namespace_runlevel_count rsyslog)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_integer NS33_APK_RSYSLOG_RUNLEVEL \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(rc-service syswarden-lab-net status 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_status NS34_APK_NET_ACTIVE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\"\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(rc-service cronie status 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_status NS35_APK_CRON_ACTIVE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\"\n"
+        + "syswarden_namespace_status=0\n"
+        + "syswarden_namespace_actual=\"$(rc-service rsyslog status 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_expect_status NS36_APK_RSYSLOG_ACTIVE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\"\n"
     )
 
 
@@ -6380,6 +6563,15 @@ def inspect_container_isolation(
         or set(security_opts) != {"label=disable", "no-new-privileges"}
     ):
         raise LifecycleLabError("container namespace/capability isolation is not exact")
+    memory_limit = host.get("Memory")
+    pids_limit = host.get("PidsLimit")
+    if (
+        type(memory_limit) is not int
+        or memory_limit != 1_073_741_824
+        or type(pids_limit) is not int
+        or pids_limit != 512
+    ):
+        raise LifecycleLabError("container memory/PID limits are not exact")
     expected_stop = "SIGINT" if spec.family == "apk" else "SIGRTMIN+3"
     if config.get("StopSignal") != expected_stop:
         raise LifecycleLabError("container stop signal differs from the init contract")

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -32,6 +32,25 @@ def set_capability_bit(mask: str, bit: int, *, present: bool) -> str:
     return f"{value:016x}"
 
 
+def namespace_failure_record(
+    predicate: str,
+    status: int | str,
+    actual: str,
+    expected: str,
+) -> str:
+    actual_bytes = actual.encode()
+    expected_bytes = expected.encode()
+    prefix_bytes = package_lifecycle_lab.NAMESPACE_DIAGNOSTIC_PREFIX_BYTES
+    return (
+        package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+        + f"\tpredicate={predicate}\trc={status}"
+        + f"\tactual_bytes={len(actual_bytes)}"
+        + f"\tactual_hex_prefix={actual_bytes[:prefix_bytes].hex()}"
+        + f"\texpected_bytes={len(expected_bytes)}"
+        + f"\texpected_hex_prefix={expected_bytes[:prefix_bytes].hex()}\n"
+    )
+
+
 class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
     def __init__(
         self,
@@ -270,6 +289,8 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
         namespace_failure_stderr: str = "runtime not ready\n",
         inspect_cap_add: list[str] | None = None,
         inspect_run_tmpfs: str = "rw,nodev,nosuid,exec,size=64m,mode=755",
+        inspect_memory: object = 1_073_741_824,
+        inspect_pids_limit: object = 512,
         uid_map: list[dict[str, int]] | None = None,
         gid_map: list[dict[str, int]] | None = None,
     ) -> None:
@@ -282,6 +303,8 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
         self.namespace_failure_stderr = namespace_failure_stderr
         self.inspect_cap_add = inspect_cap_add
         self.inspect_run_tmpfs = inspect_run_tmpfs
+        self.inspect_memory = inspect_memory
+        self.inspect_pids_limit = inspect_pids_limit
         self.uid_map = uid_map if uid_map is not None else [
             {"container_id": 0, "host_id": 1000, "size": 1},
             {"container_id": 1, "host_id": 524288, "size": 65536},
@@ -703,6 +726,8 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
                             "UTSMode": "private",
                             "CgroupMode": "private",
                             "UsernsMode": "",
+                            "Memory": self.inspect_memory,
+                            "PidsLimit": self.inspect_pids_limit,
                             "CapAdd": caps,
                             "CapDrop": [],
                             "Devices": [],
@@ -1493,7 +1518,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
         self.assertIn(
             package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
             + "\tpredicate=NS14_FEDORA_MASKS\trc=7"
-            + f"\tactual_hex={'permission denied'.encode().hex()}",
+            + "\tactual_bytes=17"
+            + f"\tactual_hex_prefix={'permission denied'.encode().hex()}",
             command_failure.stderr,
         )
 
@@ -1516,10 +1542,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         self.assertEqual(rejected.stdout, "")
         self.assertEqual(
             rejected.stderr,
-            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
-            + "\tpredicate=NS14_FEDORA_MASKS\trc=0"
-            + f"\tactual_hex={actual.encode().hex()}"
-            + f"\texpected_hex={expected.encode().hex()}\n",
+            namespace_failure_record("NS14_FEDORA_MASKS", 0, actual, expected),
         )
 
         accepted = subprocess.run(
@@ -1544,6 +1567,65 @@ class PackageLifecycleLabTests(unittest.TestCase):
         )
         self.assertEqual(failed_command.returncode, 1)
         self.assertIn("\tpredicate=NS03_ETH0_LINK\trc=7\t", failed_command.stderr)
+
+        integer_probe = (
+            package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+            + 'syswarden_namespace_expect_integer NS20_APK_RC_SYS_LINE '
+            + '"$1" "$2" 1\n'
+        )
+        for actual in ("1", "01", "+1"):
+            with self.subTest(integer=actual):
+                numeric = subprocess.run(
+                    ["/bin/sh", "-eu", "-c", integer_probe, "probe", "0", actual],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(numeric.returncode, 0, numeric.stderr)
+                self.assertEqual(numeric.stdout, "")
+                self.assertEqual(numeric.stderr, "")
+        for status, actual in (("0", "2"), ("0", "invalid"), ("7", "1")):
+            with self.subTest(status=status, rejected_integer=actual):
+                numeric = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-eu",
+                        "-c",
+                        integer_probe,
+                        "probe",
+                        status,
+                        actual,
+                    ],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(numeric.returncode, 1)
+                self.assertEqual(numeric.stdout, "")
+                self.assertIn(
+                    namespace_failure_record(
+                        "NS20_APK_RC_SYS_LINE", status, actual, "1"
+                    ),
+                    numeric.stderr,
+                )
+
+        oversized = "operator\n" + "x" * 32_768
+        bounded = subprocess.run(
+            ["/bin/sh", "-eu", "-c", probe, "probe", oversized, "exact"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(bounded.returncode, 1)
+        self.assertEqual(
+            bounded.stderr,
+            namespace_failure_record("NS14_FEDORA_MASKS", 0, oversized, "exact"),
+        )
+        actual_hex_prefix = bounded.stderr.split(
+            "\tactual_hex_prefix=", 1
+        )[1].split("\t", 1)[0]
+        self.assertEqual(len(actual_hex_prefix), 512)
+        self.assertLess(len(bounded.stderr), 800)
 
     def test_alpine_containerfile_and_runtime_attest_exact_openrc_boundary(
         self,
@@ -1584,20 +1666,70 @@ class PackageLifecycleLabTests(unittest.TestCase):
             package_lifecycle_lab.ALPINE_RC_CONF_POST_SHA256,
             package_lifecycle_lab.ALPINE_HOSTNAME_INIT_POST_SHA256,
             'container=podman',
-            "syswarden_openrc_sys_hex=",
-            "openrc --sys; printf 'syswarden-openrc-rc=%s'",
-            "od -An -v -tx1 | tr -d ' \\n'",
+            "syswarden_namespace_openrc_file=",
+            'openrc --sys > "${syswarden_namespace_openrc_file}" 2>&1',
+            "syswarden_namespace_file_record",
             package_lifecycle_lab.ALPINE_OPENRC_SYS_ATTESTATION_HEX,
             '$(separator + 1) != "cgroup2"',
             "field_number = 7",
             'options[option] == "ro"',
-            "/sys/fs/cgroup/openrc.*",
+            'options[option] == "rw"',
+            'options[option] == "nosuid"',
+            'options[option] == "nodev"',
+            'options[option] == "noexec"',
+            "delegated-cgroup2",
+            "find /sys/fs/cgroup -mindepth 1 -maxdepth 1",
             "rc-service syswarden-lab-net status",
             "rc-service cronie status",
             "rc-service rsyslog status",
         ):
             self.assertIn(expected, runtime)
         self.assertNotIn("for (index =", runtime)
+        predicates = (
+            "NS15_OPENRC_PACKAGE",
+            "NS16_APK_PROVIDER_SHA",
+            "NS17_APK_PROVIDER_STAT",
+            "NS18_APK_RC_CONF_STAT",
+            "NS19_APK_RC_CONF_SHA",
+            "NS20_APK_RC_SYS_LINE",
+            "NS21_APK_RC_CGROUP_LINE",
+            "NS22_APK_RC_SYS_COUNT",
+            "NS23_APK_RC_CGROUP_COUNT",
+            "NS24_APK_OPENRC_SYS",
+            "NS25_APK_HOSTNAME_STAT",
+            "NS26_APK_HOSTNAME_SHA",
+            "NS27_APK_HOSTNAME_KEYWORD",
+            "NS28_APK_PID1_ENV",
+            "NS29_APK_CGROUP_MOUNT",
+            "NS30_APK_CGROUP_BOUNDARY",
+            "NS31_APK_NET_RUNLEVEL",
+            "NS32_APK_CRON_RUNLEVEL",
+            "NS33_APK_RSYSLOG_RUNLEVEL",
+            "NS34_APK_NET_ACTIVE",
+            "NS35_APK_CRON_ACTIVE",
+            "NS36_APK_RSYSLOG_ACTIVE",
+        )
+        for predicate in predicates:
+            self.assertEqual(runtime.count(predicate), 1, predicate)
+            self.assertRegex(
+                runtime,
+                rf"syswarden_namespace_expect_(?:equal|integer|status) "
+                rf"{re.escape(predicate)}(?: |$)",
+            )
+        alpine_tail_start = runtime.index('syswarden_apk_info_actual="$(')
+        alpine_tail = runtime[alpine_tail_start:]
+        self.assertFalse(
+            any(line.startswith("[ ") for line in alpine_tail.splitlines())
+        )
+        self.assertFalse(
+            any(line.startswith("awk ") for line in alpine_tail.splitlines())
+        )
+        self.assertFalse(
+            any(
+                line.startswith("rc-service ")
+                for line in alpine_tail.splitlines()
+            )
+        )
         syntax = subprocess.run(
             ["/bin/sh", "-n"],
             input=package_lifecycle_lab._exec_security_guard_script(spec) + runtime,
@@ -1659,17 +1791,22 @@ class PackageLifecycleLabTests(unittest.TestCase):
                         result.stderr,
                     )
 
-        expected_openrc_attestation = b"PODMAN\nsyswarden-openrc-rc=0"
+        expected_openrc_attestation = b"PODMAN\n"
         self.assertEqual(
             package_lifecycle_lab.ALPINE_OPENRC_SYS_ATTESTATION_HEX,
             expected_openrc_attestation.hex(),
         )
-        guard_start = runtime_lines.index('syswarden_openrc_sys_hex="$(')
+        openrc_file_index = runtime_lines.index(
+            'syswarden_namespace_openrc_file="$(mktemp '
+            '/tmp/syswarden-openrc-sys.XXXXXX 2>&1)" '
+            '|| syswarden_namespace_status=$?'
+        )
+        guard_start = openrc_file_index - 1
         guard_end = next(
             index
             for index in range(guard_start, len(runtime_lines))
             if runtime_lines[index].startswith(
-                '[ "${syswarden_openrc_sys_hex}" = '
+                "syswarden_namespace_expect_equal NS24_APK_OPENRC_SYS"
             )
         )
         openrc_sys_guard = "\n".join(runtime_lines[guard_start : guard_end + 1])
@@ -1690,6 +1827,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
                     "openrc() { [ \"$1\" = --sys ] || return 2; "
                     f"printf {shlex.quote(output_format)}; "
                     f"return {command_status}; }}\n"
+                    + package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
                     + openrc_sys_guard
                     + "\n"
                 )
@@ -1700,6 +1838,16 @@ class PackageLifecycleLabTests(unittest.TestCase):
                     check=False,
                 )
                 self.assertEqual(result.returncode == 0, expected_status == 0)
+                if expected_status == 0:
+                    self.assertEqual(result.stderr, "")
+                else:
+                    self.assertIn(
+                        package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                        + "\tpredicate=NS24_APK_OPENRC_SYS\t",
+                        result.stderr,
+                    )
+                    if command_status:
+                        self.assertIn(f"\trc={command_status}\t", result.stderr)
 
         with mock.patch.object(
             package_lifecycle_lab,
@@ -1711,6 +1859,349 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 "configuration payload is not exact",
             ):
                 package_lifecycle_lab.build_containerfile(spec)
+
+    def test_alpine_file_and_configuration_guards_are_behavioral(self) -> None:
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.family == "apk"
+        )
+        runtime_lines = package_lifecycle_lab.runtime_namespace_script(
+            spec
+        ).splitlines()
+        provider_sha256 = hashlib.sha256(
+            package_lifecycle_lab.ALPINE_LAB_NETWORK_PROVIDER.encode()
+        ).hexdigest()
+        cases = (
+            (
+                "NS16_APK_PROVIDER_SHA",
+                "sha256sum",
+                f"{provider_sha256}  /etc/init.d/syswarden-lab-net",
+                "0" * 64 + "  /etc/init.d/syswarden-lab-net",
+            ),
+            (
+                "NS17_APK_PROVIDER_STAT",
+                "stat",
+                "regular file:0:0:755",
+                "symbolic link:0:0:755",
+            ),
+            (
+                "NS18_APK_RC_CONF_STAT",
+                "stat",
+                "regular file:0:0:644",
+                "symbolic link:0:0:644",
+            ),
+            (
+                "NS19_APK_RC_CONF_SHA",
+                "sha256sum",
+                package_lifecycle_lab.ALPINE_RC_CONF_POST_SHA256
+                + "  /etc/rc.conf",
+                "0" * 64 + "  /etc/rc.conf",
+            ),
+            ("NS20_APK_RC_SYS_LINE", "grep", "1", "0"),
+            ("NS21_APK_RC_CGROUP_LINE", "grep", "1", "0"),
+            ("NS22_APK_RC_SYS_COUNT", "awk", "1", "2"),
+            ("NS23_APK_RC_CGROUP_COUNT", "awk", "1", "2"),
+            (
+                "NS25_APK_HOSTNAME_STAT",
+                "stat",
+                "regular file:0:0:755",
+                "symbolic link:0:0:755",
+            ),
+            (
+                "NS26_APK_HOSTNAME_SHA",
+                "sha256sum",
+                package_lifecycle_lab.ALPINE_HOSTNAME_INIT_POST_SHA256
+                + "  /etc/init.d/hostname",
+                "0" * 64 + "  /etc/init.d/hostname",
+            ),
+            ("NS27_APK_HOSTNAME_KEYWORD", "grep", "1", "0"),
+        )
+
+        def guard_for(predicate: str) -> str:
+            end = next(
+                index
+                for index, line in enumerate(runtime_lines)
+                if predicate in line
+                and line.startswith("syswarden_namespace_expect_")
+            )
+            start = max(
+                index
+                for index in range(end)
+                if runtime_lines[index] == "syswarden_namespace_status=0"
+            )
+            return "\n".join(runtime_lines[start : end + 1]) + "\n"
+
+        for predicate, command, valid, mismatch in cases:
+            command_mock = (
+                f"{command}() {{\n"
+                "    printf '%s\\n' \"${SYSWARDEN_MOCK_OUTPUT}\"\n"
+                "    return \"${SYSWARDEN_MOCK_STATUS}\"\n"
+                "}\n"
+            )
+            probe = (
+                package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                + command_mock
+                + guard_for(predicate)
+            )
+            for label, output, status, accepted in (
+                ("valid", valid, "0", True),
+                ("mismatch", mismatch, "0", False),
+                ("producer failure", valid, "7", False),
+            ):
+                with self.subTest(predicate=predicate, case=label):
+                    result = subprocess.run(
+                        ["/bin/sh", "-eu", "-c", probe],
+                        env={
+                            **os.environ,
+                            "SYSWARDEN_MOCK_OUTPUT": output,
+                            "SYSWARDEN_MOCK_STATUS": status,
+                        },
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                    self.assertEqual(result.stdout, "")
+                    if accepted:
+                        self.assertEqual(result.stderr, "")
+                    else:
+                        self.assertEqual(
+                            result.stderr.count(
+                                package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            ),
+                            1,
+                        )
+                        self.assertIn(
+                            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            + f"\tpredicate={predicate}\trc={status}\t",
+                            result.stderr,
+                        )
+
+    def test_alpine_pid1_environment_guard_preserves_each_status(self) -> None:
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.family == "apk"
+        )
+        runtime_lines = package_lifecycle_lab.runtime_namespace_script(
+            spec
+        ).splitlines()
+        end = next(
+            index
+            for index, line in enumerate(runtime_lines)
+            if line.startswith(
+                "syswarden_namespace_expect_integer NS28_APK_PID1_ENV"
+            )
+        )
+        start = max(
+            index
+            for index in range(end)
+            if runtime_lines[index] == "syswarden_namespace_status=0"
+        )
+        guard = "\n".join(runtime_lines[start : end + 1]) + "\n"
+        mocks = r'''tr() {
+    if [ "$1" = '\000' ]; then
+        printf 'container=podman\n'
+        return "${SYSWARDEN_TR_STATUS}"
+    fi
+    command tr "$@"
+}
+grep() {
+    printf '%s\n' "${SYSWARDEN_GREP_OUTPUT}"
+    return "${SYSWARDEN_GREP_STATUS}"
+}
+'''
+        with tempfile.TemporaryDirectory() as temporary:
+            environ = Path(temporary) / "environ"
+            environ.write_bytes(b"container=podman\0")
+            probe = (
+                package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                + mocks
+                + guard.replace("/proc/1/environ", str(environ))
+            )
+            for label, tr_status, grep_status, grep_output, accepted in (
+                ("valid", "0", "0", "1", True),
+                ("count mismatch", "0", "0", "0", False),
+                ("parser failure", "0", "7", "1", False),
+                ("producer failure with valid output", "7", "0", "1", False),
+            ):
+                with self.subTest(case=label):
+                    result = subprocess.run(
+                        ["/bin/sh", "-eu", "-c", probe],
+                        env={
+                            **os.environ,
+                            "SYSWARDEN_TR_STATUS": tr_status,
+                            "SYSWARDEN_GREP_STATUS": grep_status,
+                            "SYSWARDEN_GREP_OUTPUT": grep_output,
+                        },
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode == 0, accepted, result.stderr)
+                    self.assertEqual(result.stdout, "")
+                    if accepted:
+                        self.assertEqual(result.stderr, "")
+                    else:
+                        expected_status = tr_status if tr_status != "0" else grep_status
+                        self.assertEqual(
+                            result.stderr.count(
+                                package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            ),
+                            1,
+                        )
+                        self.assertIn(
+                            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            + "\tpredicate=NS28_APK_PID1_ENV"
+                            + f"\trc={expected_status}\t",
+                            result.stderr,
+                        )
+
+    def test_complete_alpine_tail_runs_under_pinned_ash_when_available(
+        self,
+    ) -> None:
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.distribution == "alpine" and item.architecture == "amd64"
+        )
+        runtime = package_lifecycle_lab.runtime_namespace_script(spec)
+        ns15 = runtime.index(
+            "syswarden_namespace_expect_equal NS15_OPENRC_PACKAGE"
+        )
+        tail = runtime[runtime.index("\n", ns15) + 1 :]
+        provider_sha256 = hashlib.sha256(
+            package_lifecycle_lab.ALPINE_LAB_NETWORK_PROVIDER.encode()
+        ).hexdigest()
+        mocks = f'''sha256sum() {{
+    case "$1" in
+        /etc/init.d/syswarden-lab-net)
+            printf '%s  %s\n' '{provider_sha256}' "$1" ;;
+        /etc/rc.conf)
+            printf '%s  %s\n' '{package_lifecycle_lab.ALPINE_RC_CONF_POST_SHA256}' "$1" ;;
+        /etc/init.d/hostname)
+            printf '%s  %s\n' '{package_lifecycle_lab.ALPINE_HOSTNAME_INIT_POST_SHA256}' "$1" ;;
+        *) return 96 ;;
+    esac
+}}
+stat() {{
+    case "$3" in
+        /etc/init.d/syswarden-lab-net|/etc/init.d/hostname)
+            printf 'regular file:0:0:755\n' ;;
+        /etc/rc.conf) printf 'regular file:0:0:644\n' ;;
+        *) return 96 ;;
+    esac
+}}
+grep() {{ printf '1\n'; }}
+awk() {{
+    case " $* " in
+        *"/proc/self/mountinfo"*) printf 'rw\n' ;;
+        *) printf '1\n' ;;
+    esac
+}}
+tr() {{
+    if [ "$1" = '\\000' ]; then
+        printf 'container=podman\n'
+    else
+        command tr "$@"
+    fi
+}}
+openrc() {{
+    [ "$#" -eq 1 ] && [ "$1" = --sys ] || return 96
+    printf 'PODMAN\n'
+}}
+rc-update() {{
+    printf 'syswarden-lab-net | default\ncronie | default\nrsyslog | default\n'
+}}
+rc-service() {{ return 0; }}
+'''
+        base_probe = package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS + mocks
+        with tempfile.TemporaryDirectory() as temporary:
+            pid1_environment = Path(temporary) / "pid1-environ"
+            pid1_environment.write_bytes(b"container=podman\0")
+            cgroup_root = Path(temporary) / "cgroup"
+            cgroup_root.mkdir()
+            (cgroup_root / "memory.max").write_text(
+                "1073741824\n", encoding="utf-8"
+            )
+            (cgroup_root / "pids.max").write_text("512\n", encoding="utf-8")
+            self_cgroup = Path(temporary) / "self.cgroup"
+            self_cgroup.write_text("0::/\n", encoding="utf-8")
+            host_tail = (
+                tail.replace("/proc/1/environ", str(pid1_environment))
+                .replace("/proc/self/cgroup", str(self_cgroup))
+                .replace("/sys/fs/cgroup", str(cgroup_root))
+            )
+            host = subprocess.run(
+                [
+                    "/bin/sh",
+                    "-eu",
+                    "-c",
+                    base_probe + host_tail,
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(host.returncode, 0, host.stderr)
+            self.assertEqual(host.stdout, "")
+            self.assertEqual(host.stderr, "")
+
+        podman = shutil.which("podman")
+        if podman is None or subprocess.run(
+            [podman, "image", "exists", spec.image],
+            capture_output=True,
+            check=False,
+        ).returncode != 0:
+            self.skipTest("pinned local Alpine image required for ash execution")
+        alpine_environment = "/tmp/syswarden-test-pid1-environ"
+        alpine_cgroup_root = "/tmp/syswarden-test-cgroup"
+        alpine_self_cgroup = "/tmp/syswarden-test-self.cgroup"
+        alpine_tail = (
+            tail.replace("/proc/1/environ", alpine_environment)
+            .replace("/proc/self/cgroup", alpine_self_cgroup)
+            .replace("/sys/fs/cgroup", alpine_cgroup_root)
+        )
+        alpine_probe = (
+            f": > {alpine_environment}\n"
+            + f"mkdir {alpine_cgroup_root}\n"
+            + f"printf '1073741824\\n' > {alpine_cgroup_root}/memory.max\n"
+            + f"printf '512\\n' > {alpine_cgroup_root}/pids.max\n"
+            + f"printf '0::/\\n' > {alpine_self_cgroup}\n"
+            + base_probe
+            + alpine_tail
+        )
+        alpine = subprocess.run(
+            [
+                podman,
+                "run",
+                "--rm",
+                "--interactive",
+                "--pull=never",
+                "--platform=linux/amd64",
+                "--network=none",
+                "--read-only",
+                "--cap-drop=all",
+                "--security-opt=no-new-privileges",
+                "--security-opt=label=disable",
+                "--pids-limit=32",
+                "--memory=64m",
+                "--tmpfs=/tmp:rw,nodev,nosuid,noexec,size=1m,mode=1777",
+                "--user=65534:65534",
+                spec.image,
+                "/bin/ash",
+                "-eu",
+                "-s",
+            ],
+            input=alpine_probe,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(alpine.returncode, 0, alpine.stderr)
+        self.assertEqual(alpine.stdout, "")
+        self.assertEqual(alpine.stderr, "")
 
     def test_alpine_cgroup_mountinfo_awk_is_busybox_safe_and_fail_closed(
         self,
@@ -1756,20 +2247,39 @@ class PackageLifecycleLabTests(unittest.TestCase):
             "29 23 0:26 / /sys/fs/cgroup "
             "ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n"
         )
+        valid_rw = valid.replace("ro,nosuid", "rw,nosuid")
         cases = (
-            ("valid", valid, 0),
-            ("missing", "", 1),
+            ("read-only", valid, 0, "ro\n"),
+            ("delegated-read-write", valid_rw, 0, "rw\n"),
+            ("missing", "", 1, ""),
             (
-                "read-write",
-                valid.replace("ro,nosuid", "rw,nosuid"),
+                "contradictory-access",
+                valid.replace("ro,nosuid", "ro,rw,nosuid"),
                 1,
+                "",
             ),
-            ("cgroup-v1", valid.replace("- cgroup2", "- cgroup"), 1),
-            ("duplicate", valid + valid, 1),
-            ("wrong-mountpoint", valid.replace("/sys/fs/cgroup", "/cgroup"), 1),
-            ("missing-separator", valid.replace(" - cgroup2", " cgroup2"), 1),
+            ("missing-access", valid.replace("ro,", ""), 1, ""),
+            ("duplicate-access", valid.replace("ro,", "ro,ro,"), 1, ""),
+            ("missing-nosuid", valid.replace("nosuid,", ""), 1, ""),
+            ("missing-nodev", valid.replace("nodev,", ""), 1, ""),
+            ("missing-noexec", valid.replace("noexec,", ""), 1, ""),
+            ("wrong-root", valid.replace("0:26 / /sys", "0:26 /host /sys"), 1, ""),
+            ("cgroup-v1", valid.replace("- cgroup2", "- cgroup"), 1, ""),
+            ("duplicate", valid + valid, 1, ""),
+            (
+                "wrong-mountpoint",
+                valid.replace("/sys/fs/cgroup", "/cgroup"),
+                1,
+                "",
+            ),
+            (
+                "missing-separator",
+                valid.replace(" - cgroup2", " cgroup2"),
+                1,
+                "",
+            ),
         )
-        for label, mountinfo, expected_status in cases:
+        for label, mountinfo, expected_status, expected_output in cases:
             with self.subTest(mountinfo=label):
                 result = subprocess.run(
                     command,
@@ -1779,8 +2289,66 @@ class PackageLifecycleLabTests(unittest.TestCase):
                     check=False,
                 )
                 self.assertEqual(result.returncode, expected_status, result.stderr)
+                self.assertEqual(result.stdout, expected_output)
+                self.assertEqual(result.stderr, "")
 
-    def test_openrc_cgroup_glob_rejects_literal_directory_and_broken_symlink(
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.family == "apk"
+        )
+        runtime = package_lifecycle_lab.runtime_namespace_script(spec)
+        runtime_lines = runtime.splitlines()
+        assignment = next(
+            index
+            for index, line in enumerate(runtime_lines)
+            if line.startswith('syswarden_namespace_actual="$(awk ')
+            and "/proc/self/mountinfo" in line
+        )
+        guard_end = next(
+            index
+            for index in range(assignment, len(runtime_lines))
+            if runtime_lines[index].startswith(
+                "syswarden_namespace_expect_equal NS29_APK_CGROUP_MOUNT"
+            )
+        )
+        cgroup_guard = "\n".join(runtime_lines[assignment - 1 : guard_end + 1])
+        with tempfile.TemporaryDirectory() as temporary:
+            mountinfo_path = Path(temporary) / "mountinfo"
+            cgroup_guard = cgroup_guard.replace(
+                "/proc/self/mountinfo", str(mountinfo_path)
+            )
+            for label, mountinfo, expected_status, _ in cases:
+                with self.subTest(runtime_mountinfo=label):
+                    mountinfo_path.write_text(mountinfo, encoding="utf-8")
+                    guarded = subprocess.run(
+                        [
+                            "/bin/sh",
+                            "-eu",
+                            "-c",
+                            package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                            + cgroup_guard,
+                        ],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(
+                        guarded.returncode,
+                        expected_status,
+                        guarded.stderr,
+                    )
+                    self.assertEqual(guarded.stdout, "")
+                    if expected_status == 0:
+                        self.assertEqual(guarded.stderr, "")
+                    else:
+                        self.assertIn(
+                            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            + "\tpredicate=NS29_APK_CGROUP_MOUNT\t",
+                            guarded.stderr,
+                        )
+
+    def test_alpine_cgroup_boundary_accepts_only_exact_ro_or_bounded_rw(
         self,
     ) -> None:
         spec = next(
@@ -1789,35 +2357,235 @@ class PackageLifecycleLabTests(unittest.TestCase):
             if item.family == "apk"
         )
         runtime = package_lifecycle_lab.runtime_namespace_script(spec)
-        start = runtime.index("for openrc_cgroup_path")
-        end = runtime.index("done\n", start) + len("done\n")
-        loop = runtime[start:end]
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            probe = loop.replace("/sys/fs/cgroup", str(root))
-            clean = subprocess.run(
-                ["/bin/sh", "-eu", "-c", probe],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            self.assertEqual(clean.returncode, 0, clean.stderr)
-            for name, create in (
-                ("openrc.*", lambda path: path.mkdir()),
-                ("openrc.cronie", lambda path: path.mkdir()),
-                ("openrc.broken", lambda path: path.symlink_to("missing")),
-            ):
-                with self.subTest(name=name):
-                    path = root / name
-                    create(path)
-                    rejected = subprocess.run(
+        start = runtime.index("syswarden_namespace_cgroup_boundary() {")
+        predicate = "syswarden_namespace_expect_equal NS30_APK_CGROUP_BOUNDARY"
+        end = runtime.index("\n", runtime.index(predicate, start)) + 1
+        guard = runtime[start:end]
+
+        def run_guard(
+            access: str,
+            *,
+            cgroup: str = "0::/",
+            memory: str = "1073741824",
+            pids: str = "512",
+            child: str | None = None,
+            broken_symlink: bool = False,
+            missing: str | None = None,
+            unreadable: bool = False,
+            find_failure: bool = False,
+        ) -> subprocess.CompletedProcess[str]:
+            with tempfile.TemporaryDirectory() as temporary:
+                temporary_root = Path(temporary)
+                cgroup_root = temporary_root / "cgroup"
+                cgroup_root.mkdir()
+                proc_self_cgroup = temporary_root / "self.cgroup"
+                proc_self_cgroup.write_text(cgroup + "\n", encoding="utf-8")
+                if access == "rw":
+                    (cgroup_root / "memory.max").write_text(
+                        memory + "\n", encoding="utf-8"
+                    )
+                    (cgroup_root / "pids.max").write_text(
+                        pids + "\n", encoding="utf-8"
+                    )
+                if missing is not None:
+                    target = (
+                        proc_self_cgroup
+                        if missing == "cgroup"
+                        else cgroup_root / missing
+                    )
+                    target.unlink()
+                if child is not None:
+                    child_path = cgroup_root / child
+                    if broken_symlink:
+                        child_path.symlink_to("missing")
+                    else:
+                        child_path.mkdir()
+                prefix = "find() { return 7; }\n" if find_failure else ""
+                probe = (
+                    package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                    + prefix
+                    + f"syswarden_namespace_cgroup_access={shlex.quote(access)}\n"
+                    + guard.replace("/proc/self/cgroup", str(proc_self_cgroup))
+                    .replace("/sys/fs/cgroup", str(cgroup_root))
+                )
+                if unreadable:
+                    cgroup_root.chmod(0)
+                try:
+                    return subprocess.run(
                         ["/bin/sh", "-eu", "-c", probe],
-                        capture_output=True,
                         text=True,
+                        capture_output=True,
                         check=False,
                     )
-                    self.assertNotEqual(rejected.returncode, 0)
-                    path.unlink() if path.is_symlink() else path.rmdir()
+                finally:
+                    if unreadable:
+                        cgroup_root.chmod(0o700)
+
+        for access in ("ro", "rw"):
+            with self.subTest(accepted_access=access):
+                accepted = run_guard(access)
+                self.assertEqual(accepted.returncode, 0, accepted.stderr)
+                self.assertEqual(accepted.stdout, "")
+                self.assertEqual(accepted.stderr, "")
+
+        rejected_cases = (
+            ("wrong cgroup root", {"cgroup": "0::/delegated"}),
+            ("wrong memory maximum", {"memory": "max"}),
+            ("wrong PID maximum", {"pids": "max"}),
+            ("missing cgroup", {"missing": "cgroup"}),
+            ("missing memory maximum", {"missing": "memory.max"}),
+            ("missing PID maximum", {"missing": "pids.max"}),
+            ("arbitrary child", {"child": "operator.scope"}),
+            (
+                "broken symlink",
+                {"child": "operator.broken", "broken_symlink": True},
+            ),
+            ("find producer failure", {"find_failure": True}),
+        )
+        for label, options in rejected_cases:
+            with self.subTest(rejected=label):
+                rejected = run_guard("rw", **options)
+                self.assertEqual(rejected.returncode, 1)
+                self.assertEqual(rejected.stdout, "")
+                self.assertEqual(
+                    rejected.stderr.count(
+                        package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                    ),
+                    1,
+                )
+                self.assertIn(
+                    package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                    + "\tpredicate=NS30_APK_CGROUP_BOUNDARY\t",
+                    rejected.stderr,
+                )
+        if os.geteuid() != 0:
+            unreadable = run_guard("rw", unreadable=True)
+            self.assertEqual(unreadable.returncode, 1)
+            self.assertIn(
+                package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                + "\tpredicate=NS30_APK_CGROUP_BOUNDARY\t",
+                unreadable.stderr,
+            )
+
+    def test_alpine_runlevel_and_service_guards_are_independent_and_diagnostic(
+        self,
+    ) -> None:
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.family == "apk"
+        )
+        runtime = package_lifecycle_lab.runtime_namespace_script(spec)
+        runtime_lines = runtime.splitlines()
+        start = runtime_lines.index("syswarden_namespace_runlevel_count() {")
+        end = next(
+            index
+            for index in range(start, len(runtime_lines))
+            if runtime_lines[index].startswith(
+                "syswarden_namespace_expect_status NS36_APK_RSYSLOG_ACTIVE"
+            )
+        )
+        guarded_tail = "\n".join(runtime_lines[start : end + 1]) + "\n"
+
+        with tempfile.TemporaryDirectory() as temporary:
+            calls = Path(temporary) / "rc-update.calls"
+            mocks = r'''rc-update() {
+    [ "$#" -eq 2 ] && [ "$1" = show ] && [ "$2" = -v ] || return 96
+    printf 'call\n' >> "${SYSWARDEN_RC_UPDATE_CALLS}"
+    if [ "${SYSWARDEN_FAIL_RC_UPDATE:-}" = 1 ]; then
+        printf 'rc-update denied\n'
+        return 7
+    fi
+    for service in syswarden-lab-net cronie rsyslog; do
+        if [ "${service}" != "${SYSWARDEN_OMIT_SERVICE:-}" ]; then
+            printf '%s | default\n' "${service}"
+        fi
+    done
+}
+rc-service() {
+    [ "$#" -eq 2 ] && [ "$2" = status ] || return 96
+    if [ "$1" = "${SYSWARDEN_FAIL_SERVICE:-}" ]; then
+        printf '%s is stopped\n' "$1"
+        return 7
+    fi
+    printf '%s is started\n' "$1"
+}
+'''
+
+            def run_guard(**overrides: str) -> subprocess.CompletedProcess[str]:
+                calls.write_text("", encoding="utf-8")
+                return subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-eu",
+                        "-c",
+                        package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                        + mocks
+                        + guarded_tail,
+                    ],
+                    env={
+                        **os.environ,
+                        "SYSWARDEN_RC_UPDATE_CALLS": str(calls),
+                        **overrides,
+                    },
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+
+            passed = run_guard()
+            self.assertEqual(passed.returncode, 0, passed.stderr)
+            self.assertEqual(passed.stdout, "")
+            self.assertEqual(passed.stderr, "")
+            self.assertEqual(calls.read_text(encoding="utf-8"), "call\n" * 3)
+
+            for service, predicate, call_count in (
+                ("syswarden-lab-net", "NS31_APK_NET_RUNLEVEL", 1),
+                ("cronie", "NS32_APK_CRON_RUNLEVEL", 2),
+                ("rsyslog", "NS33_APK_RSYSLOG_RUNLEVEL", 3),
+            ):
+                with self.subTest(missing_runlevel=service):
+                    missing = run_guard(SYSWARDEN_OMIT_SERVICE=service)
+                    self.assertEqual(missing.returncode, 1)
+                    self.assertEqual(missing.stdout, "")
+                    self.assertEqual(
+                        calls.read_text(encoding="utf-8"),
+                        "call\n" * call_count,
+                    )
+                    self.assertEqual(
+                        missing.stderr,
+                        namespace_failure_record(predicate, 0, "0", "1"),
+                    )
+
+            failed_update = run_guard(SYSWARDEN_FAIL_RC_UPDATE="1")
+            self.assertEqual(failed_update.returncode, 1)
+            self.assertEqual(failed_update.stdout, "")
+            self.assertEqual(calls.read_text(encoding="utf-8"), "call\n")
+            self.assertEqual(
+                failed_update.stderr,
+                namespace_failure_record(
+                    "NS31_APK_NET_RUNLEVEL", 7, "rc-update denied", "1"
+                ),
+            )
+
+            for service, predicate in (
+                ("syswarden-lab-net", "NS34_APK_NET_ACTIVE"),
+                ("cronie", "NS35_APK_CRON_ACTIVE"),
+                ("rsyslog", "NS36_APK_RSYSLOG_ACTIVE"),
+            ):
+                with self.subTest(failed_service=service):
+                    failed = run_guard(SYSWARDEN_FAIL_SERVICE=service)
+                    self.assertEqual(failed.returncode, 1)
+                    self.assertEqual(failed.stdout, "")
+                    self.assertEqual(
+                        calls.read_text(encoding="utf-8"), "call\n" * 3
+                    )
+                    self.assertEqual(
+                        failed.stderr,
+                        namespace_failure_record(
+                            predicate, 7, f"{service} is stopped", ""
+                        ),
+                    )
 
     def test_container_run_is_networkless_and_mounts_packages_read_only(self) -> None:
         pair = package_lifecycle_lab.PackagePair(
@@ -1857,6 +2625,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
         self.assertNotIn("--gidmap", args)
         self.assertEqual(args[args.index("--platform") + 1], "linux/amd64")
         self.assertIn("--security-opt=no-new-privileges", args)
+        self.assertIn("--memory=1g", args)
+        self.assertIn("--pids-limit=512", args)
         self.assertEqual(
             [value for value in args if value.startswith("--tmpfs=")],
             [
@@ -2280,6 +3050,32 @@ probe
                 self.assertEqual(scenario["status"], "fail")
                 self.assertIn(
                     "namespace/capability isolation is not exact",
+                    scenario["orchestration_error"],
+                )
+
+    def test_inspect_requires_exact_memory_and_pid_limits(self) -> None:
+        spec = package_lifecycle_lab.DEFAULT_PLATFORMS[0]
+        for label, overrides in (
+            ("missing memory", {"inspect_memory": None}),
+            ("unlimited memory", {"inspect_memory": 0}),
+            ("text memory", {"inspect_memory": "1073741824"}),
+            ("float memory", {"inspect_memory": 1_073_741_824.0}),
+            ("missing PID limit", {"inspect_pids_limit": None}),
+            ("unlimited PIDs", {"inspect_pids_limit": 0}),
+            ("text PID limit", {"inspect_pids_limit": "512"}),
+            ("float PID limit", {"inspect_pids_limit": 512.0}),
+        ):
+            with self.subTest(label=label):
+                report = package_lifecycle_lab.run_lab(
+                    self.args(),
+                    runner=FakePodmanRunner(**overrides),
+                    platforms=(spec,),
+                    host_architecture="x86_64",
+                )
+                scenario = report["platforms"][0]["scenarios"][0]
+                self.assertEqual(scenario["status"], "fail")
+                self.assertIn(
+                    "container memory/PID limits are not exact",
                     scenario["orchestration_error"],
                 )
 
@@ -3176,10 +3972,8 @@ probe
         self.assertEqual(sleep.call_count, 29)
 
     def test_namespace_failure_record_is_preserved_in_report(self) -> None:
-        diagnostic = (
-            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
-            + "\tpredicate=NS14_FEDORA_MASKS\trc=0"
-            + "\tactual_hex=6f70657261746f72\texpected_hex=6578616374\n"
+        diagnostic = namespace_failure_record(
+            "NS14_FEDORA_MASKS", 0, "operator", "exact"
         )
         runner = FakePodmanRunner(
             namespace_failures=30,

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -2111,10 +2111,10 @@ openrc() {{
     [ "$#" -eq 1 ] && [ "$1" = --sys ] || return 96
     printf 'PODMAN\n'
 }}
-rc-update() {{
+rc_update() {{
     printf 'syswarden-lab-net | default\ncronie | default\nrsyslog | default\n'
 }}
-rc-service() {{ return 0; }}
+rc_service() {{ return 0; }}
 '''
         base_probe = package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS + mocks
         with tempfile.TemporaryDirectory() as temporary:
@@ -2132,10 +2132,12 @@ rc-service() {{ return 0; }}
                 tail.replace("/proc/1/environ", str(pid1_environment))
                 .replace("/proc/self/cgroup", str(self_cgroup))
                 .replace("/sys/fs/cgroup", str(cgroup_root))
+                .replace("rc-update show -v", "rc_update show -v")
+                .replace("rc-service ", "rc_service ")
             )
             host = subprocess.run(
                 [
-                    "/bin/sh",
+                    shutil.which("dash") or "/bin/sh",
                     "-eu",
                     "-c",
                     base_probe + host_tail,
@@ -2162,6 +2164,8 @@ rc-service() {{ return 0; }}
             tail.replace("/proc/1/environ", alpine_environment)
             .replace("/proc/self/cgroup", alpine_self_cgroup)
             .replace("/sys/fs/cgroup", alpine_cgroup_root)
+            .replace("rc-update show -v", "rc_update show -v")
+            .replace("rc-service ", "rc_service ")
         )
         alpine_probe = (
             f": > {alpine_environment}\n"
@@ -2485,11 +2489,16 @@ rc-service() {{ return 0; }}
                 "syswarden_namespace_expect_status NS36_APK_RSYSLOG_ACTIVE"
             )
         )
-        guarded_tail = "\n".join(runtime_lines[start : end + 1]) + "\n"
+        guarded_tail = (
+            "\n".join(runtime_lines[start : end + 1])
+            .replace("rc-update show -v", "rc_update show -v")
+            .replace("rc-service ", "rc_service ")
+            + "\n"
+        )
 
         with tempfile.TemporaryDirectory() as temporary:
             calls = Path(temporary) / "rc-update.calls"
-            mocks = r'''rc-update() {
+            mocks = r'''rc_update() {
     [ "$#" -eq 2 ] && [ "$1" = show ] && [ "$2" = -v ] || return 96
     printf 'call\n' >> "${SYSWARDEN_RC_UPDATE_CALLS}"
     if [ "${SYSWARDEN_FAIL_RC_UPDATE:-}" = 1 ]; then
@@ -2502,7 +2511,7 @@ rc-service() {{ return 0; }}
         fi
     done
 }
-rc-service() {
+rc_service() {
     [ "$#" -eq 2 ] && [ "$2" = status ] || return 96
     if [ "$1" = "${SYSWARDEN_FAIL_SERVICE:-}" ]; then
         printf '%s is stopped\n' "$1"
@@ -2516,7 +2525,7 @@ rc-service() {
                 calls.write_text("", encoding="utf-8")
                 return subprocess.run(
                     [
-                        "/bin/sh",
+                        shutil.which("dash") or "/bin/sh",
                         "-eu",
                         "-c",
                         package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                7,
+                8,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 6)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 7)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 7)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 8)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 14,
-                "scripts/ci/release_gate_test.py": 14,
+                ".github/workflows/release-manager.yml": 16,
+                "scripts/ci/release_gate_test.py": 16,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -879,6 +879,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         pinned_contracts = (
             (
+                'if [[ "${v4032_stabilization_parent_sha}" != '
+                '"41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then'
+            ),
+            (
                 'if [[ "${v4032_local_parent_sha}" != '
                 '"93bb85a657d8f8927cd6617c4105653732c59114" ]]; then'
             ),
@@ -913,6 +917,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        stabilization_subject_contract = (
+            "v4032_stabilization_expected_subject='Qualification : stabilize "
+            "v4.03.2 ARM64 lifecycle evidence (#102)'"
+        )
         local_subject_contract = (
             "v4032_local_expected_subject='Qualification : repair v4.03.2 "
             "ARM64 lab and config root handling (#101)'"
@@ -942,6 +950,16 @@ class ReleaseGateTests(unittest.TestCase):
             ".github/workflows/release-qualification.yml",
             "scripts/ci/release_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
+        )
+        stabilization_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/package_lifecycle_lab.py",
+            "scripts/ci/package_lifecycle_lab_test.py",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
+            "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+            "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
         )
         local_paths = (
             ".github/workflows/release-manager.yml",
@@ -990,6 +1008,7 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(stabilization_subject_contract), 1)
             self.assertEqual(block.count(local_subject_contract), 1)
             self.assertEqual(block.count(runc_subject_contract), 1)
             self.assertEqual(block.count(runtime_subject_contract), 1)
@@ -999,18 +1018,100 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_stabilization_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_stabilization_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_stabilization_head_line[@]} != 2"), 1
+            )
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 ARM64 lifecycle stabilization "
+                    "diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    "# END exact v4.03.2 ARM64 lifecycle stabilization "
+                    "diff contract"
+                ),
+                1,
+            )
+            stabilization_diff = block.split(
+                "# BEGIN exact v4.03.2 ARM64 lifecycle stabilization "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 ARM64 lifecycle stabilization diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                stabilization_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(
+                stabilization_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+            )
+            self.assertEqual(
+                stabilization_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                stabilization_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                stabilization_diff.count(
+                    "${#actual_v4032_stabilization_diff[@]} != "
+                    "${#expected_v4032_stabilization_diff[@]}"
+                ),
+                1,
+            )
+            for path in stabilization_paths:
+                self.assertEqual(stabilization_diff.count(f'"{path}"'), 2)
+                self.assertEqual(stabilization_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_local_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_local_parent_sha="$(git rev-parse '
+                    '"${v4032_local_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_local_subject="$(git log -1 --format=%s '
+                    '"${v4032_local_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_local_subject}" != '
                     '"${v4032_local_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
-                block.count('v4032_local_parent_sha="$(git rev-parse HEAD^)"'),
-                1,
-            )
-            self.assertEqual(
                 block.count(
-                    'v4032_local_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    'v4032_local_head_line <<< "$(git rev-list --parents -n 1 '
+                    '"${v4032_local_ref}")"'
                 ),
                 1,
             )
@@ -1036,11 +1137,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 local_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_local_ref}^" "${v4032_local_ref}"'
                 ),
                 1,
             )
-            self.assertEqual(local_diff.count("for tree_ref in HEAD^ HEAD; do"), 1)
+            self.assertEqual(
+                local_diff.count(
+                    'for tree_ref in "${v4032_local_ref}^" '
+                    '"${v4032_local_ref}"; do'
+                ),
+                1,
+            )
             self.assertEqual(local_diff.count('"${tree_mode}" != "100644"'), 1)
             self.assertEqual(local_diff.count('"${tree_type}" != "blob"'), 1)
             self.assertEqual(
@@ -1053,7 +1161,9 @@ class ReleaseGateTests(unittest.TestCase):
             for path in local_paths:
                 self.assertEqual(local_diff.count(f'"{path}"'), 2)
                 self.assertEqual(local_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_runc_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count('v4032_runc_ref="${v4032_local_ref}^"\n'), 1
+            )
             self.assertEqual(
                 block.count(
                     'v4032_runc_parent_sha="$(git rev-parse '
@@ -1438,7 +1548,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                5,
+                6,
             )
             self.assertEqual(
                 block.count(
@@ -1457,12 +1567,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                6,
+                7,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 6)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 7)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1480,6 +1590,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in runtime_paths else 0
                 expected_count += 2 if path in runc_paths else 0
                 expected_count += 2 if path in local_paths else 0
+                expected_count += 2 if path in stabilization_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1
@@ -1488,6 +1599,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_status_count += 1 if path in runtime_paths else 0
                 expected_status_count += 1 if path in runc_paths else 0
                 expected_status_count += 1 if path in local_paths else 0
+                expected_status_count += 1 if path in stabilization_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1619,6 +1731,30 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_stabilization_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 ARM64 lifecycle stabilization diff contract\n"
+        )
+        end = "# END exact v4.03.2 ARM64 lifecycle stabilization diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_stabilization_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_stabilization_expected_subject="
+        end = (
+            'read -r -a v4032_stabilization_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_local_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -1626,20 +1762,31 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 final qualification repair diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_local_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_local_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_local_expected_subject="
+        subject_assignment = (
+            'v4032_local_subject="$(git log -1 --format=%s '
+            '"${v4032_local_ref}")"'
+        )
         end = (
             'read -r -a v4032_local_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 "${v4032_local_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_local_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_runc_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -2031,6 +2178,57 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_stabilization_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_stabilization_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#101)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#103)",
+                    False,
+                ),
+                "wrong verb": (
+                    "Qualification : repair v4.03.2 ARM64 lifecycle evidence (#102)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_stabilization_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_stabilization_diff_script(),
+            "v4032-stabilization-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/package_lifecycle_lab.py",
+                "scripts/ci/package_lifecycle_lab_test.py",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
+            ),
+        )
+
     def test_release_manager_v4032_local_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -2250,9 +2448,36 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "stabilization parent resolution": workflow.replace(
+                'v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_stabilization_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact stabilization parent": workflow.replace(
+                "41d7a7da2895f5d3949cc63f3e45308c03f7f93a",
+                "51d7a7da2895f5d3949cc63f3e45308c03f7f93a",
+            ),
+            "stabilization canonical subject": workflow.replace(
+                "Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)",
+                "Qualification : arbitrary v4.03.2 stabilization (#102)",
+            ),
+            "stabilization subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "stabilization linear head": workflow.replace(
+                'v4032_stabilization_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_stabilization_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "local reference": workflow.replace(
+                "v4032_local_ref=HEAD^", "v4032_local_ref=HEAD^^"
+            ),
             "local parent resolution": workflow.replace(
-                'v4032_local_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_local_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_local_parent_sha="$(git rev-parse '
+                '"${v4032_local_ref}^")"',
+                'v4032_local_parent_sha="$(git rev-parse '
+                '"${v4032_local_ref}^^")"',
             ),
             "exact local parent": workflow.replace(
                 "93bb85a657d8f8927cd6617c4105653732c59114",
@@ -2263,17 +2488,18 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : arbitrary v4.03.2 final repair (#101)",
             ),
             "local subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_local_subject="$(git log -1 --format=%s '
+                '"${v4032_local_ref}")"',
+                'v4032_local_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "local linear head": workflow.replace(
-                'v4032_local_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
-                'v4032_local_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_local_head_line <<< "$(git rev-list --parents -n 1 '
+                '"${v4032_local_ref}")"',
+                'v4032_local_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
             ),
             "runc reference": workflow.replace(
-                "v4032_runc_ref=HEAD^", "v4032_runc_ref=HEAD^^"
+                'v4032_runc_ref="${v4032_local_ref}^"',
+                'v4032_runc_ref="${v4032_local_ref}^^"',
             ),
             "runc parent resolution": workflow.replace(
                 'v4032_runc_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -1092,6 +1092,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--machine="${user_name}@"',
             '--property=\'Type=exec\'',
             "--property='Delegate=cpu io memory pids'",
+            "--property='MemoryMax=1G'",
+            "--property='TasksMax=512'",
             "--property='UMask=0077'",
             '--setenv="CONTAINERS_CONF=${containers_conf}"',
             "--setenv='CONTAINERS_CONF_OVERRIDE='",
@@ -1168,6 +1170,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, script)
         self.assertEqual(script.count("sudo -n systemd-run"), 1)
+        self.assertEqual(script.count("--property='MemoryMax=1G'"), 1)
+        self.assertEqual(script.count("--property='TasksMax=512'"), 1)
         self.assertEqual(script.count("scripts/ci/package_lifecycle_lab.py"), 1)
         self.assertEqual(script.count("'conmon_path=[\"/usr/local/lib/podman/conmon\"]'"), 1)
         self.assertEqual(script.count("'remote=false'"), 1)
@@ -1219,6 +1223,23 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "'exec /usr/local/bin/podman --remote=false \"$@\"'"
         )
         systemd_run = script.index("sudo -n systemd-run")
+        systemd_command = script.index(
+            "/usr/bin/bash --noprofile --norc -e -o pipefail -c",
+            systemd_run,
+        )
+        transient_properties = re.findall(
+            r"--property='([^']+)'", script[systemd_run:systemd_command]
+        )
+        self.assertEqual(
+            transient_properties,
+            [
+                "Type=exec",
+                "Delegate=cpu io memory pids",
+                "MemoryMax=1G",
+                "TasksMax=512",
+                "UMask=0077",
+            ],
+        )
         configuration_guard = script.index(
             "native ARM64 Podman configuration isolation is incomplete"
         )

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
@@ -3,14 +3,107 @@
 package integration
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"syswarden-cli/config"
 	"syswarden-cli/pkg/system"
+	"time"
 )
+
+const (
+	managedServiceOutputLimit     = 4096
+	managedServiceEvidenceLimit   = 512
+	managedServiceDiagnosticLimit = 4096
+	managedServiceCommandTimeout  = 30 * time.Second
+	trustedPathSymlinkLimit       = 40
+
+	trustedCommandPath         = "/usr/sbin:/usr/bin:/sbin:/bin"
+	trustedSystemctlPath       = "/usr/bin/systemctl"
+	trustedJournalctlPath      = "/usr/bin/journalctl"
+	trustedRsyslogdPath        = "/usr/sbin/rsyslogd"
+	trustedOpenRCServicePath   = "/sbin/rc-service"
+	trustedCheckmodulePath     = "/usr/bin/checkmodule"
+	trustedSemodulePackagePath = "/usr/bin/semodule_package"
+	trustedSemodulePath        = "/usr/sbin/semodule"
+	selinuxRuntimeEnforcement  = "/sys/fs/selinux/enforce"
+)
+
+type managedServiceRunner func(string, ...string) ([]byte, error)
+type managedServiceExecutor func(context.Context, string, ...string) ([]byte, error)
+type trustedExecutableValidator func(string) error
+
+type trustedPathMetadata struct {
+	mode os.FileMode
+	uid  uint32
+}
+
+type trustedPathLstat func(string) (trustedPathMetadata, error)
+type trustedPathReadlink func(string) (string, error)
+
+type selinuxRuntimeState uint8
+
+const (
+	selinuxRuntimeDisabled selinuxRuntimeState = iota
+	selinuxRuntimeActive
+	selinuxRuntimeIndeterminate
+)
+
+var trustedSELinuxPolicyTools = [...]string{
+	trustedCheckmodulePath,
+	trustedSemodulePackagePath,
+	trustedSemodulePath,
+}
+
+type managedServiceDiagnosticError struct {
+	message string
+	cause   error
+}
+
+func (diagnostic *managedServiceDiagnosticError) Error() string { return diagnostic.message }
+func (diagnostic *managedServiceDiagnosticError) Unwrap() error { return diagnostic.cause }
+
+type boundedCombinedOutput struct {
+	buffer    bytes.Buffer
+	truncated bool
+}
+
+func (output *boundedCombinedOutput) Write(data []byte) (int, error) {
+	written := len(data)
+	remaining := managedServiceOutputLimit - output.buffer.Len()
+	if remaining > 0 {
+		if len(data) > remaining {
+			data = data[:remaining]
+		}
+		_, _ = output.buffer.Write(data)
+	}
+	if written > remaining {
+		output.truncated = true
+	}
+	return written, nil
+}
+
+func (output *boundedCombinedOutput) Bytes() []byte {
+	result := append([]byte(nil), output.buffer.Bytes()...)
+	if !output.truncated {
+		return result
+	}
+	marker := []byte("\n[output truncated]")
+	if len(marker) >= managedServiceOutputLimit {
+		return append([]byte(nil), marker[:managedServiceOutputLimit]...)
+	}
+	if len(result) > managedServiceOutputLimit-len(marker) {
+		result = result[:managedServiceOutputLimit-len(marker)]
+	}
+	return append(result, marker...)
+}
 
 const rsyslogSELinuxPolicy = `module syswarden_rsyslog 1.0;
 require {
@@ -95,33 +188,56 @@ func SetupWAFLogForwarder() error {
 		fmt.Println("[WARN] Configured ModSecurity log patterns have no real regular-file match; custom rsyslog input was omitted.")
 	}
 
-	_ = os.MkdirAll("/etc/rsyslog.d", 0750)
-	if err := os.WriteFile(confPath, []byte(rsyslogConf), 0600); err != nil {
-		return fmt.Errorf("failed to write WAF bridge config: %w", err)
+	selinuxState, selinuxStateErr := detectSELinuxRuntime()
+	configureSELinuxPolicy, err := shouldConfigureRsyslogSELinuxPolicy(
+		selinuxState,
+		selinuxStateErr,
+		validateTrustedExecutable,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare Rsyslog SELinux policy before writing WAF bridge config: %w", err)
 	}
-	// SELinux Hardening (RHEL/Alma) - Compile and install policy to allow rsyslog -> UDS communication
-	if _, err := exec.LookPath("checkmodule"); err == nil {
+	if selinuxState == selinuxRuntimeIndeterminate {
+		fmt.Println("[WARN] SELinux runtime state is indeterminate; applying the Rsyslog policy defensively.")
+	}
+
+	// SELinux Hardening (RHEL/Alma) - Compile and install policy to allow rsyslog -> UDS communication.
+	if configureSELinuxPolicy {
 		fmt.Println("[INFO] Compiling and injecting SELinux policy for Rsyslog UDS bridge...")
 		if err := withPrivateSELinuxPolicyWorkspace("", func(workspace string) error {
-			compile := exec.Command("checkmodule", "-M", "-m", "-o", "syswarden_rsyslog.mod", "syswarden_rsyslog.te")
-			compile.Dir = workspace
-			if err := compile.Run(); err != nil {
-				return fmt.Errorf("compile SELinux policy: %w", err)
+			if err := runSELinuxPolicyCommand(
+				workspace,
+				"compile SELinux policy",
+				trustedCheckmodulePath,
+				"-M", "-m", "-o", "syswarden_rsyslog.mod", "syswarden_rsyslog.te",
+			); err != nil {
+				return err
 			}
-			pack := exec.Command("semodule_package", "-o", "syswarden_rsyslog.pp", "-m", "syswarden_rsyslog.mod")
-			pack.Dir = workspace
-			if err := pack.Run(); err != nil {
-				return fmt.Errorf("package SELinux policy: %w", err)
+			if err := runSELinuxPolicyCommand(
+				workspace,
+				"package SELinux policy",
+				trustedSemodulePackagePath,
+				"-o", "syswarden_rsyslog.pp", "-m", "syswarden_rsyslog.mod",
+			); err != nil {
+				return err
 			}
-			install := exec.Command("semodule", "-i", "syswarden_rsyslog.pp")
-			install.Dir = workspace
-			if err := install.Run(); err != nil {
-				return fmt.Errorf("install SELinux policy: %w", err)
+			if err := runSELinuxPolicyCommand(
+				workspace,
+				"install SELinux policy",
+				trustedSemodulePath,
+				"-i", "syswarden_rsyslog.pp",
+			); err != nil {
+				return err
 			}
 			return nil
 		}); err != nil {
-			fmt.Printf("[WARN] Failed to install Rsyslog SELinux policy: %v\n", err)
+			return fmt.Errorf("install Rsyslog SELinux policy before writing WAF bridge config: %w", err)
 		}
+	}
+
+	_ = os.MkdirAll("/etc/rsyslog.d", 0750)
+	if err := os.WriteFile(confPath, []byte(rsyslogConf), 0600); err != nil {
+		return fmt.Errorf("failed to write WAF bridge config: %w", err)
 	}
 
 	if err := restartManagedService("rsyslog"); err != nil {
@@ -137,9 +253,233 @@ func restartManagedService(service string) error {
 		service,
 		system.ServiceManagerRuntimeState,
 		system.IsAlpine,
-		func(name string, args ...string) error {
-			return exec.Command(name, args...).Run() // #nosec G204 -- callers pass fixed product integration service constants
+		runManagedServiceCommand,
+	)
+}
+
+func runManagedServiceCommand(name string, args ...string) ([]byte, error) {
+	return runManagedServiceCommandUsing(
+		context.Background(),
+		managedServiceCommandTimeout,
+		validateTrustedExecutable,
+		executeManagedServiceCommand,
+		name,
+		args...,
+	)
+}
+
+func runManagedServiceCommandUsing(
+	parent context.Context,
+	timeout time.Duration,
+	validate trustedExecutableValidator,
+	execute managedServiceExecutor,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	if !filepath.IsAbs(name) {
+		return nil, fmt.Errorf("refusing non-absolute privileged command path %q", name)
+	}
+	if err := validate(name); err != nil {
+		return nil, fmt.Errorf("validate trusted executable %s: %w", name, err)
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	output, err := execute(ctx, name, args...)
+	if contextErr := ctx.Err(); contextErr != nil && !errors.Is(err, contextErr) {
+		err = errors.Join(err, contextErr)
+	}
+	return output, err
+}
+
+func executeManagedServiceCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return executeManagedServiceCommandInDirectory(ctx, "", name, args...)
+}
+
+func executeManagedServiceCommandInDirectory(
+	ctx context.Context,
+	directory string,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	command := newTrustedCommand(ctx, name, args...)
+	command.Dir = directory
+	var output boundedCombinedOutput
+	command.Stdout = &output
+	command.Stderr = &output
+	err := command.Run()
+	return output.Bytes(), err
+}
+
+func newTrustedCommand(ctx context.Context, name string, args ...string) *exec.Cmd {
+	command := exec.CommandContext(ctx, name, args...) // #nosec G204 -- name is an absolute, validated product constant
+	command.Env = []string{
+		"LANG=C",
+		"LC_ALL=C",
+		"PATH=" + trustedCommandPath,
+	}
+	return command
+}
+
+func validateTrustedExecutable(path string) error {
+	return validateTrustedExecutableUsing(path, lstatTrustedPath, os.Readlink)
+}
+
+func lstatTrustedPath(path string) (trustedPathMetadata, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return trustedPathMetadata{}, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return trustedPathMetadata{}, fmt.Errorf("unsupported Linux file metadata")
+	}
+	return trustedPathMetadata{mode: info.Mode(), uid: stat.Uid}, nil
+}
+
+func validateTrustedExecutableUsing(
+	path string,
+	lstat trustedPathLstat,
+	readlink trustedPathReadlink,
+) error {
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("path is not absolute")
+	}
+	if filepath.Clean(path) != path {
+		return fmt.Errorf("path is not canonical")
+	}
+
+	// This pre-exec check relies on immutable, root-owned ancestors to prevent
+	// non-root replacement between validation and CommandContext execution.
+	remaining := trustedPathComponents(path)
+	current := string(os.PathSeparator)
+	symlinks := 0
+	for {
+		metadata, err := lstat(current)
+		if err != nil {
+			return fmt.Errorf("lstat trusted path component %s: %w", current, err)
+		}
+		if metadata.uid != 0 {
+			return fmt.Errorf("trusted path component %s is not root-owned", current)
+		}
+		if metadata.mode&os.ModeSymlink != 0 {
+			// Linux ignores symlink permission bits, so root-owned 0777 usrmerge
+			// links are safe when their checked parent directories are immutable.
+			symlinks++
+			if symlinks > trustedPathSymlinkLimit {
+				return fmt.Errorf("trusted path exceeds %d symbolic links", trustedPathSymlinkLimit)
+			}
+			target, err := readlink(current)
+			if err != nil {
+				return fmt.Errorf("read trusted symbolic link %s: %w", current, err)
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(current), target)
+			}
+			if len(remaining) > 0 {
+				target = filepath.Join(target, filepath.Join(remaining...))
+			}
+			remaining = trustedPathComponents(filepath.Clean(target))
+			current = string(os.PathSeparator)
+			continue
+		}
+		if metadata.mode.Perm()&0022 != 0 {
+			return fmt.Errorf("trusted path component %s is group/world writable", current)
+		}
+		if len(remaining) == 0 {
+			if !metadata.mode.IsRegular() {
+				return fmt.Errorf("trusted executable %s is not a regular file", current)
+			}
+			if metadata.mode.Perm()&0111 == 0 {
+				return fmt.Errorf("trusted executable %s is not executable", current)
+			}
+			return nil
+		}
+		if !metadata.mode.IsDir() {
+			return fmt.Errorf("trusted path ancestor %s is not a directory", current)
+		}
+		current = filepath.Join(current, remaining[0])
+		remaining = remaining[1:]
+	}
+}
+
+func trustedPathComponents(path string) []string {
+	path = strings.TrimPrefix(path, string(os.PathSeparator))
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, string(os.PathSeparator))
+}
+
+func detectSELinuxRuntime() (selinuxRuntimeState, error) {
+	return detectSELinuxRuntimeUsing(os.ReadFile)
+}
+
+func detectSELinuxRuntimeUsing(readFile func(string) ([]byte, error)) (selinuxRuntimeState, error) {
+	value, err := readFile(selinuxRuntimeEnforcement)
+	if errors.Is(err, os.ErrNotExist) {
+		return selinuxRuntimeDisabled, nil
+	}
+	if err != nil {
+		return selinuxRuntimeIndeterminate, fmt.Errorf("read SELinux enforcement state: %w", err)
+	}
+	switch strings.TrimSpace(string(value)) {
+	case "0", "1":
+		return selinuxRuntimeActive, nil
+	default:
+		return selinuxRuntimeIndeterminate, fmt.Errorf("unexpected SELinux enforcement state")
+	}
+}
+
+func shouldConfigureRsyslogSELinuxPolicy(
+	state selinuxRuntimeState,
+	detectionErr error,
+	validate trustedExecutableValidator,
+) (bool, error) {
+	if state == selinuxRuntimeDisabled {
+		return false, nil
+	}
+	if state != selinuxRuntimeActive && state != selinuxRuntimeIndeterminate {
+		return false, fmt.Errorf("unrecognized SELinux runtime state %d", state)
+	}
+	var causes []error
+	if state == selinuxRuntimeIndeterminate && detectionErr != nil {
+		causes = append(causes, detectionErr)
+	}
+	missingTool := false
+	for _, tool := range trustedSELinuxPolicyTools {
+		if err := validate(tool); err != nil {
+			missingTool = true
+			causes = append(causes, fmt.Errorf("required SELinux policy tool %s: %w", tool, err))
+		}
+	}
+	if missingTool {
+		return false, errors.Join(causes...)
+	}
+	return true, nil
+}
+
+func runSELinuxPolicyCommand(
+	directory string,
+	operation string,
+	name string,
+	args ...string,
+) error {
+	output, err := runManagedServiceCommandUsing(
+		context.Background(),
+		managedServiceCommandTimeout,
+		validateTrustedExecutable,
+		func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return executeManagedServiceCommandInDirectory(ctx, directory, name, args...)
 		},
+		name,
+		args...,
+	)
+	if err == nil {
+		return nil
+	}
+	return newManagedServiceDiagnosticError(
+		fmt.Sprintf("%s: %s", operation, managedServiceEvidence(err, output)),
+		err,
 	)
 }
 
@@ -147,7 +487,7 @@ func restartManagedServiceUsing(
 	service string,
 	classify func() (string, error),
 	isAlpine func() bool,
-	run func(string, ...string) error,
+	run managedServiceRunner,
 ) error {
 	state, err := classify()
 	if err != nil {
@@ -165,35 +505,122 @@ func restartManagedServiceUsing(
 				// circular OpenRC wait. Rsyslog on Alpine does not apply new rules
 				// after its nominal reload action, so restart it without traversing
 				// the dependency graph after validating the complete configuration.
-				if err := run("/usr/sbin/rsyslogd", "-N1", "-f", "/etc/rsyslog.conf"); err != nil {
+				if _, err := run(trustedRsyslogdPath, "-N1", "-f", "/etc/rsyslog.conf"); err != nil {
 					return fmt.Errorf("validate rsyslog configuration before OpenRC restart: %w", err)
 				}
-				if err := run("/sbin/rc-service", "--ifnotstarted", service, "start"); err != nil {
+				if _, err := run(trustedOpenRCServicePath, "--ifnotstarted", service, "start"); err != nil {
 					return fmt.Errorf("conditionally start OpenRC service %s with dependencies: %w", service, err)
 				}
-				if err := run("/sbin/rc-service", service, "status"); err != nil {
+				if _, err := run(trustedOpenRCServicePath, service, "status"); err != nil {
 					return fmt.Errorf("attest active OpenRC service %s before dependency-bypassing restart: %w", service, err)
 				}
-				if err := run("/sbin/rc-service", "--nodeps", service, "restart"); err != nil {
+				if _, err := run(trustedOpenRCServicePath, "--nodeps", service, "restart"); err != nil {
 					return fmt.Errorf("restart OpenRC service %s without dependency traversal: %w", service, err)
 				}
-				if err := run("/sbin/rc-service", service, "status"); err != nil {
+				if _, err := run(trustedOpenRCServicePath, service, "status"); err != nil {
 					return fmt.Errorf("attest restarted OpenRC service %s: %w", service, err)
 				}
 				return nil
 			}
-			if err := run("/sbin/rc-service", service, "restart"); err != nil {
+			if _, err := run(trustedOpenRCServicePath, service, "restart"); err != nil {
 				return fmt.Errorf("restart OpenRC service %s: %w", service, err)
 			}
 			return nil
 		}
-		if err := run("systemctl", "restart", service); err != nil {
+		if service == "rsyslog" {
+			return restartSystemdRsyslogUsing(run)
+		}
+		if _, err := run(trustedSystemctlPath, "restart", service); err != nil {
 			return fmt.Errorf("restart systemd service %s: %w", service, err)
 		}
 		return nil
 	default:
 		return fmt.Errorf("refusing unrecognized service-manager runtime state %q", state)
 	}
+}
+
+func restartSystemdRsyslogUsing(run managedServiceRunner) error {
+	validationOutput, validationErr := run(
+		trustedRsyslogdPath, "-N1", "-f", "/etc/rsyslog.conf",
+	)
+	if validationErr != nil {
+		return newManagedServiceDiagnosticError(
+			fmt.Sprintf(
+				"validate complete rsyslog configuration before systemd restart: %s",
+				managedServiceEvidence(validationErr, validationOutput),
+			),
+			validationErr,
+		)
+	}
+
+	firstOutput, firstErr := run(trustedSystemctlPath, "restart", "rsyslog")
+	firstActiveOutput, firstActiveErr := run(
+		trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
+	)
+	if firstErr == nil && firstActiveErr == nil {
+		return nil
+	}
+
+	resetOutput, resetErr := run(trustedSystemctlPath, "reset-failed", "rsyslog")
+	retryOutput, retryErr := run(trustedSystemctlPath, "restart", "rsyslog")
+	retryActiveOutput, retryActiveErr := run(
+		trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
+	)
+	if retryErr == nil && retryActiveErr == nil {
+		fmt.Println("[WARN] Initial rsyslog restart failed; recovered after one bounded retry.")
+		return nil
+	}
+
+	journalOutput, journalErr := run(
+		trustedJournalctlPath, "--no-pager", "--quiet", "--boot", "--unit", "rsyslog.service", "--lines=40",
+	)
+	return newManagedServiceDiagnosticError(
+		fmt.Sprintf(
+			"restart systemd service rsyslog failed after one bounded retry: first_restart=%s; first_active=%s; reset_failed=%s; retry_restart=%s; retry_active=%s; journal=%s",
+			managedServiceEvidence(firstErr, firstOutput),
+			managedServiceEvidence(firstActiveErr, firstActiveOutput),
+			managedServiceEvidence(resetErr, resetOutput),
+			managedServiceEvidence(retryErr, retryOutput),
+			managedServiceEvidence(retryActiveErr, retryActiveOutput),
+			managedServiceEvidence(journalErr, journalOutput),
+		),
+		firstErr,
+		firstActiveErr,
+		resetErr,
+		retryErr,
+		retryActiveErr,
+		journalErr,
+	)
+}
+
+func managedServiceEvidence(err error, output []byte) string {
+	errorText := ""
+	if err != nil {
+		errorText = err.Error()
+	}
+	return boundedDiagnosticText(fmt.Sprintf(
+		"error=%s output=%s",
+		strconv.QuoteToASCII(errorText),
+		strconv.QuoteToASCII(string(output)),
+	), managedServiceEvidenceLimit, "[evidence truncated]")
+}
+
+func newManagedServiceDiagnosticError(message string, causes ...error) error {
+	return &managedServiceDiagnosticError{
+		message: boundedDiagnosticText(message, managedServiceDiagnosticLimit, "[diagnostic truncated]"),
+		cause:   errors.Join(causes...),
+	}
+}
+
+func boundedDiagnosticText(value string, limit int, marker string) string {
+	if len(value) <= limit {
+		return value
+	}
+	marker = "\n" + marker
+	if len(marker) >= limit {
+		return marker[:limit]
+	}
+	return value[:limit-len(marker)] + marker
 }
 
 func withPrivateSELinuxPolicyWorkspace(parent string, action func(workspace string) error) error {

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
@@ -3,11 +3,14 @@
 package integration
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPrivateSELinuxPolicyWorkspaceUsesPrivateUniqueDirectory(t *testing.T) {
@@ -65,15 +68,360 @@ func TestPrivateSELinuxPolicyWorkspaceCleansUpAfterFailure(t *testing.T) {
 	}
 }
 
+func TestBoundedCombinedOutputRetainsAVisibleHardLimit(t *testing.T) {
+	var output boundedCombinedOutput
+	payload := []byte(strings.Repeat("x", managedServiceOutputLimit*2))
+	if written, err := output.Write(payload); err != nil || written != len(payload) {
+		t.Fatalf("Write() = (%d, %v), want (%d, nil)", written, err, len(payload))
+	}
+	result := output.Bytes()
+	if len(result) != managedServiceOutputLimit {
+		t.Fatalf("bounded output size = %d, want %d", len(result), managedServiceOutputLimit)
+	}
+	if !strings.HasSuffix(string(result), "\n[output truncated]") {
+		t.Fatalf("bounded output lacks truncation marker: %q", result[len(result)-32:])
+	}
+}
+
+type trustedPathTestEntry struct {
+	metadata trustedPathMetadata
+	target   string
+}
+
+func validateTrustedTestPath(path string, entries map[string]trustedPathTestEntry) error {
+	return validateTrustedExecutableUsing(
+		path,
+		func(path string) (trustedPathMetadata, error) {
+			entry, ok := entries[path]
+			if !ok {
+				return trustedPathMetadata{}, os.ErrNotExist
+			}
+			return entry.metadata, nil
+		},
+		func(path string) (string, error) {
+			entry, ok := entries[path]
+			if !ok || entry.metadata.mode&os.ModeSymlink == 0 {
+				return "", os.ErrInvalid
+			}
+			return entry.target, nil
+		},
+	)
+}
+
+func secureDirectTrustedPath() map[string]trustedPathTestEntry {
+	return map[string]trustedPathTestEntry{
+		"/":             {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/usr":          {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/usr/bin":      {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/usr/bin/tool": {metadata: trustedPathMetadata{uid: 0, mode: 0755}},
+	}
+}
+
+func secureUsrmergeTrustedPath() map[string]trustedPathTestEntry {
+	return map[string]trustedPathTestEntry{
+		"/":             {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/sbin":         {metadata: trustedPathMetadata{uid: 0, mode: os.ModeSymlink | 0777}, target: "usr/sbin"},
+		"/usr":          {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/usr/sbin":     {metadata: trustedPathMetadata{uid: 0, mode: os.ModeSymlink | 0777}, target: "bin"},
+		"/usr/bin":      {metadata: trustedPathMetadata{uid: 0, mode: os.ModeDir | 0755}},
+		"/usr/bin/tool": {metadata: trustedPathMetadata{uid: 0, mode: 0755}},
+	}
+}
+
+func TestValidateTrustedExecutableRequiresRootOwnedImmutableMetadata(t *testing.T) {
+	if err := validateTrustedTestPath("/usr/bin/tool", secureDirectTrustedPath()); err != nil {
+		t.Fatalf("secure direct executable rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		edit func(map[string]trustedPathTestEntry)
+		want string
+	}{
+		{
+			name: "non-root owner",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.uid = 1000
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "not root-owned",
+		},
+		{
+			name: "0020 group-writable executable",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.mode |= 0020
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "group/world writable",
+		},
+		{
+			name: "0002 world-writable ancestor",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin"]
+				entry.metadata.mode |= 0002
+				entries["/usr/bin"] = entry
+			},
+			want: "group/world writable",
+		},
+		{
+			name: "non-regular executable",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.mode = os.ModeDir | 0755
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "not a regular file",
+		},
+		{
+			name: "non-executable regular file",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.mode = 0644
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "not executable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries := secureDirectTrustedPath()
+			test.edit(entries)
+			if err := validateTrustedTestPath("/usr/bin/tool", entries); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("metadata validation error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateTrustedExecutableAllowsSecureUsrmergeAndRejectsUnsafeTargets(t *testing.T) {
+	if err := validateTrustedTestPath("/sbin/tool", secureUsrmergeTrustedPath()); err != nil {
+		t.Fatalf("secure root-owned usrmerge chain rejected: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		edit func(map[string]trustedPathTestEntry)
+		want string
+	}{
+		{
+			name: "non-root symlink",
+			path: "/sbin",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/sbin"]
+				entry.metadata.uid = 1000
+				entries["/sbin"] = entry
+			},
+			want: "not root-owned",
+		},
+		{
+			name: "non-root symlink target",
+			path: "/usr/bin/tool",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.uid = 1000
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "not root-owned",
+		},
+		{
+			name: "mutable symlink target",
+			path: "/usr/bin/tool",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin/tool"]
+				entry.metadata.mode |= 0020
+				entries["/usr/bin/tool"] = entry
+			},
+			want: "group/world writable",
+		},
+		{
+			name: "mutable resolved ancestor",
+			path: "/usr/bin",
+			edit: func(entries map[string]trustedPathTestEntry) {
+				entry := entries["/usr/bin"]
+				entry.metadata.mode |= 0002
+				entries["/usr/bin"] = entry
+			},
+			want: "group/world writable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries := secureUsrmergeTrustedPath()
+			test.edit(entries)
+			err := validateTrustedTestPath("/sbin/tool", entries)
+			if err == nil || !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), test.path) {
+				t.Fatalf("usrmerge validation error = %v, want %q at %s", err, test.want, test.path)
+			}
+		})
+	}
+}
+
+func TestDetectSELinuxRuntimeDistinguishesDisabledActiveAndIndeterminate(t *testing.T) {
+	readFailure := errors.New("synthetic SELinux read failure")
+	tests := []struct {
+		name      string
+		value     string
+		readErr   error
+		wantState selinuxRuntimeState
+		wantErr   error
+	}{
+		{name: "missing enforcement file is disabled", readErr: os.ErrNotExist, wantState: selinuxRuntimeDisabled},
+		{name: "permissive runtime is active", value: "0\n", wantState: selinuxRuntimeActive},
+		{name: "enforcing runtime is active", value: "1\n", wantState: selinuxRuntimeActive},
+		{name: "read failure is indeterminate", readErr: readFailure, wantState: selinuxRuntimeIndeterminate, wantErr: readFailure},
+		{name: "unexpected content is indeterminate", value: "unknown", wantState: selinuxRuntimeIndeterminate},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state, err := detectSELinuxRuntimeUsing(func(path string) ([]byte, error) {
+				if path != selinuxRuntimeEnforcement {
+					t.Fatalf("SELinux probe path = %q, want %q", path, selinuxRuntimeEnforcement)
+				}
+				return []byte(test.value), test.readErr
+			})
+			if state != test.wantState {
+				t.Fatalf("SELinux state = %d, want %d", state, test.wantState)
+			}
+			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+				t.Fatalf("SELinux detection error = %v, want wrapped %v", err, test.wantErr)
+			}
+			if test.wantState == selinuxRuntimeIndeterminate && err == nil {
+				t.Fatal("indeterminate SELinux state lacks an error")
+			}
+			if test.wantState != selinuxRuntimeIndeterminate && err != nil {
+				t.Fatalf("determinate SELinux state error = %v", err)
+			}
+		})
+	}
+}
+
+func TestRsyslogSELinuxPolicyGateFailsClosedForEveryMissingTool(t *testing.T) {
+	for _, state := range []selinuxRuntimeState{selinuxRuntimeActive, selinuxRuntimeIndeterminate} {
+		for _, missing := range trustedSELinuxPolicyTools {
+			t.Run(strconv.Itoa(int(state))+"/"+filepath.Base(missing), func(t *testing.T) {
+				toolFailure := errors.New("synthetic missing SELinux tool")
+				detectionFailure := errors.New("synthetic indeterminate detection")
+				var detectionErr error
+				if state == selinuxRuntimeIndeterminate {
+					detectionErr = detectionFailure
+				}
+				configure, err := shouldConfigureRsyslogSELinuxPolicy(
+					state,
+					detectionErr,
+					func(path string) error {
+						if path == missing {
+							return toolFailure
+						}
+						return nil
+					},
+				)
+				if configure || !errors.Is(err, toolFailure) || !strings.Contains(err.Error(), missing) {
+					t.Fatalf("SELinux policy gate = (%t, %v), want fail-closed missing %s", configure, err, missing)
+				}
+				if detectionErr != nil && !errors.Is(err, detectionFailure) {
+					t.Fatalf("SELinux policy gate lost detection cause: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestRsyslogSELinuxPolicyGateSkipsDisabledAndDefendsIndeterminate(t *testing.T) {
+	validations := 0
+	configure, err := shouldConfigureRsyslogSELinuxPolicy(
+		selinuxRuntimeDisabled,
+		nil,
+		func(string) error {
+			validations++
+			return errors.New("must not run")
+		},
+	)
+	if err != nil || configure || validations != 0 {
+		t.Fatalf("disabled SELinux gate = (%t, %v, %d validations), want (false, nil, 0)", configure, err, validations)
+	}
+
+	configure, err = shouldConfigureRsyslogSELinuxPolicy(
+		selinuxRuntimeIndeterminate,
+		errors.New("synthetic detection failure"),
+		func(string) error { return nil },
+	)
+	if err != nil || !configure {
+		t.Fatalf("indeterminate SELinux with complete toolchain = (%t, %v), want defensive policy work", configure, err)
+	}
+}
+
+func TestTrustedCommandIgnoresHostilePATHAndSanitizesEnvironment(t *testing.T) {
+	hostilePath := t.TempDir()
+	t.Setenv("PATH", hostilePath)
+	t.Setenv("SYSWARDEN_TEST_SECRET", "must-not-be-inherited")
+	command := newTrustedCommand(context.Background(), trustedSystemctlPath, "is-active", "rsyslog")
+	if command.Path != trustedSystemctlPath {
+		t.Fatalf("trusted command path = %q, want %q", command.Path, trustedSystemctlPath)
+	}
+	wantEnv := strings.Join([]string{"LANG=C", "LC_ALL=C", "PATH=" + trustedCommandPath}, "\n")
+	if got := strings.Join(command.Env, "\n"); got != wantEnv {
+		t.Fatalf("trusted command environment = %q, want %q", got, wantEnv)
+	}
+	if strings.Contains(strings.Join(command.Env, "\n"), hostilePath) {
+		t.Fatal("trusted command inherited hostile PATH")
+	}
+}
+
+func TestManagedServiceCommandPropagatesDeadlineAndCausesWithoutWaiting(t *testing.T) {
+	parent, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	sentinel := errors.New("synthetic executor failure")
+	typed := &os.PathError{Op: "exec", Path: trustedSystemctlPath, Err: sentinel}
+	deadlineObserved := false
+	_, err := runManagedServiceCommandUsing(
+		parent,
+		managedServiceCommandTimeout,
+		func(string) error { return nil },
+		func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			_, deadlineObserved = ctx.Deadline()
+			if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				t.Fatalf("executor context error = %v, want deadline exceeded", ctx.Err())
+			}
+			return nil, typed
+		},
+		trustedSystemctlPath,
+		"restart", "rsyslog",
+	)
+	var pathErr *os.PathError
+	if !deadlineObserved || !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, sentinel) || !errors.As(err, &pathErr) {
+		t.Fatalf("deadline/cause propagation error = %v", err)
+	}
+}
+
+func TestManagedServiceDiagnosticCapsPostEscapingAndPreservesTypedCause(t *testing.T) {
+	sentinel := errors.New("synthetic diagnostic failure")
+	typed := &os.PathError{Op: "journal", Path: trustedJournalctlPath, Err: sentinel}
+	escaped := strconv.QuoteToASCII(strings.Repeat("\x1b", managedServiceDiagnosticLimit*2))
+	err := newManagedServiceDiagnosticError("journal="+escaped, typed)
+	if len(err.Error()) != managedServiceDiagnosticLimit || !strings.HasSuffix(err.Error(), "[diagnostic truncated]") {
+		t.Fatalf("bounded diagnostic size/suffix = (%d, %q)", len(err.Error()), err.Error()[len(err.Error())-32:])
+	}
+	if strings.ContainsRune(err.Error(), '\x1b') {
+		t.Fatal("bounded diagnostic contains an unescaped terminal control byte")
+	}
+	var pathErr *os.PathError
+	if !errors.Is(err, sentinel) || !errors.As(err, &pathErr) {
+		t.Fatalf("bounded diagnostic lost typed cause: %v", err)
+	}
+}
+
 func TestRestartManagedServiceUsesOpenRCNodepsRestartForRsyslog_SW_PKG_001(t *testing.T) {
 	var calls []string
 	err := restartManagedServiceUsing(
 		"rsyslog",
 		func() (string, error) { return "ACTIVE", nil },
 		func() bool { return true },
-		func(name string, args ...string) error {
+		func(name string, args ...string) ([]byte, error) {
 			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
-			return nil
+			return nil, nil
 		},
 	)
 	if err != nil {
@@ -97,9 +445,9 @@ func TestRestartManagedServiceKeepsOpenRCRestartForOtherServices_SW_PKG_001(t *t
 		"wazuh-agent",
 		func() (string, error) { return "ACTIVE", nil },
 		func() bool { return true },
-		func(name string, args ...string) error {
+		func(name string, args ...string) ([]byte, error) {
 			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
-			return nil
+			return nil, nil
 		},
 	)
 	if err != nil {
@@ -110,21 +458,154 @@ func TestRestartManagedServiceKeepsOpenRCRestartForOtherServices_SW_PKG_001(t *t
 	}
 }
 
-func TestRestartManagedServiceKeepsSystemdRestartForRsyslog_SW_PKG_001(t *testing.T) {
+func TestRestartManagedServiceValidatesAndAttestsSystemdRsyslog_SW_PKG_001(t *testing.T) {
 	var calls []string
 	err := restartManagedServiceUsing(
 		"rsyslog",
 		func() (string, error) { return "ACTIVE", nil },
 		func() bool { return false },
-		func(name string, args ...string) error {
+		func(name string, args ...string) ([]byte, error) {
 			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
-			return nil
+			return nil, nil
 		},
 	)
 	if err != nil {
 		t.Fatalf("restartManagedServiceUsing() error = %v", err)
 	}
-	if got, want := strings.Join(calls, "\n"), "systemctl restart rsyslog"; got != want {
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("service-manager calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceRetriesSystemdRsyslogExactlyOnce_SW_PKG_001(t *testing.T) {
+	sentinel := errors.New("synthetic first restart failure")
+	var calls []string
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			switch len(calls) {
+			case 2:
+				return []byte("first restart output"), sentinel
+			case 3:
+				return []byte("failed\n"), sentinel
+			default:
+				return nil, nil
+			}
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() recovery error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reset-failed rsyslog",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("recovery calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceRejectsInvalidSystemdRsyslogConfig_SW_PKG_001(t *testing.T) {
+	sentinel := errors.New("synthetic validation failure")
+	var calls []string
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return []byte("invalid\x1bconfig"), sentinel
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "validate complete rsyslog configuration") {
+		t.Fatalf("validation error = %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("validation diagnostic lost command cause: %v", err)
+	}
+	if strings.ContainsRune(err.Error(), '\x1b') || !strings.Contains(err.Error(), `\x1b`) {
+		t.Fatalf("validation evidence is not safely escaped: %q", err.Error())
+	}
+	if got, want := strings.Join(calls, "\n"), "/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf"; got != want {
+		t.Fatalf("validation calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceBoundsTerminalSystemdRsyslogEvidence_SW_PKG_001(t *testing.T) {
+	sentinel := errors.New("synthetic command failure")
+	largeOutput := []byte(strings.Repeat("x", managedServiceOutputLimit*3) + "\x1bsecret")
+	var calls []string
+	err := restartManagedServiceUsing(
+		"rsyslog",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			if len(calls) == 1 {
+				return nil, nil
+			}
+			return largeOutput, sentinel
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed after one bounded retry") {
+		t.Fatalf("terminal retry error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reset-failed rsyslog",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/journalctl --no-pager --quiet --boot --unit rsyslog.service --lines=40",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("terminal failure calls = %q, want %q", got, want)
+	}
+	if !strings.Contains(err.Error(), "[evidence truncated]") {
+		t.Fatalf("terminal evidence did not report truncation: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "journal=") {
+		t.Fatalf("terminal diagnostic omitted bounded journal evidence: %q", err.Error())
+	}
+	if len(err.Error()) > managedServiceDiagnosticLimit {
+		t.Fatalf("terminal diagnostic size = %d, limit %d", len(err.Error()), managedServiceDiagnosticLimit)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("terminal diagnostic lost command cause: %v", err)
+	}
+	if strings.Contains(err.Error(), "secret") || strings.ContainsRune(err.Error(), '\x1b') {
+		t.Fatalf("terminal evidence escaped its bound: %q", err.Error())
+	}
+}
+
+func TestRestartManagedServiceKeepsSingleSystemdRestartForOtherServices_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsing(
+		"wazuh-agent",
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsing() error = %v", err)
+	}
+	if got, want := strings.Join(calls, "\n"), "/usr/bin/systemctl restart wazuh-agent"; got != want {
 		t.Fatalf("service-manager calls = %q, want %q", got, want)
 	}
 }
@@ -135,9 +616,9 @@ func TestRestartManagedServiceDefersOfflineWithoutCommand_SW_PKG_001(t *testing.
 		"rsyslog",
 		func() (string, error) { return "OFFLINE", nil },
 		func() bool { return true },
-		func(string, ...string) error {
+		func(string, ...string) ([]byte, error) {
 			called = true
-			return nil
+			return nil, nil
 		},
 	)
 	if err != nil {
@@ -155,9 +636,9 @@ func TestRestartManagedServiceFailsClosedOnUnknownStateAndRunnerError_SW_PKG_001
 			"rsyslog",
 			func() (string, error) { return "UNKNOWN", nil },
 			func() bool { return true },
-			func(string, ...string) error {
+			func(string, ...string) ([]byte, error) {
 				called = true
-				return nil
+				return nil, nil
 			},
 		)
 		if err == nil || !strings.Contains(err.Error(), "refusing unrecognized service-manager runtime state") {
@@ -212,12 +693,12 @@ func TestRestartManagedServiceFailsClosedOnUnknownStateAndRunnerError_SW_PKG_001
 				"rsyslog",
 				func() (string, error) { return "ACTIVE", nil },
 				func() bool { return true },
-				func(string, ...string) error {
+				func(string, ...string) ([]byte, error) {
 					calls++
 					if calls == test.failCall {
-						return sentinel
+						return nil, sentinel
 					}
-					return nil
+					return nil, nil
 				},
 			)
 			if !errors.Is(err, sentinel) || !strings.Contains(err.Error(), test.wantErrorText) {


### PR DESCRIPTION
## Summary

- classify the SELinux runtime before mutating the rsyslog bridge configuration
- execute fixed privileged service and SELinux tools through root-owned immutable paths, bounded output, and 30-second command deadlines
- validate the complete rsyslog configuration, attest systemd activation, and allow exactly one reset/retry with bounded terminal journal evidence
- replace silent late Alpine assertions with numbered, bounded, producer-status-preserving diagnostics
- accept a delegated read-write cgroup2 mount only when the private root, memory limit, PID limit, and absence of child cgroups are all exact
- bind the native ARM64 transient unit and Podman container to matching 1 GiB memory and 512-task boundaries

## Qualification evidence

PR #101 is merged at `41d7a7da2895f5d3949cc63f3e45308c03f7f93a`. Fresh qualification run `32752697807` passed Debian, Ubuntu, Fedora, and the hosted gates, then isolated two ARM64 lifecycle failures:

- AlmaLinux reached package configuration but rsyslog entered a failed systemd state. Exact x86_64 and QEMU ARM64 reproductions showed that the SELinux warning was non-causal, while the previous unbounded runner discarded the service failure evidence.
- Alpine failed in the late namespace attestation before package installation. The revised proof preserves every producer status and supports the runner's delegated read-write cgroup2 view only under the exact immutable outer resource boundary.

No release tag has been created.

## Validation

- `go test -mod=readonly -count=1 ./...`
- focused integration tests, race detector, and `go vet`
- 181 lifecycle-module tests outside the sandbox, no skips
- 114 direct lifecycle-lab tests with real Podman coverage
- 31 release-qualification workflow tests
- all 10 generated platform shell syntax checks
- Python compilation, `gofmt`, ASCII/confidentiality scan, and `git diff --check`
- two independent blocker-only security reviews, clean

## Release contract

The release manager now requires the future squash commit to have parent `41d7a7da2895f5d3949cc63f3e45308c03f7f93a`, exact subject `Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)`, one linear parent, and exactly the eight reviewed `M 100644` paths. Both coordinate and publish paths preserve the complete PR101 and older v4.03.2 ancestry chain.

Follow-up to #101.
