### PR TITLE
Qualification : repair v4.03.2 ARM64 init runtime

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,83 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"
+              v4032_init_runtime_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_init_runtime_parent_sha}" != "97ebc9991fdeec293abd04444ad6600f11c30ee4" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair is not based on the reviewed PR102 squash." >&2
+                exit 1
+              fi
+              v4032_init_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 init runtime (#103)'
+              if [[ "${commit_subject}" != "${v4032_init_runtime_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_init_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_init_runtime_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 init runtime repair diff contract
+              expected_v4032_init_runtime_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              mapfile -d '' -t actual_v4032_init_runtime_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_init_runtime_diff[@]} != ${#expected_v4032_init_runtime_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair must modify exactly the eight reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_init_runtime_diff[@]}; index++)); do
+                if [[ "${actual_v4032_init_runtime_diff[index]}" != "${expected_v4032_init_runtime_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 init runtime repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_init_runtime_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_init_runtime_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 init runtime repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 init runtime repair diff contract
+              v4032_stabilization_ref=HEAD^
+              v4032_stabilization_parent_sha="$(git rev-parse "${v4032_stabilization_ref}^")"
               if [[ "${v4032_stabilization_parent_sha}" != "41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization is not based on the reviewed PR101 squash." >&2
                 exit 1
               fi
               v4032_stabilization_expected_subject='Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)'
-              if [[ "${commit_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
+              v4032_stabilization_subject="$(git log -1 --format=%s "${v4032_stabilization_ref}")"
+              if [[ "${v4032_stabilization_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 "${v4032_stabilization_ref}")"
               if (( ${#v4032_stabilization_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must be one linear commit." >&2
                 exit 1
@@ -163,7 +229,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_stabilization_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_stabilization_ref}^" "${v4032_stabilization_ref}"
               )
               if (( ${#actual_v4032_stabilization_diff[@]} != ${#expected_v4032_stabilization_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must modify exactly the eight reviewed files." >&2
@@ -185,7 +252,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
                 "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_stabilization_ref}^" "${v4032_stabilization_ref}"; do
                 for fix_path in "${v4032_stabilization_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -200,7 +267,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 lifecycle stabilization diff contract
-              v4032_local_ref=HEAD^
+              v4032_local_ref="${v4032_stabilization_ref}^"
               v4032_local_parent_sha="$(git rev-parse "${v4032_local_ref}^")"
               if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2
@@ -1122,17 +1189,83 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"
+              v4032_init_runtime_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_init_runtime_parent_sha}" != "97ebc9991fdeec293abd04444ad6600f11c30ee4" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair is not based on the reviewed PR102 squash." >&2
+                exit 1
+              fi
+              v4032_init_runtime_expected_subject='Qualification : repair v4.03.2 ARM64 init runtime (#103)'
+              if [[ "${commit_subject}" != "${v4032_init_runtime_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_init_runtime_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_init_runtime_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 ARM64 init runtime repair diff contract
+              expected_v4032_init_runtime_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/package_lifecycle_lab.py"
+                M "scripts/ci/package_lifecycle_lab_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              mapfile -d '' -t actual_v4032_init_runtime_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_init_runtime_diff[@]} != ${#expected_v4032_init_runtime_diff[@]} )); then
+                echo "ERROR: the v4.03.2 ARM64 init runtime repair must modify exactly the eight reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_init_runtime_diff[@]}; index++)); do
+                if [[ "${actual_v4032_init_runtime_diff[index]}" != "${expected_v4032_init_runtime_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 ARM64 init runtime repair contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_init_runtime_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/package_lifecycle_lab.py"
+                "scripts/ci/package_lifecycle_lab_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_init_runtime_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 ARM64 init runtime repair ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 ARM64 init runtime repair diff contract
+              v4032_stabilization_ref=HEAD^
+              v4032_stabilization_parent_sha="$(git rev-parse "${v4032_stabilization_ref}^")"
               if [[ "${v4032_stabilization_parent_sha}" != "41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization is not based on the reviewed PR101 squash." >&2
                 exit 1
               fi
               v4032_stabilization_expected_subject='Qualification : stabilize v4.03.2 ARM64 lifecycle evidence (#102)'
-              if [[ "${commit_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
+              v4032_stabilization_subject="$(git log -1 --format=%s "${v4032_stabilization_ref}")"
+              if [[ "${v4032_stabilization_subject}" != "${v4032_stabilization_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_stabilization_head_line <<< "$(git rev-list --parents -n 1 "${v4032_stabilization_ref}")"
               if (( ${#v4032_stabilization_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must be one linear commit." >&2
                 exit 1
@@ -1149,7 +1282,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
               )
               mapfile -d '' -t actual_v4032_stabilization_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_stabilization_ref}^" "${v4032_stabilization_ref}"
               )
               if (( ${#actual_v4032_stabilization_diff[@]} != ${#expected_v4032_stabilization_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 lifecycle stabilization must modify exactly the eight reviewed files." >&2
@@ -1171,7 +1305,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
                 "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_stabilization_ref}^" "${v4032_stabilization_ref}"; do
                 for fix_path in "${v4032_stabilization_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1186,7 +1320,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 lifecycle stabilization diff contract
-              v4032_local_ref=HEAD^
+              v4032_local_ref="${v4032_stabilization_ref}^"
               v4032_local_parent_sha="$(git rev-parse "${v4032_local_ref}^")"
               if [[ "${v4032_local_parent_sha}" != "93bb85a657d8f8927cd6617c4105653732c59114" ]]; then
                 echo "ERROR: the v4.03.2 final qualification repair is not based on the reviewed PR99 squash." >&2

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -803,6 +803,7 @@ jobs:
   qualify-release:
     name: Qualify Exact Pre-Tag Commit
     needs: package-lifecycle-arm64
+    if: ${{ !cancelled() }}
     outputs:
       candidate_artifact_id: ${{ steps.candidate.outputs.artifact_id }}
       candidate_artifact_name: ${{ steps.candidate.outputs.artifact_name }}

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -217,6 +217,34 @@ stop() {
     return 0
 }
 """
+ALPINE_RSYSLOG_READINESS_PROVIDER = """#!/sbin/openrc-run
+name="syswarden-lab-rsyslog-ready"
+description="Ensure rsyslog is active in the isolated SysWarden lifecycle lab"
+
+depend() {
+    need syswarden-lab-net
+    after rsyslog
+}
+
+start() {
+    ebegin "Attesting isolated lifecycle rsyslog service"
+    if ! rc-service rsyslog status >/dev/null 2>&1; then
+        if ! rc-service rsyslog start; then
+            eend 1
+            return 1
+        fi
+    fi
+    if ! rc-service rsyslog status >/dev/null 2>&1; then
+        eend 1
+        return 1
+    fi
+    eend 0
+}
+
+stop() {
+    return 0
+}
+"""
 ALPINE_OPENRC_VERSION = "0.62.6-r0"
 ALPINE_OPENRC_SYS_ATTESTATION_HEX = (
     "504f444d414e0a"
@@ -1554,6 +1582,9 @@ def build_containerfile(spec: PlatformSpec) -> str:
         provider_encoded = base64.b64encode(
             ALPINE_LAB_NETWORK_PROVIDER.encode("utf-8")
         ).decode("ascii")
+        rsyslog_readiness_encoded = base64.b64encode(
+            ALPINE_RSYSLOG_READINESS_PROVIDER.encode("utf-8")
+        ).decode("ascii")
         init_contract = (
             "RUN apk info -e 'openrc="
             + ALPINE_OPENRC_VERSION
@@ -1585,8 +1616,12 @@ def build_containerfile(spec: PlatformSpec) -> str:
             + f"RUN printf '%s' {shlex.quote(provider_encoded)} | base64 -d > "
             "/etc/init.d/syswarden-lab-net && "
             "chmod 0755 /etc/init.d/syswarden-lab-net\n"
+            + f"RUN printf '%s' {shlex.quote(rsyslog_readiness_encoded)} | base64 -d > "
+            "/etc/init.d/syswarden-lab-rsyslog-ready && "
+            "chmod 0755 /etc/init.d/syswarden-lab-rsyslog-ready\n"
             "RUN rc-update add syswarden-lab-net default && "
             "rc-update add cronie default && rc-update add rsyslog default && "
+            "rc-update add syswarden-lab-rsyslog-ready default && "
             "rc-update -u\n"
             "STOPSIGNAL SIGINT\n"
             'CMD ["/sbin/openrc-init"]\n'
@@ -2429,6 +2464,170 @@ prepare_service_runtime_fixture() {
             attest_alpine_crond_provider || return 1
             ;;
     esac
+}
+
+# The exact historical AlmaLinux v4.02.8 RPM ignores a failed rsyslog restart.
+# In a rootless cgroup that restart can strand a live daemon in failed state.
+# This transition-only lab fixture refuses manual stop before that old scriptlet,
+# while candidate reload and all active-state assertions remain fully enforced.
+rootless_podman_id_map() {
+    awk '
+        NF != 3 || $1 !~ /^(0|[1-9][0-9]*)$/ ||
+            $2 !~ /^(0|[1-9][0-9]*)$/ ||
+            $3 !~ /^[1-9][0-9]*$/ { invalid = 1; next }
+        NR == 1 {
+            if ($1 != 0 || $2 == 0 || $3 != 1) invalid = 1
+            next_inside = 1
+            next
+        }
+        {
+            if ($1 != next_inside || $2 == 0) invalid = 1
+            next_inside += $3
+        }
+        END { exit (invalid || NR < 2) ? 1 : 0 }
+    ' "$1"
+}
+
+attest_rootless_podman_systemd_runtime() {
+    syswarden_transition_proc_root="${1:-/proc}"
+    [ "${container:-}" = podman ] || return 1
+    [ "$(cat "${syswarden_transition_proc_root}/1/comm" 2>/dev/null || true)" = systemd ] || return 1
+    rootless_podman_id_map "${syswarden_transition_proc_root}/1/uid_map" || return 1
+    rootless_podman_id_map "${syswarden_transition_proc_root}/1/gid_map" || return 1
+    [ "$(syswarden_classify_service_manager / systemd)" = ACTIVE ]
+}
+
+alma_v4028_rpm_transition_selected() {
+    [ "${PACKAGE_FAMILY}:${SCENARIO}:${EXPECTED_DISTRIBUTION}" = \
+        rpm:upgrade-rollback:almalinux ] && \
+        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.02.8 ] && \
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.2 ]
+}
+
+attest_alma_v4028_previous_rpm_artifact() {
+    [ -f "${PREVIOUS_PACKAGE}" ] && [ ! -L "${PREVIOUS_PACKAGE}" ] || return 1
+    [ "${PREVIOUS_PACKAGE##*/}" = \
+        "syswarden-4.02.8-1.${EXPECTED_PACKAGE_ARCHITECTURE}.rpm" ] || return 1
+    [ "$(hash_file "${PREVIOUS_PACKAGE}" 2>/dev/null || true)" = "${EXPECTED_PREVIOUS_SHA256}" ] || return 1
+    syswarden_transition_previous_record="$(
+        rpm -qp --queryformat '%{NAME}|%{EPOCHNUM}|%{VERSION}|%{RELEASE}|%{ARCH}' \
+            "${PREVIOUS_PACKAGE}" 2>/dev/null
+    )" || return 1
+    [ "${syswarden_transition_previous_record}" = \
+        "syswarden|0|4.02.8|1|${EXPECTED_PACKAGE_ARCHITECTURE}" ]
+}
+
+attest_alma_v4028_rsyslog_process() {
+    syswarden_transition_expected_pid="$1"
+    syswarden_transition_proc_root="${2:-/proc}"
+    case "${syswarden_transition_expected_pid}" in ''|*[!0-9]*) return 1 ;; esac
+    [ "${syswarden_transition_expected_pid}" -gt 1 ] || return 1
+    kill -0 "${syswarden_transition_expected_pid}" 2>/dev/null || return 1
+    [ "$(cat "${syswarden_transition_proc_root}/${syswarden_transition_expected_pid}/comm" 2>/dev/null || true)" = rsyslogd ] || return 1
+    [ "$(readlink "${syswarden_transition_proc_root}/${syswarden_transition_expected_pid}/exe" 2>/dev/null || true)" = /usr/sbin/rsyslogd ]
+}
+
+attest_alma_v4028_rpm_rsyslog_fixture() {
+    alma_v4028_rpm_transition_selected || return 0
+    syswarden_transition_proc_root="$1"
+    syswarden_transition_systemd_root="$2"
+    syswarden_transition_owner="$3"
+    syswarden_transition_rsyslogd="$4"
+    syswarden_transition_dropin_dir="${syswarden_transition_systemd_root}/rsyslog.service.d"
+    syswarden_transition_dropin="${syswarden_transition_dropin_dir}/90-syswarden-lifecycle-v4028.conf"
+    syswarden_transition_expected_pid="${syswarden_transition_rsyslog_pid_before:-}"
+
+    attest_rootless_podman_systemd_runtime "${syswarden_transition_proc_root}" || return 1
+    attest_alma_v4028_previous_rpm_artifact || return 1
+    case "${syswarden_transition_rsyslogd}" in /*) ;; *) return 1 ;; esac
+    [ -x "${syswarden_transition_rsyslogd}" ] && \
+        [ ! -L "${syswarden_transition_rsyslogd}" ] || return 1
+    "${syswarden_transition_rsyslogd}" -N1 -f /etc/rsyslog.conf \
+        >/dev/null 2>&1 || return 1
+    [ -d "${syswarden_transition_systemd_root}" ] && \
+        [ ! -L "${syswarden_transition_systemd_root}" ] && \
+        [ "$(stat -c '%u:%g:%a' "${syswarden_transition_systemd_root}" 2>/dev/null || true)" = \
+            "${syswarden_transition_owner}:755" ] || return 1
+    [ -d "${syswarden_transition_dropin_dir}" ] && \
+        [ ! -L "${syswarden_transition_dropin_dir}" ] && \
+        [ "$(stat -c '%u:%g:%a' "${syswarden_transition_dropin_dir}" 2>/dev/null || true)" = \
+            "${syswarden_transition_owner}:755" ] || return 1
+    [ -f "${syswarden_transition_dropin}" ] && \
+        [ ! -L "${syswarden_transition_dropin}" ] && \
+        [ "$(stat -c '%u:%g:%a' "${syswarden_transition_dropin}" 2>/dev/null || true)" = \
+            "${syswarden_transition_owner}:644" ] && \
+        [ "$(hash_file "${syswarden_transition_dropin}" 2>/dev/null || true)" = \
+            896e27cd6a65891cd2184253fcfba7e691f0d46047f41d08ee11be81a7d06098 ] || return 1
+    [ "$(systemctl show -p RefuseManualStop --value rsyslog.service 2>/dev/null || true)" = yes ] || return 1
+    [ "$(systemctl is-enabled rsyslog.service 2>/dev/null || true)" = enabled ] || return 1
+    [ "$(systemctl is-active rsyslog.service 2>/dev/null || true)" = active ] || return 1
+    [ "$(systemctl show -p MainPID --value rsyslog.service 2>/dev/null || true)" = \
+        "${syswarden_transition_expected_pid}" ] || return 1
+    attest_alma_v4028_rsyslog_process \
+        "${syswarden_transition_expected_pid}" "${syswarden_transition_proc_root}"
+}
+
+prepare_alma_v4028_rpm_rsyslog_fixture() {
+    alma_v4028_rpm_transition_selected || return 0
+    syswarden_transition_proc_root="$1"
+    syswarden_transition_systemd_root="$2"
+    syswarden_transition_owner="$3"
+    syswarden_transition_rsyslogd="$4"
+    syswarden_transition_dropin_dir="${syswarden_transition_systemd_root}/rsyslog.service.d"
+    syswarden_transition_dropin="${syswarden_transition_dropin_dir}/90-syswarden-lifecycle-v4028.conf"
+    syswarden_transition_expected_pid="${syswarden_transition_rsyslog_pid_before:-}"
+
+    attest_rootless_podman_systemd_runtime "${syswarden_transition_proc_root}" || return 1
+    attest_alma_v4028_previous_rpm_artifact || return 1
+    case "${syswarden_transition_rsyslogd}" in /*) ;; *) return 1 ;; esac
+    [ -x "${syswarden_transition_rsyslogd}" ] && \
+        [ ! -L "${syswarden_transition_rsyslogd}" ] || return 1
+    "${syswarden_transition_rsyslogd}" -N1 -f /etc/rsyslog.conf \
+        >/dev/null 2>&1 || return 1
+    [ "$(systemctl show -p RefuseManualStop --value rsyslog.service 2>/dev/null || true)" = no ] || return 1
+    [ "$(systemctl is-enabled rsyslog.service 2>/dev/null || true)" = enabled ] || return 1
+    [ "$(systemctl is-active rsyslog.service 2>/dev/null || true)" = active ] || return 1
+    [ "$(systemctl show -p MainPID --value rsyslog.service 2>/dev/null || true)" = \
+        "${syswarden_transition_expected_pid}" ] || return 1
+    attest_alma_v4028_rsyslog_process \
+        "${syswarden_transition_expected_pid}" "${syswarden_transition_proc_root}" || return 1
+    [ -d "${syswarden_transition_systemd_root}" ] && \
+        [ ! -L "${syswarden_transition_systemd_root}" ] && \
+        [ "$(stat -c '%u:%g:%a' "${syswarden_transition_systemd_root}" 2>/dev/null || true)" = \
+            "${syswarden_transition_owner}:755" ] || return 1
+    [ ! -e "${syswarden_transition_dropin}" ] && [ ! -L "${syswarden_transition_dropin}" ] || return 1
+    if [ -e "${syswarden_transition_dropin_dir}" ] || [ -L "${syswarden_transition_dropin_dir}" ]; then
+        return 1
+    fi
+    mkdir -m 0755 "${syswarden_transition_dropin_dir}" || return 1
+    (umask 077 && printf '%s\n' '[Unit]' 'RefuseManualStop=yes' > "${syswarden_transition_dropin}") || return 1
+    chmod 0644 "${syswarden_transition_dropin}" || return 1
+    [ "$(stat -c '%u:%g:%a' "${syswarden_transition_dropin_dir}" 2>/dev/null || true)" = \
+        "${syswarden_transition_owner}:755" ] || return 1
+    [ "$(stat -c '%u:%g:%a' "${syswarden_transition_dropin}" 2>/dev/null || true)" = \
+        "${syswarden_transition_owner}:644" ] || return 1
+    [ "$(hash_file "${syswarden_transition_dropin}" 2>/dev/null || true)" = \
+        896e27cd6a65891cd2184253fcfba7e691f0d46047f41d08ee11be81a7d06098 ] || return 1
+    systemctl daemon-reload >/dev/null 2>&1 || return 1
+    attest_alma_v4028_rpm_rsyslog_fixture \
+        "${syswarden_transition_proc_root}" "${syswarden_transition_systemd_root}" \
+        "${syswarden_transition_owner}" "${syswarden_transition_rsyslogd}" || return 1
+    printf 'TRANSITION alma-v4028-rpm-rsyslog fixture=refuse-manual-stop pid=%s\n' \
+        "${syswarden_transition_expected_pid}" >> "${COMMAND_LOG}"
+}
+
+attest_alma_v4028_rpm_rsyslog_after_previous() {
+    alma_v4028_rpm_transition_selected || return 0
+    syswarden_transition_installed_record="$(
+        rpm -q --queryformat '%{NAME}|%{EPOCHNUM}|%{VERSION}|%{RELEASE}|%{ARCH}' \
+            syswarden 2>/dev/null
+    )" || return 1
+    [ "${syswarden_transition_installed_record}" = \
+        "syswarden|0|4.02.8|1|${EXPECTED_PACKAGE_ARCHITECTURE}" ] || return 1
+    [ "$(installed_version 2>/dev/null || true)" = 4.02.8 ] || return 1
+    attest_alma_v4028_rpm_rsyslog_fixture "$@" || return 1
+    printf 'TRANSITION alma-v4028-rpm-rsyslog postinstall=active pid=%s\n' \
+        "${syswarden_transition_rsyslog_pid_before}" >> "${COMMAND_LOG}"
 }
 
 prepare_package_transition() {
@@ -3930,7 +4129,11 @@ probe_execution_architecture() {
 scenario_upgrade_rollback_initial() {
     prepare_expected_payloads || return
     prepare_package_transition || return
+    prepare_alma_v4028_rpm_rsyslog_fixture \
+        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     run_install_step install.previous "${PREVIOUS_PACKAGE}" || return
+    attest_alma_v4028_rpm_rsyslog_after_previous \
+        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     if [ "${FORWARD_ONLY_APK_TRANSITION}" = "1" ]; then
         probe_forward_only_apk_payload previous
     else
@@ -3969,7 +4172,11 @@ scenario_upgrade_rollback_restart_two() {
     probe_payload restart-two candidate "${EXPECTED_CANDIDATE_VERSION}"
     assert_all_state_preserved restart-two
     prepare_package_transition || return
+    attest_alma_v4028_rpm_rsyslog_fixture \
+        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     run_install_step rollback.previous "${PREVIOUS_PACKAGE}" || return
+    attest_alma_v4028_rpm_rsyslog_after_previous \
+        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     if [ "${FORWARD_ONLY_APK_TRANSITION}" = "1" ]; then
         probe_forward_only_apk_payload rollback
     else
@@ -5156,6 +5363,8 @@ def container_run_arguments(
         f"EXPECTED_PACKAGE_ARCHITECTURE={spec.package_architecture}",
         "--env",
         f"EXPECTED_UNAME_ARCHITECTURE={spec.uname_architecture}",
+        "--env",
+        f"EXPECTED_DISTRIBUTION={spec.distribution}",
         "--env",
         f"EXPECTED_CANDIDATE_VERSION={pair.candidate.version}",
         "--env",

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import ipaddress
 import json
@@ -1655,7 +1656,20 @@ class PackageLifecycleLabTests(unittest.TestCase):
         )
         self.assertIn("keyword -prefix -lxc -docker\\)$/\\1 -podman", containerfile)
         self.assertIn(
-            "rc-update add rsyslog default && rc-update -u\n",
+            "rc-update add rsyslog default && "
+            "rc-update add syswarden-lab-rsyslog-ready default && "
+            "rc-update -u\n",
+            containerfile,
+        )
+        rsyslog_readiness = (
+            package_lifecycle_lab.ALPINE_RSYSLOG_READINESS_PROVIDER
+        )
+        self.assertIn(
+            base64.b64encode(rsyslog_readiness.encode()).decode(),
+            containerfile,
+        )
+        self.assertIn(
+            "/etc/init.d/syswarden-lab-rsyslog-ready",
             containerfile,
         )
         self.assertNotIn("/tmp/syswarden-openrc-config", containerfile)
@@ -1684,6 +1698,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             "rc-service rsyslog status",
         ):
             self.assertIn(expected, runtime)
+        self.assertNotIn("rc-service rsyslog start", runtime)
+        self.assertNotIn("rc-service rsyslog restart", runtime)
         self.assertNotIn("for (index =", runtime)
         predicates = (
             "NS15_OPENRC_PACKAGE",
@@ -1859,6 +1875,189 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 "configuration payload is not exact",
             ):
                 package_lifecycle_lab.build_containerfile(spec)
+
+    def test_alpine_rsyslog_readiness_provider_is_fail_closed_and_portable(
+        self,
+    ) -> None:
+        provider = package_lifecycle_lab.ALPINE_RSYSLOG_READINESS_PROVIDER
+        self.assertTrue(provider.startswith("#!/sbin/openrc-run\n"))
+        self.assertIn("need syswarden-lab-net", provider)
+        self.assertIn("after rsyslog", provider)
+        self.assertEqual(provider.count("rc-service rsyslog status"), 2)
+        self.assertEqual(provider.count("rc-service rsyslog start"), 1)
+        self.assertNotIn("|| true", provider)
+        syntax = subprocess.run(
+            [shutil.which("dash") or "/bin/sh", "-n"],
+            input=provider,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
+        mocks = r'''syswarden_test_status_calls=0
+ebegin() {
+    printf 'ebegin:%s\n' "$1" >> "${SYSWARDEN_TEST_CALLS}"
+}
+eend() {
+    printf 'eend:%s\n' "$1" >> "${SYSWARDEN_TEST_CALLS}"
+}
+rc_service() {
+    [ "$#" -eq 2 ] || return 96
+    printf 'rc-service:%s:%s\n' "$1" "$2" >> "${SYSWARDEN_TEST_CALLS}"
+    case "$2" in
+        status)
+            syswarden_test_status_calls=$((syswarden_test_status_calls + 1))
+            if [ "${syswarden_test_status_calls}" -eq 1 ]; then
+                return "${SYSWARDEN_TEST_INITIAL_STATUS}"
+            fi
+            return "${SYSWARDEN_TEST_FINAL_STATUS}"
+            ;;
+        start)
+            return "${SYSWARDEN_TEST_START_STATUS}"
+            ;;
+        *) return 96 ;;
+    esac
+}
+'''
+        probe = mocks + provider.replace("rc-service", "rc_service") + "\nstart\n"
+        shells = [("posix", [shutil.which("dash") or "/bin/sh"])]
+        busybox = shutil.which("busybox")
+        if busybox is not None:
+            shells.append(("busybox-ash", [busybox, "ash"]))
+        cases = (
+            (
+                "already-active",
+                "0",
+                "7",
+                "0",
+                0,
+                (
+                    "ebegin:Attesting isolated lifecycle rsyslog service",
+                    "rc-service:rsyslog:status",
+                    "rc-service:rsyslog:status",
+                    "eend:0",
+                ),
+            ),
+            (
+                "start-stopped-service",
+                "3",
+                "0",
+                "0",
+                0,
+                (
+                    "ebegin:Attesting isolated lifecycle rsyslog service",
+                    "rc-service:rsyslog:status",
+                    "rc-service:rsyslog:start",
+                    "rc-service:rsyslog:status",
+                    "eend:0",
+                ),
+            ),
+            (
+                "start-fails",
+                "3",
+                "7",
+                "0",
+                1,
+                (
+                    "ebegin:Attesting isolated lifecycle rsyslog service",
+                    "rc-service:rsyslog:status",
+                    "rc-service:rsyslog:start",
+                    "eend:1",
+                ),
+            ),
+            (
+                "start-does-not-become-active",
+                "3",
+                "0",
+                "3",
+                1,
+                (
+                    "ebegin:Attesting isolated lifecycle rsyslog service",
+                    "rc-service:rsyslog:status",
+                    "rc-service:rsyslog:start",
+                    "rc-service:rsyslog:status",
+                    "eend:1",
+                ),
+            ),
+            (
+                "active-service-stops-before-final-check",
+                "0",
+                "0",
+                "3",
+                1,
+                (
+                    "ebegin:Attesting isolated lifecycle rsyslog service",
+                    "rc-service:rsyslog:status",
+                    "rc-service:rsyslog:status",
+                    "eend:1",
+                ),
+            ),
+        )
+        for shell_name, shell in shells:
+            for (
+                label,
+                initial_status,
+                start_status,
+                final_status,
+                expected_returncode,
+                expected_calls,
+            ) in cases:
+                with self.subTest(shell=shell_name, case=label):
+                    with tempfile.TemporaryDirectory() as temporary:
+                        calls = Path(temporary) / "calls"
+                        result = subprocess.run(
+                            [*shell, "-eu", "-c", probe],
+                            env={
+                                **os.environ,
+                                "SYSWARDEN_TEST_CALLS": str(calls),
+                                "SYSWARDEN_TEST_INITIAL_STATUS": initial_status,
+                                "SYSWARDEN_TEST_START_STATUS": start_status,
+                                "SYSWARDEN_TEST_FINAL_STATUS": final_status,
+                            },
+                            text=True,
+                            capture_output=True,
+                            check=False,
+                        )
+                        self.assertEqual(
+                            result.returncode,
+                            expected_returncode,
+                            result.stderr,
+                        )
+                        self.assertEqual(result.stdout, "")
+                        self.assertEqual(result.stderr, "")
+                        self.assertEqual(
+                            calls.read_text(encoding="utf-8").splitlines(),
+                            list(expected_calls),
+                        )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            calls = Path(temporary) / "calls"
+            calls.write_text("", encoding="utf-8")
+            stopped = subprocess.run(
+                [
+                    shutil.which("dash") or "/bin/sh",
+                    "-eu",
+                    "-c",
+                    mocks
+                    + provider.replace("rc-service", "rc_service")
+                    + "\nstop\n",
+                ],
+                env={
+                    **os.environ,
+                    "SYSWARDEN_TEST_CALLS": str(calls),
+                    "SYSWARDEN_TEST_INITIAL_STATUS": "96",
+                    "SYSWARDEN_TEST_START_STATUS": "96",
+                    "SYSWARDEN_TEST_FINAL_STATUS": "96",
+                },
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(stopped.returncode, 0, stopped.stderr)
+            self.assertEqual(stopped.stdout, "")
+            self.assertEqual(stopped.stderr, "")
+            self.assertEqual(calls.read_text(encoding="utf-8"), "")
 
     def test_alpine_file_and_configuration_guards_are_behavioral(self) -> None:
         spec = next(
@@ -2657,6 +2856,7 @@ rc_service() {
         self.assertNotIn("/run/podman/podman.sock", " ".join(args))
         self.assertIn("EXPECTED_PACKAGE_ARCHITECTURE=amd64", args)
         self.assertIn("EXPECTED_UNAME_ARCHITECTURE=x86_64", args)
+        self.assertIn("EXPECTED_DISTRIBUTION=debian", args)
         self.assertIn("EXPECTED_CANDIDATE_VERSION=4.02.8", args)
         self.assertIn("EXPECTED_PREVIOUS_VERSION=4.02.7", args)
 
@@ -3556,6 +3756,9 @@ probe
             "seed_legacy_saas_monitor_state() { :; }\n"
             "prepare_service_runtime_fixture() { :; }\n"
             "prepare_package_transition() { prepare_service_runtime_fixture; }\n"
+            "prepare_alma_v4028_rpm_rsyslog_fixture() { :; }\n"
+            "attest_alma_v4028_rpm_rsyslog_fixture() { :; }\n"
+            "attest_alma_v4028_rpm_rsyslog_after_previous() { :; }\n"
             "remove_service_manager_sentinels() { :; }\n"
             "load_state_contract() { return 0; }\n"
             'run_install_step() { printf "%s\\n" "$1" >> "${CALLS}"; }\n'
@@ -3607,6 +3810,9 @@ probe
             "FAILURES=0\n"
             "probe_execution_architecture() { return 0; }\n"
             "prepare_package_transition() { return 0; }\n"
+            "prepare_alma_v4028_rpm_rsyslog_fixture() { return 0; }\n"
+            "attest_alma_v4028_rpm_rsyslog_fixture() { return 0; }\n"
+            "attest_alma_v4028_rpm_rsyslog_after_previous() { return 0; }\n"
             "prepare_expected_payloads() {\n"
             '    case "${SCENARIO}" in\n'
             "        upgrade-rollback) return 0 ;;\n"
@@ -5585,6 +5791,311 @@ probe
                     f"{scenario}.{label}.service_manager_calls", checks
                 )
 
+    def test_alma_v4028_rpm_rsyslog_transition_fixture_is_exact_and_fail_closed(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("# The exact historical AlmaLinux v4.02.8 RPM")
+        end = source.index("\nprepare_package_transition() {", start)
+        functions = source[start:end]
+        scenario_start = source.index("scenario_upgrade_rollback_initial() {")
+        scenario_end = source.index("\nscenario_remove() {", scenario_start)
+        scenarios = source[scenario_start:scenario_end]
+
+        self.assertIn("RefuseManualStop=yes", functions)
+        self.assertIn(
+            "896e27cd6a65891cd2184253fcfba7e691f0d46047f41d08ee11be81a7d06098",
+            functions,
+        )
+        self.assertEqual(functions.count("systemctl daemon-reload"), 1)
+        for forbidden in (
+            "systemctl start rsyslog",
+            "systemctl stop rsyslog",
+            "systemctl restart rsyslog",
+            "systemctl reset-failed rsyslog",
+        ):
+            self.assertNotIn(forbidden, functions)
+        self.assertEqual(
+            scenarios.count("prepare_alma_v4028_rpm_rsyslog_fixture \\\n"),
+            1,
+        )
+        self.assertEqual(
+            scenarios.count("attest_alma_v4028_rpm_rsyslog_fixture \\\n"),
+            1,
+        )
+        self.assertEqual(
+            scenarios.count(
+                "attest_alma_v4028_rpm_rsyslog_after_previous \\\n"
+            ),
+            2,
+        )
+        for candidate_step in (
+            'run_install_step upgrade.candidate "${CANDIDATE_PACKAGE}"',
+            'run_install_step reinstall.candidate "${CANDIDATE_PACKAGE}"',
+            'run_install_step recovery.candidate "${CANDIDATE_PACKAGE}"',
+        ):
+            candidate_index = scenarios.index(candidate_step)
+            preceding = scenarios[:candidate_index].splitlines()[-2:]
+            self.assertNotIn("alma_v4028", "\n".join(preceding))
+
+        harness = (
+            "#!/bin/sh\nset -u\n"
+            + functions
+            + r'''
+hash_file() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+installed_version() {
+    printf '%s\n' "${TEST_INSTALLED_VERSION:-4.02.8}"
+}
+syswarden_classify_service_manager() {
+    printf '%s\n' "${TEST_MANAGER_STATE:-ACTIVE}"
+}
+rpm() {
+    printf 'rpm %s\n' "$*" >> "${TEST_CALLS}"
+    case "$1" in
+        -qp)
+            printf '%s' "${TEST_ARTIFACT_RECORD:-syswarden|0|4.02.8|1|x86_64}"
+            ;;
+        -q)
+            printf '%s' "${TEST_INSTALLED_RECORD:-syswarden|0|4.02.8|1|x86_64}"
+            ;;
+        *) return 97 ;;
+    esac
+}
+systemctl() {
+    printf 'systemctl %s\n' "$*" >> "${TEST_CALLS}"
+    syswarden_test_reloaded=0
+    [ ! -f "${TEST_RELOADED}" ] || syswarden_test_reloaded=1
+    case "$*" in
+        'show -p RefuseManualStop --value rsyslog.service')
+            if [ "${syswarden_test_reloaded}" -eq 1 ]; then
+                printf '%s\n' "${TEST_FINAL_PROPERTY:-yes}"
+            else
+                printf '%s\n' "${TEST_INITIAL_PROPERTY:-no}"
+            fi
+            ;;
+        'is-enabled rsyslog.service')
+            if [ "${syswarden_test_reloaded}" -eq 1 ]; then
+                printf '%s\n' "${TEST_FINAL_ENABLED:-enabled}"
+            else
+                printf '%s\n' "${TEST_INITIAL_ENABLED:-enabled}"
+            fi
+            ;;
+        'is-active rsyslog.service')
+            if [ "${syswarden_test_reloaded}" -eq 1 ]; then
+                printf '%s\n' "${TEST_FINAL_ACTIVE:-active}"
+            else
+                printf '%s\n' "${TEST_INITIAL_ACTIVE:-active}"
+            fi
+            ;;
+        'show -p MainPID --value rsyslog.service')
+            if [ "${syswarden_test_reloaded}" -eq 1 ]; then
+                printf '%s\n' "${TEST_FINAL_PID:-123}"
+            else
+                printf '%s\n' "${TEST_INITIAL_PID:-123}"
+            fi
+            ;;
+        'daemon-reload')
+            syswarden_test_reload_rc="${TEST_DAEMON_RELOAD_RC:-0}"
+            if [ "${syswarden_test_reload_rc}" -eq 0 ]; then
+                : > "${TEST_RELOADED}"
+            fi
+            return "${syswarden_test_reload_rc}"
+            ;;
+        *) return 97 ;;
+    esac
+}
+kill() {
+    printf 'kill %s\n' "$*" >> "${TEST_CALLS}"
+    return "${TEST_KILL_RC:-0}"
+}
+
+case "${TEST_ACTION:-full}" in
+    prepare)
+        prepare_alma_v4028_rpm_rsyslog_fixture \
+            "${TEST_PROC_ROOT}" "${TEST_SYSTEMD_ROOT}" "${TEST_OWNER}" \
+            "${TEST_RSYSLOGD}"
+        ;;
+    full)
+        prepare_alma_v4028_rpm_rsyslog_fixture \
+            "${TEST_PROC_ROOT}" "${TEST_SYSTEMD_ROOT}" "${TEST_OWNER}" \
+            "${TEST_RSYSLOGD}" &&
+        attest_alma_v4028_rpm_rsyslog_after_previous \
+            "${TEST_PROC_ROOT}" "${TEST_SYSTEMD_ROOT}" "${TEST_OWNER}" \
+            "${TEST_RSYSLOGD}"
+        ;;
+    tamper)
+        prepare_alma_v4028_rpm_rsyslog_fixture \
+            "${TEST_PROC_ROOT}" "${TEST_SYSTEMD_ROOT}" "${TEST_OWNER}" \
+            "${TEST_RSYSLOGD}" || exit $?
+        printf '%s\n' tampered > \
+            "${TEST_SYSTEMD_ROOT}/rsyslog.service.d/90-syswarden-lifecycle-v4028.conf"
+        attest_alma_v4028_rpm_rsyslog_after_previous \
+            "${TEST_PROC_ROOT}" "${TEST_SYSTEMD_ROOT}" "${TEST_OWNER}" \
+            "${TEST_RSYSLOGD}"
+        ;;
+    *) exit 98 ;;
+esac
+'''
+        )
+
+        def run_case(
+            overrides: dict[str, str] | None = None,
+            *,
+            invalid_map: bool = False,
+            wrong_process: bool = False,
+            preexisting_dropin: bool = False,
+            wrong_package_name: bool = False,
+        ) -> tuple[subprocess.CompletedProcess[str], list[str], Path]:
+            temporary = tempfile.TemporaryDirectory()
+            self.addCleanup(temporary.cleanup)
+            root = Path(temporary.name)
+            proc_root = root / "proc"
+            pid1 = proc_root / "1"
+            process = proc_root / "123"
+            pid1.mkdir(parents=True)
+            process.mkdir()
+            (pid1 / "comm").write_text("systemd\n", encoding="ascii")
+            identity_map = (
+                "0 0 4294967295\n"
+                if invalid_map
+                else "0 1000 1\n1 524288 65536\n"
+            )
+            (pid1 / "uid_map").write_text(identity_map, encoding="ascii")
+            (pid1 / "gid_map").write_text(identity_map, encoding="ascii")
+            (process / "comm").write_text(
+                "unexpected\n" if wrong_process else "rsyslogd\n",
+                encoding="ascii",
+            )
+            (process / "exe").symlink_to("/usr/sbin/rsyslogd")
+            systemd_root = root / "systemd"
+            systemd_root.mkdir(mode=0o755)
+            if preexisting_dropin:
+                dropin_dir = systemd_root / "rsyslog.service.d"
+                dropin_dir.mkdir(mode=0o755)
+                (dropin_dir / "90-syswarden-lifecycle-v4028.conf").write_text(
+                    "unexpected\n", encoding="ascii"
+                )
+            package = root / (
+                "unexpected.rpm"
+                if wrong_package_name
+                else "syswarden-4.02.8-1.x86_64.rpm"
+            )
+            package.write_bytes(b"exact historical RPM fixture")
+            rsyslogd = root / "rsyslogd"
+            rsyslogd.write_text(
+                "#!/bin/sh\n"
+                "printf 'rsyslogd %s\\n' \"$*\" >> \"${TEST_CALLS}\"\n"
+                "exit \"${TEST_VALIDATE_RC:-0}\"\n",
+                encoding="ascii",
+            )
+            rsyslogd.chmod(0o755)
+            calls = root / "calls"
+            calls.write_text("", encoding="ascii")
+            command_log = root / "commands.log"
+            reloaded = root / "daemon-reloaded"
+            environment = {
+                **os.environ,
+                "container": "podman",
+                "PACKAGE_FAMILY": "rpm",
+                "SCENARIO": "upgrade-rollback",
+                "EXPECTED_DISTRIBUTION": "almalinux",
+                "EXPECTED_PREVIOUS_VERSION": "4.02.8",
+                "EXPECTED_CANDIDATE_VERSION": "4.03.2",
+                "EXPECTED_PREVIOUS_SHA256": hashlib.sha256(
+                    package.read_bytes()
+                ).hexdigest(),
+                "EXPECTED_PACKAGE_ARCHITECTURE": "x86_64",
+                "PREVIOUS_PACKAGE": str(package),
+                "COMMAND_LOG": str(command_log),
+                "TEST_CALLS": str(calls),
+                "TEST_RELOADED": str(reloaded),
+                "TEST_PROC_ROOT": str(proc_root),
+                "TEST_SYSTEMD_ROOT": str(systemd_root),
+                "TEST_OWNER": f"{systemd_root.stat().st_uid}:{systemd_root.stat().st_gid}",
+                "TEST_RSYSLOGD": str(rsyslogd),
+                "syswarden_transition_rsyslog_pid_before": "123",
+            }
+            environment.update(overrides or {})
+            result = subprocess.run(
+                [shutil.which("dash") or "/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            observed = calls.read_text(encoding="ascii").splitlines()
+            return result, observed, systemd_root
+
+        accepted, calls, systemd_root = run_case()
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+        self.assertEqual(calls.count("systemctl daemon-reload"), 1)
+        self.assertGreaterEqual(
+            sum(call.endswith(" -N1 -f /etc/rsyslog.conf") for call in calls), 3
+        )
+        self.assertFalse(
+            any(
+                call.startswith(
+                    (
+                        "systemctl start ",
+                        "systemctl stop ",
+                        "systemctl restart ",
+                        "systemctl reload rsyslog",
+                    )
+                )
+                for call in calls
+            )
+        )
+        dropin = (
+            systemd_root
+            / "rsyslog.service.d"
+            / "90-syswarden-lifecycle-v4028.conf"
+        )
+        self.assertEqual(dropin.read_bytes(), b"[Unit]\nRefuseManualStop=yes\n")
+        self.assertEqual(dropin.stat().st_mode & 0o777, 0o644)
+
+        for label, overrides in (
+            ("other-family", {"PACKAGE_FAMILY": "deb"}),
+            ("other-scenario", {"SCENARIO": "remove"}),
+            ("other-distribution", {"EXPECTED_DISTRIBUTION": "fedora"}),
+            ("other-version", {"EXPECTED_PREVIOUS_VERSION": "4.02.7"}),
+            ("other-candidate", {"EXPECTED_CANDIDATE_VERSION": "4.03.3"}),
+        ):
+            with self.subTest(noop=label):
+                result, observed, root = run_case(overrides)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(observed, [])
+                self.assertFalse((root / "rsyslog.service.d").exists())
+
+        failures: tuple[
+            tuple[str, dict[str, str], dict[str, bool]], ...
+        ] = (
+            ("artifact-digest", {"EXPECTED_PREVIOUS_SHA256": "0" * 64}, {}),
+            ("artifact-identity", {"TEST_ARTIFACT_RECORD": "other"}, {}),
+            ("artifact-name", {}, {"wrong_package_name": True}),
+            ("invalid-config", {"TEST_VALIDATE_RC": "1"}, {}),
+            ("inactive-before", {"TEST_INITIAL_ACTIVE": "inactive"}, {}),
+            ("wrong-pid-before", {"TEST_INITIAL_PID": "124"}, {}),
+            ("reload-failure", {"TEST_DAEMON_RELOAD_RC": "1"}, {}),
+            ("property-not-loaded", {"TEST_FINAL_PROPERTY": "no"}, {}),
+            ("inactive-after", {"TEST_FINAL_ACTIVE": "failed"}, {}),
+            ("wrong-pid-after", {"TEST_FINAL_PID": "124"}, {}),
+            ("installed-identity", {"TEST_INSTALLED_RECORD": "other"}, {}),
+            ("installed-version", {"TEST_INSTALLED_VERSION": "4.03.2"}, {}),
+            ("rootless-map", {}, {"invalid_map": True}),
+            ("process-identity", {}, {"wrong_process": True}),
+            ("preexisting-dropin", {}, {"preexisting_dropin": True}),
+        )
+        for label, overrides, options in failures:
+            with self.subTest(fail_closed=label):
+                result, observed, _ = run_case(overrides, **options)
+                self.assertNotEqual(result.returncode, 0, result)
+                self.assertNotIn("systemctl restart rsyslog.service", observed)
+
+        tampered, _, _ = run_case({"TEST_ACTION": "tamper"})
+        self.assertNotEqual(tampered.returncode, 0, tampered)
+
     def test_package_transitions_reset_only_an_active_rsyslog_rate_limit(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         start = source.index("prepare_package_transition() {")
@@ -5614,10 +6125,8 @@ probe
         self.assertEqual(function.count("kill -0"), 2)
 
         commands = (
-            ('install.previous "${PREVIOUS_PACKAGE}"', 1),
             ('upgrade.candidate "${CANDIDATE_PACKAGE}"', 1),
             ('reinstall.candidate "${CANDIDATE_PACKAGE}"', 1),
-            ('rollback.previous "${PREVIOUS_PACKAGE}"', 1),
             ('recovery.candidate "${CANDIDATE_PACKAGE}"', 1),
             ('install.candidate "${CANDIDATE_PACKAGE}"', 2),
         )
@@ -5630,6 +6139,24 @@ probe
                     ),
                     expected_count,
                 )
+        self.assertEqual(
+            source.count(
+                "    prepare_package_transition || return\n"
+                "    prepare_alma_v4028_rpm_rsyslog_fixture \\\n"
+                "        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return\n"
+                '    run_install_step install.previous "${PREVIOUS_PACKAGE}" || return'
+            ),
+            1,
+        )
+        self.assertEqual(
+            source.count(
+                "    prepare_package_transition || return\n"
+                "    attest_alma_v4028_rpm_rsyslog_fixture \\\n"
+                "        /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return\n"
+                '    run_install_step rollback.previous "${PREVIOUS_PACKAGE}" || return'
+            ),
+            1,
+        )
 
         harness = function + r'''
 prepare_service_runtime_fixture() {

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -835,13 +835,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                8,
+                9,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 7)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 8)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 8)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 9)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 16,
-                "scripts/ci/release_gate_test.py": 16,
+                ".github/workflows/release-manager.yml": 18,
+                "scripts/ci/release_gate_test.py": 18,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -878,6 +878,10 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         pinned_contracts = (
+            (
+                'if [[ "${v4032_init_runtime_parent_sha}" != '
+                '"97ebc9991fdeec293abd04444ad6600f11c30ee4" ]]; then'
+            ),
             (
                 'if [[ "${v4032_stabilization_parent_sha}" != '
                 '"41d7a7da2895f5d3949cc63f3e45308c03f7f93a" ]]; then'
@@ -917,6 +921,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        init_runtime_subject_contract = (
+            "v4032_init_runtime_expected_subject='Qualification : repair "
+            "v4.03.2 ARM64 init runtime (#103)'"
+        )
         stabilization_subject_contract = (
             "v4032_stabilization_expected_subject='Qualification : stabilize "
             "v4.03.2 ARM64 lifecycle evidence (#102)'"
@@ -945,13 +953,7 @@ class ReleaseGateTests(unittest.TestCase):
             "v4032_expected_subject='Qualification : repair v4.03.2 "
             "package lifecycle qualification (#95) (#95)'"
         )
-        arm64_paths = (
-            ".github/workflows/release-manager.yml",
-            ".github/workflows/release-qualification.yml",
-            "scripts/ci/release_gate_test.py",
-            "scripts/ci/release_qualification_workflow_test.py",
-        )
-        stabilization_paths = (
+        init_runtime_paths = (
             ".github/workflows/release-manager.yml",
             ".github/workflows/release-qualification.yml",
             "scripts/ci/package_lifecycle_lab.py",
@@ -961,6 +963,13 @@ class ReleaseGateTests(unittest.TestCase):
             "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
             "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
         )
+        arm64_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
+        )
+        stabilization_paths = init_runtime_paths
         local_paths = (
             ".github/workflows/release-manager.yml",
             ".github/workflows/release-qualification.yml",
@@ -1008,6 +1017,7 @@ class ReleaseGateTests(unittest.TestCase):
             "README.md",
         )
         for block in blocks:
+            self.assertEqual(block.count(init_runtime_subject_contract), 1)
             self.assertEqual(block.count(stabilization_subject_contract), 1)
             self.assertEqual(block.count(local_subject_contract), 1)
             self.assertEqual(block.count(runc_subject_contract), 1)
@@ -1018,20 +1028,98 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_init_runtime_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_init_runtime_parent_sha="$(git rev-parse HEAD^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_init_runtime_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_init_runtime_head_line[@]} != 2"), 1
+            )
+            self.assertEqual(
+                block.count(
+                    "# BEGIN exact v4.03.2 ARM64 init runtime repair diff contract"
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    "# END exact v4.03.2 ARM64 init runtime repair diff contract"
+                ),
+                1,
+            )
+            init_runtime_diff = block.split(
+                "# BEGIN exact v4.03.2 ARM64 init runtime repair diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 ARM64 init runtime repair diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                init_runtime_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(
+                init_runtime_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+            )
+            self.assertEqual(
+                init_runtime_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                init_runtime_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                init_runtime_diff.count(
+                    "${#actual_v4032_init_runtime_diff[@]} != "
+                    "${#expected_v4032_init_runtime_diff[@]}"
+                ),
+                1,
+            )
+            for path in init_runtime_paths:
+                self.assertEqual(init_runtime_diff.count(f'"{path}"'), 2)
+                self.assertEqual(init_runtime_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_stabilization_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_stabilization_parent_sha="$(git rev-parse '
+                    '"${v4032_stabilization_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_stabilization_subject="$(git log -1 --format=%s '
+                    '"${v4032_stabilization_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_stabilization_subject}" != '
                     '"${v4032_stabilization_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"'
-                ),
-                1,
-            )
-            self.assertEqual(
-                block.count(
                     'v4032_stabilization_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_stabilization_ref}")"'
                 ),
                 1,
             )
@@ -1063,12 +1151,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 stabilization_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_stabilization_ref}^" '
+                    '"${v4032_stabilization_ref}"'
                 ),
                 1,
             )
             self.assertEqual(
-                stabilization_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+                stabilization_diff.count(
+                    'for tree_ref in "${v4032_stabilization_ref}^" '
+                    '"${v4032_stabilization_ref}"; do'
+                ),
+                1,
             )
             self.assertEqual(
                 stabilization_diff.count('"${tree_mode}" != "100644"'), 1
@@ -1086,7 +1180,12 @@ class ReleaseGateTests(unittest.TestCase):
             for path in stabilization_paths:
                 self.assertEqual(stabilization_diff.count(f'"{path}"'), 2)
                 self.assertEqual(stabilization_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_local_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_local_ref="${v4032_stabilization_ref}^"\n'
+                ),
+                1,
+            )
             self.assertEqual(
                 block.count(
                     'v4032_local_parent_sha="$(git rev-parse '
@@ -1548,7 +1647,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                6,
+                7,
             )
             self.assertEqual(
                 block.count(
@@ -1567,12 +1666,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                7,
+                8,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 7)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 8)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -1591,6 +1690,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in runc_paths else 0
                 expected_count += 2 if path in local_paths else 0
                 expected_count += 2 if path in stabilization_paths else 0
+                expected_count += 2 if path in init_runtime_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1
@@ -1600,6 +1700,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_status_count += 1 if path in runc_paths else 0
                 expected_status_count += 1 if path in local_paths else 0
                 expected_status_count += 1 if path in stabilization_paths else 0
+                expected_status_count += 1 if path in init_runtime_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -1731,6 +1832,28 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_init_runtime_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.2 ARM64 init runtime repair diff contract\n"
+        end = "# END exact v4.03.2 ARM64 init runtime repair diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_init_runtime_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_init_runtime_expected_subject="
+        end = (
+            'read -r -a v4032_init_runtime_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_stabilization_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -1740,20 +1863,33 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 ARM64 lifecycle stabilization diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_stabilization_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_stabilization_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_stabilization_expected_subject="
+        subject_assignment = (
+            'v4032_stabilization_subject="$(git log -1 --format=%s '
+            '"${v4032_stabilization_ref}")"'
+        )
         end = (
             'read -r -a v4032_stabilization_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 '
+            '"${v4032_stabilization_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment,
+            'v4032_stabilization_subject="${COMMIT_SUBJECT:?}"',
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_local_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -2178,6 +2314,57 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_init_runtime_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_init_runtime_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : repair v4.03.2 ARM64 init runtime (#103)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : repair v4.03.2 ARM64 init runtime",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : repair v4.03.2 ARM64 init runtime (#102)",
+                    False,
+                ),
+                "next pull request": (
+                    "Qualification : repair v4.03.2 ARM64 init runtime (#104)",
+                    False,
+                ),
+                "wrong verb": (
+                    "Qualification : stabilize v4.03.2 ARM64 init runtime (#103)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : repair v4.03.2 ARM64 init runtime (#103) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_init_runtime_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_init_runtime_diff_script(),
+            "v4032-init-runtime-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/package_lifecycle_lab.py",
+                "scripts/ci/package_lifecycle_lab_test.py",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+                "src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go",
+            ),
+        )
+
     def test_release_manager_v4032_stabilization_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -2448,9 +2635,37 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "init runtime parent resolution": workflow.replace(
+                'v4032_init_runtime_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_init_runtime_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact init runtime parent": workflow.replace(
+                "97ebc9991fdeec293abd04444ad6600f11c30ee4",
+                "87ebc9991fdeec293abd04444ad6600f11c30ee4",
+            ),
+            "init runtime canonical subject": workflow.replace(
+                "Qualification : repair v4.03.2 ARM64 init runtime (#103)",
+                "Qualification : arbitrary v4.03.2 ARM64 init runtime (#103)",
+            ),
+            "init runtime subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "init runtime linear head": workflow.replace(
+                'v4032_init_runtime_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_init_runtime_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "stabilization reference": workflow.replace(
+                "v4032_stabilization_ref=HEAD^",
+                "v4032_stabilization_ref=HEAD^^",
+            ),
             "stabilization parent resolution": workflow.replace(
-                'v4032_stabilization_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_stabilization_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_stabilization_parent_sha="$(git rev-parse '
+                '"${v4032_stabilization_ref}^")"',
+                'v4032_stabilization_parent_sha="$(git rev-parse '
+                '"${v4032_stabilization_ref}^^")"',
             ),
             "exact stabilization parent": workflow.replace(
                 "41d7a7da2895f5d3949cc63f3e45308c03f7f93a",
@@ -2461,17 +2676,20 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : arbitrary v4.03.2 stabilization (#102)",
             ),
             "stabilization subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_stabilization_subject="$(git log -1 --format=%s '
+                '"${v4032_stabilization_ref}")"',
+                'v4032_stabilization_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "stabilization linear head": workflow.replace(
                 'v4032_stabilization_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_stabilization_ref}")"',
                 'v4032_stabilization_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "local reference": workflow.replace(
-                "v4032_local_ref=HEAD^", "v4032_local_ref=HEAD^^"
+                'v4032_local_ref="${v4032_stabilization_ref}^"',
+                'v4032_local_ref="${v4032_stabilization_ref}^^"',
             ),
             "local parent resolution": workflow.replace(
                 'v4032_local_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -425,6 +425,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(label, x64)
         self.assertIn("needs: package-lifecycle-arm64", x64)
+        self.assertIn("if: ${{ !cancelled() }}", x64)
         self.assertNotIn("environment:", x64)
         self.assertNotIn("${{ secrets.", x64)
         self.assertNotIn("SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY", x64)

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
@@ -5,8 +5,12 @@ package integration
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,11 +20,13 @@ import (
 	"syswarden-cli/config"
 	"syswarden-cli/pkg/system"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
 	managedServiceOutputLimit     = 4096
-	managedServiceEvidenceLimit   = 512
+	managedServiceEvidenceLimit   = 384
 	managedServiceDiagnosticLimit = 4096
 	managedServiceCommandTimeout  = 30 * time.Second
 	trustedPathSymlinkLimit       = 40
@@ -34,6 +40,12 @@ const (
 	trustedSemodulePackagePath = "/usr/bin/semodule_package"
 	trustedSemodulePath        = "/usr/sbin/semodule"
 	selinuxRuntimeEnforcement  = "/sys/fs/selinux/enforce"
+
+	wafRsyslogParentDirectory = "/etc"
+	wafRsyslogDirectoryName   = "rsyslog.d"
+	wafRsyslogConfigName      = "99-syswarden-waf-bridge.conf"
+	wafRsyslogConfigReadLimit = 64 * 1024
+	wafRsyslogStagingAttempts = 128
 )
 
 type managedServiceRunner func(string, ...string) ([]byte, error)
@@ -178,8 +190,6 @@ func renderWAFRsyslogConfig(rawPatterns string) (string, int, error) {
 func SetupWAFLogForwarder() error {
 	fmt.Println("[INFO] Configuring WAF Multi-Tenant Log Bridge (Rsyslog -> UDS)...")
 
-	confPath := "/etc/rsyslog.d/99-syswarden-waf-bridge.conf"
-
 	rsyslogConf, activePatterns, err := renderWAFRsyslogConfig(config.GlobalConfig.ModsecLogs)
 	if err != nil {
 		return fmt.Errorf("render WAF bridge config: %w", err)
@@ -235,17 +245,458 @@ func SetupWAFLogForwarder() error {
 		}
 	}
 
-	_ = os.MkdirAll("/etc/rsyslog.d", 0750)
-	if err := os.WriteFile(confPath, []byte(rsyslogConf), 0600); err != nil {
-		return fmt.Errorf("failed to write WAF bridge config: %w", err)
+	configChanged, publicationErr := reconcileWAFRsyslogConfig([]byte(rsyslogConf))
+	if publicationErr == nil && !configChanged {
+		fmt.Println("[INFO] WAF bridge rsyslog configuration is unchanged; runtime activation will be re-attested.")
 	}
-
-	if err := restartManagedService("rsyslog"); err != nil {
-		return fmt.Errorf("activate WAF bridge rsyslog configuration: %w", err)
+	if err := finishWAFRsyslogSetup(configChanged, publicationErr, reconcileWAFRsyslogService); err != nil {
+		return err
 	}
 
 	fmt.Println("[+] WAF Log Bridge successfully configured.")
 	return nil
+}
+
+type wafRsyslogConfigState struct {
+	exists bool
+	dev    uint64
+	ino    uint64
+	size   int64
+	mode   uint32
+	uid    uint32
+	gid    uint32
+	mtime  unix.Timespec
+	ctime  unix.Timespec
+	digest [sha256.Size]byte
+}
+
+// wafRsyslogPublicationDurabilityError means a published target directory could
+// not be synced. The caller must still activate the visible file, while a later
+// idempotent run retries the durability barrier before it can succeed.
+type wafRsyslogPublicationDurabilityError struct {
+	cause error
+}
+
+func (failure *wafRsyslogPublicationDurabilityError) Error() string { return failure.cause.Error() }
+func (failure *wafRsyslogPublicationDurabilityError) Unwrap() error { return failure.cause }
+
+func finishWAFRsyslogSetup(
+	configChanged bool,
+	publicationErr error,
+	activate func(bool) error,
+) error {
+	var durabilityErr *wafRsyslogPublicationDurabilityError
+	if publicationErr != nil && !errors.As(publicationErr, &durabilityErr) {
+		return fmt.Errorf("publish WAF bridge rsyslog configuration: %w", publicationErr)
+	}
+
+	activationErr := activate(configChanged)
+	if activationErr != nil {
+		activationErr = fmt.Errorf("activate WAF bridge rsyslog configuration: %w", activationErr)
+	}
+	if publicationErr != nil {
+		publicationErr = fmt.Errorf("publish WAF bridge rsyslog configuration: %w", publicationErr)
+	}
+	return errors.Join(publicationErr, activationErr)
+}
+
+func validateWAFRsyslogDirectoryMetadata(
+	label string,
+	stat *unix.Stat_t,
+	expectedUID, expectedGID uint32,
+) error {
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR {
+		return fmt.Errorf("%s is not a real directory", label)
+	}
+	if stat.Uid != expectedUID || stat.Gid != expectedGID {
+		return fmt.Errorf(
+			"%s must be owned by uid %d gid %d, got uid %d gid %d",
+			label, expectedUID, expectedGID, stat.Uid, stat.Gid,
+		)
+	}
+	if stat.Mode&0022 != 0 {
+		return fmt.Errorf("%s must not be group/world writable: mode %04o", label, stat.Mode&07777)
+	}
+	return nil
+}
+
+func openWAFRsyslogDirectoryAt(
+	parentPath string,
+	expectedUID, expectedGID uint32,
+) (*os.File, error) {
+	parentFD, err := unix.Open(
+		parentPath,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open anchored rsyslog parent directory %s: %w", parentPath, err)
+	}
+	defer unix.Close(parentFD)
+
+	var parentStat unix.Stat_t
+	if err := unix.Fstat(parentFD, &parentStat); err != nil {
+		return nil, fmt.Errorf("inspect anchored rsyslog parent directory %s: %w", parentPath, err)
+	}
+	if err := validateWAFRsyslogDirectoryMetadata(
+		"rsyslog parent directory "+parentPath,
+		&parentStat,
+		expectedUID,
+		expectedGID,
+	); err != nil {
+		return nil, err
+	}
+
+	created := false
+	if err := unix.Mkdirat(parentFD, wafRsyslogDirectoryName, 0750); err != nil {
+		if !errors.Is(err, unix.EEXIST) {
+			return nil, fmt.Errorf("create anchored rsyslog directory: %w", err)
+		}
+	} else {
+		created = true
+	}
+
+	directoryFD, err := unix.Openat(
+		parentFD,
+		wafRsyslogDirectoryName,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open anchored rsyslog directory without following symlinks: %w", err)
+	}
+	if created {
+		if err := unix.Fchmod(directoryFD, 0750); err != nil {
+			_ = unix.Close(directoryFD)
+			return nil, fmt.Errorf("set anchored rsyslog directory mode: %w", err)
+		}
+	}
+
+	var directoryStat unix.Stat_t
+	if err := unix.Fstat(directoryFD, &directoryStat); err != nil {
+		_ = unix.Close(directoryFD)
+		return nil, fmt.Errorf("inspect anchored rsyslog directory: %w", err)
+	}
+	if err := validateWAFRsyslogDirectoryMetadata(
+		"rsyslog directory "+filepath.Join(parentPath, wafRsyslogDirectoryName),
+		&directoryStat,
+		expectedUID,
+		expectedGID,
+	); err != nil {
+		_ = unix.Close(directoryFD)
+		return nil, err
+	}
+	// Sync on every pass so a previous post-Mkdirat sync failure is recoverable
+	// even though the directory is already visible on the next attempt.
+	if err := unix.Fsync(parentFD); err != nil {
+		_ = unix.Close(directoryFD)
+		return nil, fmt.Errorf("sync rsyslog parent directory: %w", err)
+	}
+
+	directory := os.NewFile(
+		uintptr(directoryFD),
+		filepath.Join(parentPath, wafRsyslogDirectoryName),
+	)
+	if directory == nil {
+		_ = unix.Close(directoryFD)
+		return nil, fmt.Errorf("wrap anchored rsyslog directory descriptor")
+	}
+	return directory, nil
+}
+
+func sameWAFRsyslogStat(left, right *unix.Stat_t) bool {
+	return uint64(left.Dev) == uint64(right.Dev) &&
+		uint64(left.Ino) == uint64(right.Ino) &&
+		left.Size == right.Size &&
+		left.Mode == right.Mode &&
+		left.Uid == right.Uid &&
+		left.Gid == right.Gid &&
+		left.Mtim == right.Mtim &&
+		left.Ctim == right.Ctim
+}
+
+func inspectWAFRsyslogConfig(
+	directory *os.File,
+	expectedUID, expectedGID uint32,
+) (wafRsyslogConfigState, []byte, error) {
+	fd, err := unix.Openat(
+		int(directory.Fd()),
+		wafRsyslogConfigName,
+		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if errors.Is(err, unix.ENOENT) {
+		return wafRsyslogConfigState{}, nil, nil
+	}
+	if err != nil {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf(
+			"open anchored rsyslog configuration without following symlinks: %w",
+			err,
+		)
+	}
+	file := os.NewFile(uintptr(fd), wafRsyslogConfigName)
+	if file == nil {
+		_ = unix.Close(fd)
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("wrap anchored rsyslog configuration descriptor")
+	}
+
+	var before unix.Stat_t
+	if err := unix.Fstat(fd, &before); err != nil {
+		_ = file.Close()
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("inspect rsyslog configuration: %w", err)
+	}
+	if before.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = file.Close()
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("rsyslog configuration must be a regular file")
+	}
+	if before.Uid != expectedUID || before.Gid != expectedGID {
+		_ = file.Close()
+		return wafRsyslogConfigState{}, nil, fmt.Errorf(
+			"rsyslog configuration must be owned by uid %d gid %d, got uid %d gid %d",
+			expectedUID, expectedGID, before.Uid, before.Gid,
+		)
+	}
+	if before.Mode&07777 != 0600 {
+		_ = file.Close()
+		return wafRsyslogConfigState{}, nil, fmt.Errorf(
+			"rsyslog configuration mode must be 0600, got %04o",
+			before.Mode&07777,
+		)
+	}
+	if before.Size < 0 || before.Size > wafRsyslogConfigReadLimit {
+		_ = file.Close()
+		return wafRsyslogConfigState{}, nil, fmt.Errorf(
+			"rsyslog configuration size %d exceeds limit %d",
+			before.Size,
+			wafRsyslogConfigReadLimit,
+		)
+	}
+
+	content, readErr := io.ReadAll(io.LimitReader(file, wafRsyslogConfigReadLimit+1))
+	var after unix.Stat_t
+	statErr := unix.Fstat(fd, &after)
+	closeErr := file.Close()
+	if readErr != nil {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("read bounded rsyslog configuration: %w", readErr)
+	}
+	if len(content) > wafRsyslogConfigReadLimit {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf(
+			"rsyslog configuration grew beyond limit %d while reading",
+			wafRsyslogConfigReadLimit,
+		)
+	}
+	if statErr != nil {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("reinspect rsyslog configuration: %w", statErr)
+	}
+	if closeErr != nil {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("close rsyslog configuration: %w", closeErr)
+	}
+	if !sameWAFRsyslogStat(&before, &after) || int64(len(content)) != before.Size {
+		return wafRsyslogConfigState{}, nil, fmt.Errorf("rsyslog configuration changed while reading")
+	}
+
+	return wafRsyslogConfigState{
+		exists: true,
+		dev:    uint64(after.Dev),
+		ino:    uint64(after.Ino),
+		size:   after.Size,
+		mode:   after.Mode,
+		uid:    after.Uid,
+		gid:    after.Gid,
+		mtime:  after.Mtim,
+		ctime:  after.Ctim,
+		digest: sha256.Sum256(content),
+	}, content, nil
+}
+
+func sameWAFRsyslogConfigState(expected, actual wafRsyslogConfigState) bool {
+	return expected.exists == actual.exists &&
+		expected.dev == actual.dev &&
+		expected.ino == actual.ino &&
+		expected.size == actual.size &&
+		expected.mode == actual.mode &&
+		expected.uid == actual.uid &&
+		expected.gid == actual.gid &&
+		expected.mtime == actual.mtime &&
+		expected.ctime == actual.ctime &&
+		expected.digest == actual.digest
+}
+
+func createWAFRsyslogStagingFile(
+	directory *os.File,
+	expectedUID, expectedGID uint32,
+) (*os.File, string, error) {
+	for range wafRsyslogStagingAttempts {
+		var random [16]byte
+		if _, err := cryptorand.Read(random[:]); err != nil {
+			return nil, "", fmt.Errorf("generate rsyslog staging name: %w", err)
+		}
+		name := "." + wafRsyslogConfigName + ".syswarden-" + hex.EncodeToString(random[:]) + ".tmp"
+		fd, err := unix.Openat(
+			int(directory.Fd()),
+			name,
+			unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+			0600,
+		)
+		if errors.Is(err, unix.EEXIST) {
+			continue
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("create anchored rsyslog staging file: %w", err)
+		}
+		if err := unix.Fchmod(fd, 0600); err != nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(int(directory.Fd()), name, 0)
+			return nil, "", fmt.Errorf("set rsyslog staging file mode: %w", err)
+		}
+		var stat unix.Stat_t
+		if err := unix.Fstat(fd, &stat); err != nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(int(directory.Fd()), name, 0)
+			return nil, "", fmt.Errorf("inspect rsyslog staging file: %w", err)
+		}
+		if stat.Uid != expectedUID || stat.Gid != expectedGID {
+			if err := unix.Fchown(fd, int(expectedUID), int(expectedGID)); err != nil {
+				_ = unix.Close(fd)
+				_ = unix.Unlinkat(int(directory.Fd()), name, 0)
+				return nil, "", fmt.Errorf("set rsyslog staging file owner: %w", err)
+			}
+		}
+		file := os.NewFile(uintptr(fd), name)
+		if file == nil {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(int(directory.Fd()), name, 0)
+			return nil, "", fmt.Errorf("wrap rsyslog staging file descriptor")
+		}
+		return file, name, nil
+	}
+	return nil, "", fmt.Errorf("create rsyslog staging file: too many name collisions")
+}
+
+func reconcileWAFRsyslogConfig(desired []byte) (bool, error) {
+	return reconcileWAFRsyslogConfigAt(
+		wafRsyslogParentDirectory,
+		0,
+		0,
+		desired,
+		nil,
+	)
+}
+
+func reconcileWAFRsyslogConfigAt(
+	parentPath string,
+	expectedUID, expectedGID uint32,
+	desired []byte,
+	beforeRename func() error,
+) (bool, error) {
+	return reconcileWAFRsyslogConfigAtUsing(
+		parentPath,
+		expectedUID,
+		expectedGID,
+		desired,
+		beforeRename,
+		func(directory *os.File) error { return directory.Sync() },
+	)
+}
+
+func reconcileWAFRsyslogConfigAtUsing(
+	parentPath string,
+	expectedUID, expectedGID uint32,
+	desired []byte,
+	beforeRename func() error,
+	syncDirectory func(*os.File) error,
+) (bool, error) {
+	if len(desired) > wafRsyslogConfigReadLimit {
+		return false, fmt.Errorf(
+			"desired rsyslog configuration size %d exceeds limit %d",
+			len(desired),
+			wafRsyslogConfigReadLimit,
+		)
+	}
+	directory, err := openWAFRsyslogDirectoryAt(parentPath, expectedUID, expectedGID)
+	if err != nil {
+		return false, err
+	}
+	defer directory.Close()
+
+	initial, existing, err := inspectWAFRsyslogConfig(directory, expectedUID, expectedGID)
+	if err != nil {
+		return false, err
+	}
+	if initial.exists && bytes.Equal(existing, desired) {
+		// Retrying this sync closes a prior crash or fsync-failure window after
+		// Renameat. Exact content is not durable until this directory sync passes.
+		if err := syncDirectory(directory); err != nil {
+			return false, &wafRsyslogPublicationDurabilityError{
+				cause: fmt.Errorf("sync unchanged rsyslog configuration directory: %w", err),
+			}
+		}
+		return false, nil
+	}
+
+	staging, stagingName, err := createWAFRsyslogStagingFile(directory, expectedUID, expectedGID)
+	if err != nil {
+		return true, err
+	}
+	defer func() {
+		if staging != nil {
+			_ = staging.Close()
+		}
+		if stagingName != "" {
+			_ = unix.Unlinkat(int(directory.Fd()), stagingName, 0)
+		}
+	}()
+
+	if written, err := staging.Write(desired); err != nil {
+		return true, fmt.Errorf("write rsyslog staging file: %w", err)
+	} else if written != len(desired) {
+		return true, fmt.Errorf("write rsyslog staging file: %w", io.ErrShortWrite)
+	}
+	if err := staging.Sync(); err != nil {
+		return true, fmt.Errorf("sync rsyslog staging file: %w", err)
+	}
+	if err := staging.Close(); err != nil {
+		return true, fmt.Errorf("close rsyslog staging file: %w", err)
+	}
+	staging = nil
+
+	if beforeRename != nil {
+		if err := beforeRename(); err != nil {
+			return true, err
+		}
+	}
+	current, _, err := inspectWAFRsyslogConfig(directory, expectedUID, expectedGID)
+	if err != nil {
+		return true, fmt.Errorf("reinspect rsyslog configuration before publication: %w", err)
+	}
+	if !sameWAFRsyslogConfigState(initial, current) {
+		return true, fmt.Errorf("rsyslog configuration changed before publication")
+	}
+	if err := unix.Renameat(
+		int(directory.Fd()),
+		stagingName,
+		int(directory.Fd()),
+		wafRsyslogConfigName,
+	); err != nil {
+		return true, fmt.Errorf("atomically publish rsyslog configuration: %w", err)
+	}
+	stagingName = ""
+	if err := syncDirectory(directory); err != nil {
+		return true, &wafRsyslogPublicationDurabilityError{
+			cause: fmt.Errorf("sync rsyslog configuration directory after publication: %w", err),
+		}
+	}
+	return true, nil
+}
+
+func reconcileWAFRsyslogService(configChanged bool) error {
+	return restartManagedServiceUsingConfigState(
+		"rsyslog",
+		configChanged,
+		system.ServiceManagerRuntimeState,
+		system.IsAlpine,
+		runManagedServiceCommand,
+	)
 }
 
 func restartManagedService(service string) error {
@@ -489,6 +940,16 @@ func restartManagedServiceUsing(
 	isAlpine func() bool,
 	run managedServiceRunner,
 ) error {
+	return restartManagedServiceUsingConfigState(service, true, classify, isAlpine, run)
+}
+
+func restartManagedServiceUsingConfigState(
+	service string,
+	_ bool,
+	classify func() (string, error),
+	isAlpine func() bool,
+	run managedServiceRunner,
+) error {
 	state, err := classify()
 	if err != nil {
 		return err
@@ -502,17 +963,18 @@ func restartManagedServiceUsing(
 			if service == "rsyslog" {
 				// The firewall OpenRC service needs rsyslog and invokes the reload
 				// pipeline during start. Stopping that dependency here creates a
-				// circular OpenRC wait. Rsyslog on Alpine does not apply new rules
-				// after its nominal reload action, so restart it without traversing
-				// the dependency graph after validating the complete configuration.
+				// circular OpenRC wait. Alpine's nominal rsyslog reload does not apply
+				// new rules, so every valid setup attempt performs one bounded nodeps
+				// restart. This also recovers a crash after atomic publication but
+				// before service activation.
 				if _, err := run(trustedRsyslogdPath, "-N1", "-f", "/etc/rsyslog.conf"); err != nil {
-					return fmt.Errorf("validate rsyslog configuration before OpenRC restart: %w", err)
+					return fmt.Errorf("validate rsyslog configuration before OpenRC activation: %w", err)
 				}
 				if _, err := run(trustedOpenRCServicePath, "--ifnotstarted", service, "start"); err != nil {
 					return fmt.Errorf("conditionally start OpenRC service %s with dependencies: %w", service, err)
 				}
 				if _, err := run(trustedOpenRCServicePath, service, "status"); err != nil {
-					return fmt.Errorf("attest active OpenRC service %s before dependency-bypassing restart: %w", service, err)
+					return fmt.Errorf("attest active OpenRC service %s before configuration reconciliation: %w", service, err)
 				}
 				if _, err := run(trustedOpenRCServicePath, "--nodeps", service, "restart"); err != nil {
 					return fmt.Errorf("restart OpenRC service %s without dependency traversal: %w", service, err)
@@ -546,11 +1008,33 @@ func restartSystemdRsyslogUsing(run managedServiceRunner) error {
 	if validationErr != nil {
 		return newManagedServiceDiagnosticError(
 			fmt.Sprintf(
-				"validate complete rsyslog configuration before systemd restart: %s",
+				"validate complete rsyslog configuration before systemd activation: %s",
 				managedServiceEvidence(validationErr, validationOutput),
 			),
 			validationErr,
 		)
+	}
+
+	initialActiveOutput, initialActiveErr := run(
+		trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
+	)
+	reloadEvidence := "not-attempted"
+	reloadActiveEvidence := "not-attempted"
+	var reloadErr, reloadActiveErr error
+	if initialActiveErr == nil {
+		// Reload even exact content to recover a crash after atomic publication
+		// but before the previous setup attempt reached service activation.
+		reloadOutput, currentReloadErr := run(trustedSystemctlPath, "reload", "rsyslog")
+		reloadErr = currentReloadErr
+		reloadEvidence = managedServiceEvidence(reloadErr, reloadOutput)
+		reloadActiveOutput, currentReloadActiveErr := run(
+			trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
+		)
+		reloadActiveErr = currentReloadActiveErr
+		reloadActiveEvidence = managedServiceEvidence(reloadActiveErr, reloadActiveOutput)
+		if reloadErr == nil && reloadActiveErr == nil {
+			return nil
+		}
 	}
 
 	firstOutput, firstErr := run(trustedSystemctlPath, "restart", "rsyslog")
@@ -558,6 +1042,7 @@ func restartSystemdRsyslogUsing(run managedServiceRunner) error {
 		trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
 	)
 	if firstErr == nil && firstActiveErr == nil {
+		fmt.Println("[WARN] Rsyslog required one bounded restart fallback after reload or active-state attestation.")
 		return nil
 	}
 
@@ -567,7 +1052,7 @@ func restartSystemdRsyslogUsing(run managedServiceRunner) error {
 		trustedSystemctlPath, "is-active", "--quiet", "rsyslog",
 	)
 	if retryErr == nil && retryActiveErr == nil {
-		fmt.Println("[WARN] Initial rsyslog restart failed; recovered after one bounded retry.")
+		fmt.Println("[WARN] Initial rsyslog restart or active-state attestation failed; recovered after one bounded retry.")
 		return nil
 	}
 
@@ -576,7 +1061,10 @@ func restartSystemdRsyslogUsing(run managedServiceRunner) error {
 	)
 	return newManagedServiceDiagnosticError(
 		fmt.Sprintf(
-			"restart systemd service rsyslog failed after one bounded retry: first_restart=%s; first_active=%s; reset_failed=%s; retry_restart=%s; retry_active=%s; journal=%s",
+			"activate systemd service rsyslog failed after one bounded retry following reload or active-state attestation: initial_active=%s; reload=%s; reload_active=%s; first_restart=%s; first_active=%s; reset_failed=%s; retry_restart=%s; retry_active=%s; journal=%s",
+			managedServiceEvidence(initialActiveErr, initialActiveOutput),
+			reloadEvidence,
+			reloadActiveEvidence,
 			managedServiceEvidence(firstErr, firstOutput),
 			managedServiceEvidence(firstActiveErr, firstActiveOutput),
 			managedServiceEvidence(resetErr, resetOutput),
@@ -584,6 +1072,9 @@ func restartSystemdRsyslogUsing(run managedServiceRunner) error {
 			managedServiceEvidence(retryActiveErr, retryActiveOutput),
 			managedServiceEvidence(journalErr, journalOutput),
 		),
+		initialActiveErr,
+		reloadErr,
+		reloadActiveErr,
 		firstErr,
 		firstActiveErr,
 		resetErr,

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux_test.go
@@ -5,12 +5,16 @@ package integration
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestPrivateSELinuxPolicyWorkspaceUsesPrivateUniqueDirectory(t *testing.T) {
@@ -413,6 +417,497 @@ func TestManagedServiceDiagnosticCapsPostEscapingAndPreservesTypedCause(t *testi
 	}
 }
 
+func wafRsyslogTestOwner(t *testing.T) (uint32, uint32) {
+	t.Helper()
+	info, err := os.Stat(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("temporary directory has no Linux stat metadata")
+	}
+	return stat.Uid, stat.Gid
+}
+
+func wafRsyslogTestConfigPath(parent string) string {
+	return filepath.Join(parent, wafRsyslogDirectoryName, wafRsyslogConfigName)
+}
+
+func readWAFRsyslogTestFile(t *testing.T, parent, name string) []byte {
+	t.Helper()
+	root, err := os.OpenRoot(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	file, err := root.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	return content
+}
+
+func writeWAFRsyslogTestConfig(t *testing.T, parent string, content []byte, mode os.FileMode) string {
+	t.Helper()
+	directory := filepath.Join(parent, wafRsyslogDirectoryName)
+	if err := os.Mkdir(directory, 0750); err != nil && !errors.Is(err, os.ErrExist) {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, wafRsyslogConfigName)
+	if err := os.WriteFile(path, content, mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func assertNoWAFRsyslogStagingFiles(t *testing.T, parent string) {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(parent, wafRsyslogDirectoryName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "."+wafRsyslogConfigName+".syswarden-") {
+			t.Fatalf("rsyslog staging file was not cleaned up: %s", entry.Name())
+		}
+	}
+}
+
+func TestReconcileWAFRsyslogConfigPublishesSecurelyAndIsIdempotent(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := wafRsyslogTestOwner(t)
+	desired := []byte("managed\n")
+
+	changed, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, desired, nil)
+	if err != nil {
+		t.Fatalf("first reconcileWAFRsyslogConfigAt() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("first reconciliation did not report a configuration change")
+	}
+	path := wafRsyslogTestConfigPath(parent)
+	content := readWAFRsyslogTestFile(
+		t,
+		parent,
+		filepath.Join(wafRsyslogDirectoryName, wafRsyslogConfigName),
+	)
+	if string(content) != string(desired) {
+		t.Fatalf("published configuration = %q, want %q", content, desired)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStat, ok := before.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("published configuration has no Linux stat metadata")
+	}
+	if !before.Mode().IsRegular() || before.Mode().Perm() != 0600 {
+		t.Fatalf("published configuration mode = %v, want regular 0600", before.Mode())
+	}
+	if beforeStat.Uid != uid || beforeStat.Gid != gid {
+		t.Fatalf(
+			"published configuration owner = %d:%d, want %d:%d",
+			beforeStat.Uid, beforeStat.Gid, uid, gid,
+		)
+	}
+	assertNoWAFRsyslogStagingFiles(t, parent)
+
+	changed, err = reconcileWAFRsyslogConfigAt(parent, uid, gid, desired, nil)
+	if err != nil {
+		t.Fatalf("idempotent reconcileWAFRsyslogConfigAt() error = %v", err)
+	}
+	if changed {
+		t.Fatal("identical configuration was reported as changed")
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStat, ok := after.Sys().(*syscall.Stat_t)
+	if !ok || beforeStat.Dev != afterStat.Dev || beforeStat.Ino != afterStat.Ino {
+		t.Fatal("identical configuration was unexpectedly replaced")
+	}
+}
+
+func TestReconcileWAFRsyslogConfigRejectsFileSymlinks(t *testing.T) {
+	uid, gid := wafRsyslogTestOwner(t)
+	for _, test := range []struct {
+		name        string
+		dangling    bool
+		wantOutside string
+	}{
+		{name: "symlink", wantOutside: "outside\n"},
+		{name: "dangling symlink", dangling: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parent := t.TempDir()
+			directory := filepath.Join(parent, wafRsyslogDirectoryName)
+			if err := os.Mkdir(directory, 0750); err != nil {
+				t.Fatal(err)
+			}
+			outside := filepath.Join(parent, "outside.conf")
+			if !test.dangling {
+				if err := os.WriteFile(outside, []byte(test.wantOutside), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.Symlink(outside, wafRsyslogTestConfigPath(parent)); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil {
+				t.Fatal("symlink configuration was accepted")
+			}
+			info, err := os.Lstat(wafRsyslogTestConfigPath(parent))
+			if err != nil || info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("managed symlink was modified: info=%v error=%v", info, err)
+			}
+			if !test.dangling {
+				content := readWAFRsyslogTestFile(t, parent, "outside.conf")
+				if string(content) != test.wantOutside {
+					t.Fatalf("symlink target was modified: content=%q", content)
+				}
+			}
+			assertNoWAFRsyslogStagingFiles(t, parent)
+		})
+	}
+}
+
+func TestReconcileWAFRsyslogConfigRejectsSymlinkedOrMutableDirectory(t *testing.T) {
+	uid, gid := wafRsyslogTestOwner(t)
+	t.Run("symlink", func(t *testing.T) {
+		parent := t.TempDir()
+		outside := t.TempDir()
+		if err := os.Symlink(outside, filepath.Join(parent, wafRsyslogDirectoryName)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil {
+			t.Fatal("symlinked rsyslog directory was accepted")
+		}
+		entries, err := os.ReadDir(outside)
+		if err != nil || len(entries) != 0 {
+			t.Fatalf("symlinked directory was modified: entries=%v error=%v", entries, err)
+		}
+	})
+	t.Run("group/world writable", func(t *testing.T) {
+		parent := t.TempDir()
+		directory := filepath.Join(parent, wafRsyslogDirectoryName)
+		if err := os.Mkdir(directory, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := unix.Chmod(directory, 0777); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil ||
+			!strings.Contains(err.Error(), "group/world writable") {
+			t.Fatalf("mutable rsyslog directory error = %v", err)
+		}
+	})
+}
+
+func TestReconcileWAFRsyslogConfigRejectsUnsafeMetadataAndOversize(t *testing.T) {
+	uid, gid := wafRsyslogTestOwner(t)
+	t.Run("fifo", func(t *testing.T) {
+		parent := t.TempDir()
+		directory := filepath.Join(parent, wafRsyslogDirectoryName)
+		if err := os.Mkdir(directory, 0750); err != nil {
+			t.Fatal(err)
+		}
+		path := wafRsyslogTestConfigPath(parent)
+		if err := unix.Mkfifo(path, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil ||
+			!strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("FIFO rsyslog configuration error = %v", err)
+		}
+	})
+	t.Run("mode", func(t *testing.T) {
+		parent := t.TempDir()
+		writeWAFRsyslogTestConfig(t, parent, []byte("old\n"), 0644)
+		if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil ||
+			!strings.Contains(err.Error(), "mode must be 0600") {
+			t.Fatalf("unsafe rsyslog mode error = %v", err)
+		}
+		content := readWAFRsyslogTestFile(
+			t,
+			parent,
+			filepath.Join(wafRsyslogDirectoryName, wafRsyslogConfigName),
+		)
+		if string(content) != "old\n" {
+			t.Fatalf("unsafe-mode file was modified: content=%q", content)
+		}
+	})
+	t.Run("owner", func(t *testing.T) {
+		parent := t.TempDir()
+		writeWAFRsyslogTestConfig(t, parent, []byte("old\n"), 0600)
+		root, err := os.OpenRoot(parent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer root.Close()
+		directory, err := root.Open(wafRsyslogDirectoryName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer directory.Close()
+		unexpectedUID := uid + 1
+		if unexpectedUID == uid {
+			unexpectedUID = uid - 1
+		}
+		if _, _, err := inspectWAFRsyslogConfig(directory, unexpectedUID, gid); err == nil ||
+			!strings.Contains(err.Error(), "must be owned") {
+			t.Fatalf("unsafe rsyslog owner error = %v", err)
+		}
+	})
+	t.Run("oversize", func(t *testing.T) {
+		parent := t.TempDir()
+		path := writeWAFRsyslogTestConfig(
+			t,
+			parent,
+			[]byte(strings.Repeat("x", wafRsyslogConfigReadLimit+1)),
+			0600,
+		)
+		if _, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("managed\n"), nil); err == nil ||
+			!strings.Contains(err.Error(), "exceeds limit") {
+			t.Fatalf("oversize rsyslog configuration error = %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.Size() != wafRsyslogConfigReadLimit+1 {
+			t.Fatalf("oversize rsyslog file was modified: info=%v error=%v", info, err)
+		}
+	})
+}
+
+func TestReconcileWAFRsyslogConfigFailureBeforeRenamePreservesDestinationAndCleansStage(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := wafRsyslogTestOwner(t)
+	path := writeWAFRsyslogTestConfig(t, parent, []byte("old\n"), 0600)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStat := before.Sys().(*syscall.Stat_t)
+	sentinel := errors.New("synthetic pre-publication failure")
+	stagingObserved := false
+
+	changed, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("new\n"), func() error {
+		entries, readErr := os.ReadDir(filepath.Join(parent, wafRsyslogDirectoryName))
+		if readErr != nil {
+			return readErr
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), "."+wafRsyslogConfigName+".syswarden-") {
+				continue
+			}
+			stagingObserved = true
+			info, statErr := entry.Info()
+			if statErr != nil {
+				return statErr
+			}
+			stat := info.Sys().(*syscall.Stat_t)
+			if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 || stat.Uid != uid || stat.Gid != gid {
+				t.Fatalf("staging metadata = mode %v owner %d:%d, want regular 0600 %d:%d", info.Mode(), stat.Uid, stat.Gid, uid, gid)
+			}
+		}
+		return sentinel
+	})
+	if !changed || !errors.Is(err, sentinel) {
+		t.Fatalf("pre-publication result = changed %v error %v, want true and sentinel", changed, err)
+	}
+	if !stagingObserved {
+		t.Fatal("pre-publication hook did not observe a staging file")
+	}
+	content := readWAFRsyslogTestFile(
+		t,
+		parent,
+		filepath.Join(wafRsyslogDirectoryName, wafRsyslogConfigName),
+	)
+	if string(content) != "old\n" {
+		t.Fatalf("destination was truncated before rename: content=%q", content)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStat := after.Sys().(*syscall.Stat_t)
+	if beforeStat.Dev != afterStat.Dev || beforeStat.Ino != afterStat.Ino {
+		t.Fatal("destination inode changed before atomic publication")
+	}
+	assertNoWAFRsyslogStagingFiles(t, parent)
+}
+
+func TestReconcileWAFRsyslogConfigDetectsDestinationReplacementBeforeRename(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := wafRsyslogTestOwner(t)
+	path := writeWAFRsyslogTestConfig(t, parent, []byte("old\n"), 0600)
+	replacement := filepath.Join(parent, "replacement.conf")
+	if err := os.WriteFile(replacement, []byte("replacement\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, []byte("new\n"), func() error {
+		return os.Rename(replacement, path)
+	})
+	if !changed || err == nil || !strings.Contains(err.Error(), "changed before publication") {
+		t.Fatalf("replacement race result = changed %v error %v", changed, err)
+	}
+	content := readWAFRsyslogTestFile(
+		t,
+		parent,
+		filepath.Join(wafRsyslogDirectoryName, wafRsyslogConfigName),
+	)
+	if string(content) != "replacement\n" {
+		t.Fatalf("replacement race overwrote current destination: content=%q", content)
+	}
+	assertNoWAFRsyslogStagingFiles(t, parent)
+}
+
+func TestWAFRsyslogDirectorySyncFailureIsRetriedForExactContent(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := wafRsyslogTestOwner(t)
+	sentinel := errors.New("synthetic directory sync failure")
+	desired := []byte("managed\n")
+	syncCalls := 0
+	syncDirectory := func(*os.File) error {
+		syncCalls++
+		if syncCalls <= 2 {
+			return sentinel
+		}
+		return nil
+	}
+
+	changed, firstErr := reconcileWAFRsyslogConfigAtUsing(
+		parent,
+		uid,
+		gid,
+		desired,
+		nil,
+		syncDirectory,
+	)
+	var durabilityErr *wafRsyslogPublicationDurabilityError
+	if !changed || syncCalls != 1 || !errors.Is(firstErr, sentinel) || !errors.As(firstErr, &durabilityErr) {
+		t.Fatalf("post-rename sync result = changed %v calls %d error %v", changed, syncCalls, firstErr)
+	}
+	content := readWAFRsyslogTestFile(
+		t,
+		parent,
+		filepath.Join(wafRsyslogDirectoryName, wafRsyslogConfigName),
+	)
+	if string(content) != string(desired) {
+		t.Fatalf("configuration was not atomically published before sync failure: content=%q", content)
+	}
+	before, err := os.Stat(wafRsyslogTestConfigPath(parent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeStat := before.Sys().(*syscall.Stat_t)
+
+	changed, retryErr := reconcileWAFRsyslogConfigAtUsing(
+		parent,
+		uid,
+		gid,
+		desired,
+		nil,
+		syncDirectory,
+	)
+	durabilityErr = nil
+	if changed || syncCalls != 2 || !errors.Is(retryErr, sentinel) || !errors.As(retryErr, &durabilityErr) {
+		t.Fatalf("exact-content retry result = changed %v calls %d error %v", changed, syncCalls, retryErr)
+	}
+
+	activationCalled := false
+	err = finishWAFRsyslogSetup(changed, retryErr, func(gotChanged bool) error {
+		activationCalled = true
+		if gotChanged {
+			t.Fatal("exact-content recovery unexpectedly reported a replacement")
+		}
+		return nil
+	})
+	if !activationCalled || !errors.Is(err, sentinel) {
+		t.Fatalf("exact-content durability activation result = called %v error %v", activationCalled, err)
+	}
+
+	changed, err = reconcileWAFRsyslogConfigAtUsing(
+		parent,
+		uid,
+		gid,
+		desired,
+		nil,
+		syncDirectory,
+	)
+	if changed || err != nil || syncCalls != 3 {
+		t.Fatalf("successful durability retry = changed %v calls %d error %v", changed, syncCalls, err)
+	}
+	after, err := os.Stat(wafRsyslogTestConfigPath(parent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterStat := after.Sys().(*syscall.Stat_t)
+	if beforeStat.Dev != afterStat.Dev || beforeStat.Ino != afterStat.Ino {
+		t.Fatal("exact-content durability retries unexpectedly replaced the target")
+	}
+	assertNoWAFRsyslogStagingFiles(t, parent)
+}
+
+func TestWAFRsyslogExactContentRetryActivatesAfterInterruptedPublication(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := wafRsyslogTestOwner(t)
+	desired := []byte("managed\n")
+
+	changed, err := reconcileWAFRsyslogConfigAt(parent, uid, gid, desired, nil)
+	if !changed || err != nil {
+		t.Fatalf("initial publication = changed %v error %v", changed, err)
+	}
+	// Simulate termination after durable Renameat but before finishWAFRsyslogSetup.
+	changed, err = reconcileWAFRsyslogConfigAt(parent, uid, gid, desired, nil)
+	if changed || err != nil {
+		t.Fatalf("exact-content recovery = changed %v error %v", changed, err)
+	}
+
+	var calls []string
+	err = finishWAFRsyslogSetup(changed, err, func(gotChanged bool) error {
+		if gotChanged {
+			t.Fatal("exact-content recovery unexpectedly reported a replacement")
+		}
+		return restartManagedServiceUsingConfigState(
+			"rsyslog",
+			gotChanged,
+			func() (string, error) { return "ACTIVE", nil },
+			func() bool { return false },
+			func(name string, args ...string) ([]byte, error) {
+				calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+				return nil, nil
+			},
+		)
+	})
+	if err != nil {
+		t.Fatalf("exact-content recovery activation error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reload rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("interrupted-publication recovery calls = %q, want %q", got, want)
+	}
+}
+
 func TestRestartManagedServiceUsesOpenRCNodepsRestartForRsyslog_SW_PKG_001(t *testing.T) {
 	var calls []string
 	err := restartManagedServiceUsing(
@@ -439,6 +934,33 @@ func TestRestartManagedServiceUsesOpenRCNodepsRestartForRsyslog_SW_PKG_001(t *te
 	}
 }
 
+func TestRestartManagedServiceRestartsExactContentOpenRCRsyslogAfterInterruptedSetup_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsingConfigState(
+		"rsyslog",
+		false,
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return true },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsingConfigState() error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/sbin/rc-service --ifnotstarted rsyslog start",
+		"/sbin/rc-service rsyslog status",
+		"/sbin/rc-service --nodeps rsyslog restart",
+		"/sbin/rc-service rsyslog status",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("exact-content OpenRC recovery calls = %q, want %q", got, want)
+	}
+}
+
 func TestRestartManagedServiceKeepsOpenRCRestartForOtherServices_SW_PKG_001(t *testing.T) {
 	var calls []string
 	err := restartManagedServiceUsing(
@@ -458,7 +980,7 @@ func TestRestartManagedServiceKeepsOpenRCRestartForOtherServices_SW_PKG_001(t *t
 	}
 }
 
-func TestRestartManagedServiceValidatesAndAttestsSystemdRsyslog_SW_PKG_001(t *testing.T) {
+func TestRestartManagedServiceReloadsAndAttestsActiveSystemdRsyslog_SW_PKG_001(t *testing.T) {
 	var calls []string
 	err := restartManagedServiceUsing(
 		"rsyslog",
@@ -474,11 +996,109 @@ func TestRestartManagedServiceValidatesAndAttestsSystemdRsyslog_SW_PKG_001(t *te
 	}
 	want := strings.Join([]string{
 		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
-		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reload rsyslog",
 		"/usr/bin/systemctl is-active --quiet rsyslog",
 	}, "\n")
 	if got := strings.Join(calls, "\n"); got != want {
 		t.Fatalf("service-manager calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceReloadsExactContentSystemdRsyslogAfterInterruptedSetup_SW_PKG_001(t *testing.T) {
+	var calls []string
+	err := restartManagedServiceUsingConfigState(
+		"rsyslog",
+		false,
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsingConfigState() error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reload rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("exact-content systemd recovery calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceActivatesUnchangedInactiveSystemdRsyslog_SW_PKG_001(t *testing.T) {
+	sentinel := errors.New("synthetic inactive state")
+	var calls []string
+	err := restartManagedServiceUsingConfigState(
+		"rsyslog",
+		false,
+		func() (string, error) { return "ACTIVE", nil },
+		func() bool { return false },
+		func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			if len(calls) == 2 {
+				return []byte("inactive\n"), sentinel
+			}
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("restartManagedServiceUsingConfigState() activation error = %v", err)
+	}
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	if got := strings.Join(calls, "\n"); got != want {
+		t.Fatalf("inactive-service calls = %q, want %q", got, want)
+	}
+}
+
+func TestRestartManagedServiceFallsBackAfterSystemdRsyslogReloadOrAttestationFailure_SW_PKG_001(t *testing.T) {
+	want := strings.Join([]string{
+		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl reload rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+		"/usr/bin/systemctl restart rsyslog",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
+	}, "\n")
+	for _, tt := range []struct {
+		name        string
+		failureCall int
+	}{
+		{name: "reload failure", failureCall: 3},
+		{name: "active attestation failure", failureCall: 4},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sentinel := errors.New("synthetic reload activation failure")
+			var calls []string
+			err := restartManagedServiceUsing(
+				"rsyslog",
+				func() (string, error) { return "ACTIVE", nil },
+				func() bool { return false },
+				func(name string, args ...string) ([]byte, error) {
+					calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+					if len(calls) == tt.failureCall {
+						return []byte("activation failed"), sentinel
+					}
+					return nil, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("restartManagedServiceUsing() fallback error = %v", err)
+			}
+			if got := strings.Join(calls, "\n"); got != want {
+				t.Fatalf("reload-fallback calls = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -493,8 +1113,10 @@ func TestRestartManagedServiceRetriesSystemdRsyslogExactlyOnce_SW_PKG_001(t *tes
 			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
 			switch len(calls) {
 			case 2:
-				return []byte("first restart output"), sentinel
+				return []byte("inactive\n"), sentinel
 			case 3:
+				return []byte("first restart output"), sentinel
+			case 4:
 				return []byte("failed\n"), sentinel
 			default:
 				return nil, nil
@@ -506,6 +1128,7 @@ func TestRestartManagedServiceRetriesSystemdRsyslogExactlyOnce_SW_PKG_001(t *tes
 	}
 	want := strings.Join([]string{
 		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
 		"/usr/bin/systemctl restart rsyslog",
 		"/usr/bin/systemctl is-active --quiet rsyslog",
 		"/usr/bin/systemctl reset-failed rsyslog",
@@ -564,6 +1187,7 @@ func TestRestartManagedServiceBoundsTerminalSystemdRsyslogEvidence_SW_PKG_001(t 
 	}
 	want := strings.Join([]string{
 		"/usr/sbin/rsyslogd -N1 -f /etc/rsyslog.conf",
+		"/usr/bin/systemctl is-active --quiet rsyslog",
 		"/usr/bin/systemctl restart rsyslog",
 		"/usr/bin/systemctl is-active --quiet rsyslog",
 		"/usr/bin/systemctl reset-failed rsyslog",
@@ -659,7 +1283,7 @@ func TestRestartManagedServiceFailsClosedOnUnknownStateAndRunnerError_SW_PKG_001
 			name:          "configuration validation failure",
 			failCall:      1,
 			wantCalls:     1,
-			wantErrorText: "validate rsyslog configuration before OpenRC restart",
+			wantErrorText: "validate rsyslog configuration before OpenRC activation",
 		},
 		{
 			name:          "conditional start failure",
@@ -671,7 +1295,7 @@ func TestRestartManagedServiceFailsClosedOnUnknownStateAndRunnerError_SW_PKG_001
 			name:          "pre-restart active-state failure",
 			failCall:      3,
 			wantCalls:     3,
-			wantErrorText: "attest active OpenRC service rsyslog before dependency-bypassing restart",
+			wantErrorText: "attest active OpenRC service rsyslog before configuration reconciliation",
 		},
 		{
 			name:          "nodeps restart failure",


### PR DESCRIPTION
## Summary

- Repair the sealed ARM64 Alpine lifecycle path by making rsyslog readiness explicit before package transitions while keeping runtime attestation fail closed.
- Scope the AlmaLinux workaround to the exact RPM upgrade and rollback transition from v4.02.8 to v4.03.2 under rootless systemd.
- Harden WAF rsyslog configuration publication against symlinks, FIFOs, unsafe metadata, oversized input, concurrent replacement, partial writes, and publication durability failures.
- Keep hosted x64 qualification evidence running after a sealed ARM64 failure so one attempt reports every independent blocker without relaxing any release verdict.
- Update the v4.03.2 release contract for one exact PR103 commit on top of PR102.

## Root causes closed

- Alpine could enter the package transition with rsyslog stopped even though the active OpenRC namespace was otherwise ready.
- The historical AlmaLinux v4.02.8 scriptlet restart conflicts with the rootless delegated cgroup boundary although the same rsyslog process remains healthy.
- Exact rsyslog file content was not enough to prove either directory-entry durability or activation after an interruption between atomic publication and service reload.

## Safety properties

- No SELinux, capability, seccomp, no-new-privileges, or release-gate weakening.
- Atomic descriptor-anchored publication under `/etc/rsyslog.d`, with `O_NOFOLLOW`, bounded reads, root ownership, mode `0600`, file and directory synchronization, and fail-closed race detection.
- Systemd validates, reloads, and re-attests rsyslog, with one bounded restart recovery path only when required.
- OpenRC validates, conditionally starts, attests, performs the required dependency-free restart, and re-attests.
- A failed post-rename directory sync remains visible, activates the published configuration, and must pass a later durability retry before setup can succeed.

## Validation

- 336 package and release validator tests passed.
- Go integration tests passed normally and with the race detector.
- `go vet` passed.
- gosec scanned production and test code with zero issues.
- The nosec baseline is unchanged: 56 reviewed legacy suppressions and no new or moved unqualified suppression.
- Real Alpine OpenRC readiness recovery passed.
- Real AlmaLinux rootless systemd transition evidence passed.
- Independent security review found no remaining P0 or P1 blocker.

## Exact commit contract

- Parent: `97ebc9991fdeec293abd04444ad6600f11c30ee4`
- Commit subject after squash: `Qualification : repair v4.03.2 ARM64 init runtime (#103)`
- Exactly eight modified `100644` files, as enforced by the release manager and its regression tests.
