### PR TITLE
Qualification : seal systemd-capable ARM64 crun runtime

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,185 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_crun_parent_sha="$(git rev-parse HEAD^)"
+              v4032_systemd_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_systemd_parent_sha}" != "540bab73a477c76d6301d276383602db06d36acd" ]]; then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction is not based on the reviewed PR105 squash." >&2
+                exit 1
+              fi
+              v4032_systemd_expected_subject='Qualification : seal systemd-capable ARM64 crun runtime (#109)'
+              if [[ "${commit_subject}" != "${v4032_systemd_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_systemd_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
+              expected_v4032_systemd_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_systemd_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_systemd_diff[@]} != ${#expected_v4032_systemd_diff[@]} )); then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_systemd_diff[@]}; index++)); do
+                if [[ "${actual_v4032_systemd_diff[index]}" != "${expected_v4032_systemd_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_systemd_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_systemd_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 systemd-capable ARM64 crun runtime correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
+              v4032_cli_toml_ref=HEAD^
+              v4032_cli_toml_parent_sha="$(git rev-parse "${v4032_cli_toml_ref}^")"
+              if [[ "${v4032_cli_toml_parent_sha}" != "4eacbae34561ae09611a7adb1f78717ca56e52a6" ]]; then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update is not based on the reviewed PR106 squash." >&2
+                exit 1
+              fi
+              v4032_cli_toml_expected_subject='Bump github.com/pelletier/go-toml/v2 in /src/core/syswarden-cli (#105)'
+              v4032_cli_toml_subject="$(git log -1 --format=%s "${v4032_cli_toml_ref}")"
+              if [[ "${v4032_cli_toml_subject}" != "${v4032_cli_toml_expected_subject}" ]]; then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_cli_toml_head_line <<< "$(git rev-list --parents -n 1 "${v4032_cli_toml_ref}")"
+              if (( ${#v4032_cli_toml_head_line[@]} != 2 )); then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 syswarden-cli go-toml dependency diff contract
+              expected_v4032_cli_toml_diff=(
+                M "src/core/syswarden-cli/go.mod"
+                M "src/core/syswarden-cli/go.sum"
+              )
+              mapfile -d '' -t actual_v4032_cli_toml_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_cli_toml_ref}^" "${v4032_cli_toml_ref}"
+              )
+              if (( ${#actual_v4032_cli_toml_diff[@]} != ${#expected_v4032_cli_toml_diff[@]} )); then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_cli_toml_diff[@]}; index++)); do
+                if [[ "${actual_v4032_cli_toml_diff[index]}" != "${expected_v4032_cli_toml_diff[index]}" ]]; then
+                  echo "ERROR: the reviewed syswarden-cli go-toml dependency update contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_cli_toml_paths=(
+                "src/core/syswarden-cli/go.mod"
+                "src/core/syswarden-cli/go.sum"
+              )
+              for tree_ref in "${v4032_cli_toml_ref}^" "${v4032_cli_toml_ref}"; do
+                for fix_path in "${v4032_cli_toml_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed syswarden-cli go-toml dependency ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 syswarden-cli go-toml dependency diff contract
+              v4032_core_toml_ref=HEAD^^
+              v4032_core_toml_parent_sha="$(git rev-parse "${v4032_core_toml_ref}^")"
+              if [[ "${v4032_core_toml_parent_sha}" != "3513acaee928cdd0aa235024f6ebfc5b2efe1dff" ]]; then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update is not based on the reviewed PR108 squash." >&2
+                exit 1
+              fi
+              v4032_core_toml_expected_subject='Bump github.com/pelletier/go-toml/v2 in /src/core/syswarden-core (#106)'
+              v4032_core_toml_subject="$(git log -1 --format=%s "${v4032_core_toml_ref}")"
+              if [[ "${v4032_core_toml_subject}" != "${v4032_core_toml_expected_subject}" ]]; then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_core_toml_head_line <<< "$(git rev-list --parents -n 1 "${v4032_core_toml_ref}")"
+              if (( ${#v4032_core_toml_head_line[@]} != 2 )); then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 syswarden-core go-toml dependency diff contract
+              expected_v4032_core_toml_diff=(
+                M "src/core/syswarden-core/go.mod"
+                M "src/core/syswarden-core/go.sum"
+              )
+              mapfile -d '' -t actual_v4032_core_toml_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_core_toml_ref}^" "${v4032_core_toml_ref}"
+              )
+              if (( ${#actual_v4032_core_toml_diff[@]} != ${#expected_v4032_core_toml_diff[@]} )); then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_core_toml_diff[@]}; index++)); do
+                if [[ "${actual_v4032_core_toml_diff[index]}" != "${expected_v4032_core_toml_diff[index]}" ]]; then
+                  echo "ERROR: the reviewed syswarden-core go-toml dependency update contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_core_toml_paths=(
+                "src/core/syswarden-core/go.mod"
+                "src/core/syswarden-core/go.sum"
+              )
+              for tree_ref in "${v4032_core_toml_ref}^" "${v4032_core_toml_ref}"; do
+                for fix_path in "${v4032_core_toml_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed syswarden-core go-toml dependency ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 syswarden-core go-toml dependency diff contract
+              v4032_crun_ref=HEAD^^^
+              v4032_crun_parent_sha="$(git rev-parse "${v4032_crun_ref}^")"
               if [[ "${v4032_crun_parent_sha}" != "b74756b71e26e39b98c7fa60b65a3486adfde3e8" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration is not based on the reviewed PR104 squash." >&2
                 exit 1
               fi
               v4032_crun_expected_subject='Qualification : restore v4.03.2 ARM64 lifecycle under crun (#108)'
-              if [[ "${commit_subject}" != "${v4032_crun_expected_subject}" ]]; then
+              v4032_crun_subject="$(git log -1 --format=%s "${v4032_crun_ref}")"
+              if [[ "${v4032_crun_subject}" != "${v4032_crun_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_crun_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_crun_head_line <<< "$(git rev-list --parents -n 1 "${v4032_crun_ref}")"
               if (( ${#v4032_crun_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration must be one linear commit." >&2
                 exit 1
@@ -161,7 +329,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/security/os_hardening_linux.go"
               )
               mapfile -d '' -t actual_v4032_crun_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_crun_ref}^" "${v4032_crun_ref}"
               )
               if (( ${#actual_v4032_crun_diff[@]} != ${#expected_v4032_crun_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration must modify exactly the six reviewed files." >&2
@@ -181,7 +350,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
                 "src/core/syswarden-cli/pkg/security/os_hardening_linux.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_crun_ref}^" "${v4032_crun_ref}"; do
                 for fix_path in "${v4032_crun_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -196,7 +365,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 crun runtime restoration diff contract
-              v4032_compliance_ref=HEAD^
+              v4032_compliance_ref="${v4032_crun_ref}^"
               v4032_compliance_parent_sha="$(git rev-parse "${v4032_compliance_ref}^")"
               if [[ "${v4032_compliance_parent_sha}" != "ba1e853c11033f6abcd674dc7c251848f347e55b" ]]; then
                 echo "ERROR: the v4.03.2 compliance release verdict is not based on the reviewed PR103 squash." >&2
@@ -1327,17 +1496,185 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_crun_parent_sha="$(git rev-parse HEAD^)"
+              v4032_systemd_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_systemd_parent_sha}" != "540bab73a477c76d6301d276383602db06d36acd" ]]; then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction is not based on the reviewed PR105 squash." >&2
+                exit 1
+              fi
+              v4032_systemd_expected_subject='Qualification : seal systemd-capable ARM64 crun runtime (#109)'
+              if [[ "${commit_subject}" != "${v4032_systemd_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_systemd_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
+              expected_v4032_systemd_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_systemd_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_systemd_diff[@]} != ${#expected_v4032_systemd_diff[@]} )); then
+                echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_systemd_diff[@]}; index++)); do
+                if [[ "${actual_v4032_systemd_diff[index]}" != "${expected_v4032_systemd_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_systemd_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_systemd_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 systemd-capable ARM64 crun runtime correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
+              v4032_cli_toml_ref=HEAD^
+              v4032_cli_toml_parent_sha="$(git rev-parse "${v4032_cli_toml_ref}^")"
+              if [[ "${v4032_cli_toml_parent_sha}" != "4eacbae34561ae09611a7adb1f78717ca56e52a6" ]]; then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update is not based on the reviewed PR106 squash." >&2
+                exit 1
+              fi
+              v4032_cli_toml_expected_subject='Bump github.com/pelletier/go-toml/v2 in /src/core/syswarden-cli (#105)'
+              v4032_cli_toml_subject="$(git log -1 --format=%s "${v4032_cli_toml_ref}")"
+              if [[ "${v4032_cli_toml_subject}" != "${v4032_cli_toml_expected_subject}" ]]; then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_cli_toml_head_line <<< "$(git rev-list --parents -n 1 "${v4032_cli_toml_ref}")"
+              if (( ${#v4032_cli_toml_head_line[@]} != 2 )); then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 syswarden-cli go-toml dependency diff contract
+              expected_v4032_cli_toml_diff=(
+                M "src/core/syswarden-cli/go.mod"
+                M "src/core/syswarden-cli/go.sum"
+              )
+              mapfile -d '' -t actual_v4032_cli_toml_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_cli_toml_ref}^" "${v4032_cli_toml_ref}"
+              )
+              if (( ${#actual_v4032_cli_toml_diff[@]} != ${#expected_v4032_cli_toml_diff[@]} )); then
+                echo "ERROR: the reviewed syswarden-cli go-toml dependency update must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_cli_toml_diff[@]}; index++)); do
+                if [[ "${actual_v4032_cli_toml_diff[index]}" != "${expected_v4032_cli_toml_diff[index]}" ]]; then
+                  echo "ERROR: the reviewed syswarden-cli go-toml dependency update contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_cli_toml_paths=(
+                "src/core/syswarden-cli/go.mod"
+                "src/core/syswarden-cli/go.sum"
+              )
+              for tree_ref in "${v4032_cli_toml_ref}^" "${v4032_cli_toml_ref}"; do
+                for fix_path in "${v4032_cli_toml_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed syswarden-cli go-toml dependency ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 syswarden-cli go-toml dependency diff contract
+              v4032_core_toml_ref=HEAD^^
+              v4032_core_toml_parent_sha="$(git rev-parse "${v4032_core_toml_ref}^")"
+              if [[ "${v4032_core_toml_parent_sha}" != "3513acaee928cdd0aa235024f6ebfc5b2efe1dff" ]]; then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update is not based on the reviewed PR108 squash." >&2
+                exit 1
+              fi
+              v4032_core_toml_expected_subject='Bump github.com/pelletier/go-toml/v2 in /src/core/syswarden-core (#106)'
+              v4032_core_toml_subject="$(git log -1 --format=%s "${v4032_core_toml_ref}")"
+              if [[ "${v4032_core_toml_subject}" != "${v4032_core_toml_expected_subject}" ]]; then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_core_toml_head_line <<< "$(git rev-list --parents -n 1 "${v4032_core_toml_ref}")"
+              if (( ${#v4032_core_toml_head_line[@]} != 2 )); then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 syswarden-core go-toml dependency diff contract
+              expected_v4032_core_toml_diff=(
+                M "src/core/syswarden-core/go.mod"
+                M "src/core/syswarden-core/go.sum"
+              )
+              mapfile -d '' -t actual_v4032_core_toml_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_core_toml_ref}^" "${v4032_core_toml_ref}"
+              )
+              if (( ${#actual_v4032_core_toml_diff[@]} != ${#expected_v4032_core_toml_diff[@]} )); then
+                echo "ERROR: the reviewed syswarden-core go-toml dependency update must modify exactly the two reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_core_toml_diff[@]}; index++)); do
+                if [[ "${actual_v4032_core_toml_diff[index]}" != "${expected_v4032_core_toml_diff[index]}" ]]; then
+                  echo "ERROR: the reviewed syswarden-core go-toml dependency update contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_core_toml_paths=(
+                "src/core/syswarden-core/go.mod"
+                "src/core/syswarden-core/go.sum"
+              )
+              for tree_ref in "${v4032_core_toml_ref}^" "${v4032_core_toml_ref}"; do
+                for fix_path in "${v4032_core_toml_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed syswarden-core go-toml dependency ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 syswarden-core go-toml dependency diff contract
+              v4032_crun_ref=HEAD^^^
+              v4032_crun_parent_sha="$(git rev-parse "${v4032_crun_ref}^")"
               if [[ "${v4032_crun_parent_sha}" != "b74756b71e26e39b98c7fa60b65a3486adfde3e8" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration is not based on the reviewed PR104 squash." >&2
                 exit 1
               fi
               v4032_crun_expected_subject='Qualification : restore v4.03.2 ARM64 lifecycle under crun (#108)'
-              if [[ "${commit_subject}" != "${v4032_crun_expected_subject}" ]]; then
+              v4032_crun_subject="$(git log -1 --format=%s "${v4032_crun_ref}")"
+              if [[ "${v4032_crun_subject}" != "${v4032_crun_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_crun_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_crun_head_line <<< "$(git rev-list --parents -n 1 "${v4032_crun_ref}")"
               if (( ${#v4032_crun_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration must be one linear commit." >&2
                 exit 1
@@ -1352,7 +1689,8 @@ jobs:
                 M "src/core/syswarden-cli/pkg/security/os_hardening_linux.go"
               )
               mapfile -d '' -t actual_v4032_crun_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_crun_ref}^" "${v4032_crun_ref}"
               )
               if (( ${#actual_v4032_crun_diff[@]} != ${#expected_v4032_crun_diff[@]} )); then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration must modify exactly the six reviewed files." >&2
@@ -1372,7 +1710,7 @@ jobs:
                 "src/core/syswarden-cli/pkg/security/hardening_linux_test.go"
                 "src/core/syswarden-cli/pkg/security/os_hardening_linux.go"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_crun_ref}^" "${v4032_crun_ref}"; do
                 for fix_path in "${v4032_crun_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1387,7 +1725,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 ARM64 crun runtime restoration diff contract
-              v4032_compliance_ref=HEAD^
+              v4032_compliance_ref="${v4032_crun_ref}^"
               v4032_compliance_parent_sha="$(git rev-parse "${v4032_compliance_ref}^")"
               if [[ "${v4032_compliance_parent_sha}" != "ba1e853c11033f6abcd674dc7c251848f347e55b" ]]; then
                 echo "ERROR: the v4.03.2 compliance release verdict is not based on the reviewed PR103 squash." >&2

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -65,6 +65,10 @@ jobs:
           trusted_system_tools=(
             /usr/bin/bash
             /usr/bin/chmod
+            /usr/bin/curl
+            /usr/bin/install
+            /usr/bin/rm
+            /usr/bin/rmdir
             /usr/bin/sha256sum
             /usr/bin/stat
             /usr/bin/sudo
@@ -289,8 +293,17 @@ jobs:
             "${previous_packages}" \
             "${evidence_dir}" \
             "${transition_dir}"
+          shard_root_inode="$(stat -c '%d:%i' "${shard_root}")"
+          if [[ ! "${shard_root_inode}" =~ ^[0-9]+:[0-9]+$ || \
+                -L "${shard_root}" || ! -d "${shard_root}" || \
+                "$(stat -c '%u:%g:%a:%d:%i' "${shard_root}")" != \
+                  "$(id -u):$(id -g):700:${shard_root_inode}" ]]; then
+            echo "ERROR: the native ARM64 shard workspace identity is not exact." >&2
+            exit 1
+          fi
           {
             printf 'SHARD_ROOT=%s\n' "${shard_root}"
+            printf 'ARM_SHARD_ROOT_INODE=%s\n' "${shard_root_inode}"
             printf 'ARM_CANDIDATE_PACKAGES_DIR=%s\n' "${candidate_packages}"
             printf 'ARM_PREVIOUS_PACKAGES_DIR=%s\n' "${previous_packages}"
             printf 'ARM_EVIDENCE_DIR=%s\n' "${evidence_dir}"
@@ -301,6 +314,169 @@ jobs:
             printf 'previous_packages_dir=%s\n' "${previous_packages}"
             printf 'evidence_dir=%s\n' "${evidence_dir}"
           } >> "${GITHUB_OUTPUT}"
+
+      - name: Install Exact Native ARM64 crun Runtime
+        shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+        env:
+          CRUN_COMMIT: 54f16ffbefcd022bf032af768b5c5ce075c18bfc
+          CRUN_SHA256: cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342
+          CRUN_SIZE_BYTES: '3298128'
+          CRUN_SPEC_VERSION: 1.0.0
+          CRUN_URL: https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-arm64
+          CRUN_VERSION: '1.28'
+        run: |
+          set -euo pipefail
+          umask 077
+          user_id="$(id -u)"
+          user_group="$(id -g)"
+          runtime_directory="${SHARD_ROOT}/runtime"
+          crun_download="${runtime_directory}/.crun-1.28-linux-arm64.download"
+          crun_path="${runtime_directory}/crun-1.28-linux-arm64"
+          runtime_directory_inode=""
+          install_completed=false
+
+          attest_install_shard_root() {
+            if [[ -L "${SHARD_ROOT}" || ! -d "${SHARD_ROOT}" || \
+                  ! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                  "$(/usr/bin/stat -c '%u:%g:%a:%d:%i' "${SHARD_ROOT}")" != \
+                    "${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}" ]]; then
+              return 1
+            fi
+          }
+          attest_install_runtime_directory() {
+            if [[ ! "${runtime_directory_inode}" =~ ^[0-9]+:[0-9]+$ || \
+                  -L "${runtime_directory}" || ! -d "${runtime_directory}" || \
+                  "$(/usr/bin/stat -c '%u:%g:%a:%d:%i' "${runtime_directory}")" != \
+                    "${user_id}:${user_group}:700:${runtime_directory_inode}" ]]; then
+              return 1
+            fi
+          }
+          cleanup_failed_crun_install() {
+            if ! attest_install_shard_root; then
+              return 1
+            fi
+            if [[ -L "${runtime_directory}" ]]; then
+              if ! /usr/bin/rm -f -- "${runtime_directory}" || \
+                 [[ -e "${runtime_directory}" || -L "${runtime_directory}" ]]; then
+                return 1
+              fi
+              return 0
+            fi
+            if [[ ! -e "${runtime_directory}" ]]; then
+              return 0
+            fi
+            if ! attest_install_runtime_directory; then
+              return 1
+            fi
+            if ! /usr/bin/rm -f -- "${crun_path}" "${crun_download}" || \
+               [[ -e "${crun_path}" || -L "${crun_path}" || \
+                  -e "${crun_download}" || -L "${crun_download}" ]] || \
+               ! /usr/bin/rmdir -- "${runtime_directory}" || \
+               [[ -e "${runtime_directory}" || -L "${runtime_directory}" ]]; then
+              return 1
+            fi
+          }
+          cleanup_failed_crun_install_on_exit() {
+            local exit_rc=$?
+            trap - EXIT
+            if [[ "${install_completed}" != "true" ]] && \
+               ! cleanup_failed_crun_install; then
+              exit_rc=1
+            fi
+            exit "${exit_rc}"
+          }
+          trap cleanup_failed_crun_install_on_exit EXIT
+
+          if [[ ! "${CRUN_SHA256}" =~ ^[0-9a-f]{64}$ || \
+                "${CRUN_SIZE_BYTES}" != "3298128" || \
+                "${CRUN_VERSION}" != "1.28" || \
+                "${CRUN_SPEC_VERSION}" != "1.0.0" || \
+                "${CRUN_COMMIT}" != "54f16ffbefcd022bf032af768b5c5ce075c18bfc" || \
+                "${CRUN_URL}" != "https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-arm64" ]]; then
+            echo "ERROR: the native ARM64 crun release contract is not exact." >&2
+            exit 1
+          fi
+          if ! attest_install_shard_root || \
+             [[ -e "${runtime_directory}" || -L "${runtime_directory}" ]]; then
+            echo "ERROR: the native ARM64 crun workspace is not an exact private directory." >&2
+            exit 1
+          fi
+          /usr/bin/install -d -m 0700 -- "${runtime_directory}"
+          runtime_directory_inode="$(/usr/bin/stat -c '%d:%i' "${runtime_directory}")"
+          if ! attest_install_runtime_directory; then
+            echo "ERROR: the native ARM64 crun runtime directory is not exact." >&2
+            exit 1
+          fi
+          if [[ -e "${crun_download}" || -L "${crun_download}" || \
+                -e "${crun_path}" || -L "${crun_path}" ]]; then
+            echo "ERROR: the native ARM64 crun download target already exists." >&2
+            exit 1
+          fi
+          /usr/bin/curl --disable --fail --location \
+            --proto '=https' \
+            --proto-redir '=https' \
+            --tlsv1.2 \
+            --connect-timeout 10 \
+            --max-time 120 \
+            --max-redirs 5 \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 1 \
+            --retry-max-time 120 \
+            --max-filesize "${CRUN_SIZE_BYTES}" \
+            --remove-on-error \
+            --silent \
+            --show-error \
+            --output "${crun_download}" \
+            "${CRUN_URL}"
+          if [[ ! -f "${crun_download}" || -L "${crun_download}" || \
+                "$(/usr/bin/stat -c '%u:%g:%a:%s' "${crun_download}")" != \
+                  "${user_id}:${user_group}:600:${CRUN_SIZE_BYTES}" ]]; then
+            echo "ERROR: the downloaded native ARM64 crun asset is not an exact private regular file." >&2
+            exit 1
+          fi
+          printf '%s  %s\n' "${CRUN_SHA256}" "${crun_download}" | \
+            /usr/bin/sha256sum --check --strict
+          /usr/bin/install -m 0700 -- "${crun_download}" "${crun_path}"
+          if ! attest_install_runtime_directory; then
+            echo "ERROR: the native ARM64 crun runtime directory changed during installation." >&2
+            exit 1
+          fi
+          /usr/bin/rm -f -- "${crun_download}"
+          if [[ -e "${crun_download}" || -L "${crun_download}" || \
+                ! -f "${crun_path}" || -L "${crun_path}" || \
+                ! -x "${crun_path}" || \
+                "$(/usr/bin/stat -c '%u:%g:%a:%s' "${crun_path}")" != \
+                  "${user_id}:${user_group}:700:${CRUN_SIZE_BYTES}" ]]; then
+            echo "ERROR: the installed native ARM64 crun runtime is not exact." >&2
+            exit 1
+          fi
+          printf '%s  %s\n' "${CRUN_SHA256}" "${crun_path}" | \
+            /usr/bin/sha256sum --check --strict
+          crun_inode="$(/usr/bin/stat -c '%d:%i' "${crun_path}")"
+          if [[ ! "${crun_inode}" =~ ^[0-9]+:[0-9]+$ ]]; then
+            echo "ERROR: the installed native ARM64 crun inode is malformed." >&2
+            exit 1
+          fi
+          crun_version_output="$("${crun_path}" --version)"
+          mapfile -t crun_version_lines <<< "${crun_version_output}"
+          if [[ "${#crun_version_lines[@]}" -ne 5 || \
+                "${crun_version_lines[0]:-}" != "crun version ${CRUN_VERSION}" || \
+                "${crun_version_lines[1]:-}" != "commit: ${CRUN_COMMIT}" || \
+                ! "${crun_version_lines[2]:-}" =~ ^rundir:\ /run/(user/[0-9]+/)?crun$ || \
+                "${crun_version_lines[3]:-}" != "spec: ${CRUN_SPEC_VERSION}" || \
+                ! "${crun_version_lines[4]:-}" =~ (^|[[:space:]])\+SYSTEMD($|[[:space:]]) ]]; then
+            echo "ERROR: the installed native ARM64 crun version or systemd capability is not exact." >&2
+            exit 1
+          fi
+          {
+            printf 'ARM_CRUN_PATH=%s\n' "${crun_path}"
+            printf 'ARM_CRUN_SHA256=%s\n' "${CRUN_SHA256}"
+            printf 'ARM_CRUN_INODE=%s\n' "${crun_inode}"
+            printf 'ARM_CRUN_DIRECTORY_INODE=%s\n' "${runtime_directory_inode}"
+          } >> "${GITHUB_ENV}"
+          install_completed=true
+          trap - EXIT
 
       - name: Resolve Exact ARM64 Candidate Package Artifact
         id: candidate
@@ -491,11 +667,15 @@ jobs:
         run: |
           set -euo pipefail
           user_id="$(id -u)"
+          user_group="$(id -g)"
           user_name="$(id -un)"
           user_service="user@${user_id}.service"
           runtime_dir="/run/user/${user_id}"
           delegate_directory="/etc/systemd/system/user@.service.d"
           delegate_drop_in="${delegate_directory}/syswarden-release-qualification.conf"
+          crun_directory="${SHARD_ROOT}/runtime"
+          crun_download="${crun_directory}/.crun-1.28-linux-arm64.download"
+          expected_crun_path="${crun_directory}/crun-1.28-linux-arm64"
           containers_conf="${SHARD_ROOT}/containers.conf"
           podman_info="${SHARD_ROOT}/podman-info.json"
           podman_local="${SHARD_ROOT}/podman-local"
@@ -517,17 +697,78 @@ jobs:
           test -n "${RUNNER_TEMP:-}"
           test -d "${RUNNER_TEMP}"
           test ! -L "${RUNNER_TEMP}"
-          test -d "${SHARD_ROOT}"
-          test ! -L "${SHARD_ROOT}"
-          test ! -e "${containers_conf}"
-          test ! -L "${containers_conf}"
-          test ! -e "${podman_info}"
-          test ! -L "${podman_info}"
-          test ! -e "${podman_local}"
-          test ! -L "${podman_local}"
-          if sudo -n systemctl is-active --quiet "${user_service}"; then
-            original_user_service_active=true
-          fi
+
+          attest_arm_shard_root() {
+            if [[ -L "${SHARD_ROOT}" || ! -d "${SHARD_ROOT}" || \
+                  ! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                  "$(stat -c '%u:%g:%a:%d:%i' "${SHARD_ROOT}")" != \
+                    "${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}" ]]; then
+              return 1
+            fi
+          }
+          attest_arm_crun_directory() {
+            if ! attest_arm_shard_root || \
+               [[ -L "${crun_directory}" || ! -d "${crun_directory}" || \
+                  ! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                  "$(stat -c '%u:%g:%a:%d:%i' "${crun_directory}")" != \
+                    "${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}" ]]; then
+              return 1
+            fi
+          }
+
+          attest_arm_crun() {
+            local crun_version_output
+            local -a crun_version_lines
+            if ! attest_arm_crun_directory || \
+               [[ "${ARM_CRUN_PATH}" != "${expected_crun_path}" || \
+                  ! -f "${ARM_CRUN_PATH}" || -L "${ARM_CRUN_PATH}" || \
+                  ! -x "${ARM_CRUN_PATH}" || \
+                  "$(stat -c '%u:%g:%a:%s:%d:%i' "${ARM_CRUN_PATH}")" != \
+                    "${user_id}:${user_group}:700:3298128:${ARM_CRUN_INODE}" ]]; then
+              return 1
+            fi
+            if ! printf '%s  %s\n' "${ARM_CRUN_SHA256}" "${ARM_CRUN_PATH}" | \
+                 sha256sum --check --strict >/dev/null; then
+              return 1
+            fi
+            crun_version_output="$("${ARM_CRUN_PATH}" --version)" || return 1
+            mapfile -t crun_version_lines <<< "${crun_version_output}"
+            if [[ "${#crun_version_lines[@]}" -ne 5 || \
+                  "${crun_version_lines[0]:-}" != "crun version 1.28" || \
+                  "${crun_version_lines[1]:-}" != \
+                    "commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc" || \
+                  ! "${crun_version_lines[2]:-}" =~ ^rundir:\ /run/(user/[0-9]+/)?crun$ || \
+                  "${crun_version_lines[3]:-}" != "spec: 1.0.0" || \
+                  ! "${crun_version_lines[4]:-}" =~ (^|[[:space:]])\+SYSTEMD($|[[:space:]]) ]]; then
+              return 1
+            fi
+          }
+
+          cleanup_arm_crun_runtime() {
+            if ! attest_arm_shard_root; then
+              return 1
+            fi
+            if [[ -L "${crun_directory}" ]]; then
+              if ! /usr/bin/rm -f -- "${crun_directory}" || \
+                 [[ -e "${crun_directory}" || -L "${crun_directory}" ]]; then
+                return 1
+              fi
+              return 0
+            fi
+            if [[ ! -e "${crun_directory}" ]]; then
+              return 0
+            fi
+            if ! attest_arm_crun_directory; then
+              return 1
+            fi
+            if ! /usr/bin/rm -f -- "${expected_crun_path}" "${crun_download}" || \
+               [[ -e "${expected_crun_path}" || -L "${expected_crun_path}" || \
+                  -e "${crun_download}" || -L "${crun_download}" ]] || \
+               ! /usr/bin/rmdir -- "${crun_directory}" || \
+               [[ -e "${crun_directory}" || -L "${crun_directory}" ]]; then
+              return 1
+            fi
+          }
 
           cleanup_arm_cgroup_session() {
             local cleanup_rc=0
@@ -552,12 +793,20 @@ jobs:
                 fi
               fi
             fi
-            if ! rm -f -- "${containers_conf}" "${podman_info}" "${podman_local}"; then
+            if ! attest_arm_shard_root; then
               cleanup_rc=1
+            else
+              if ! /usr/bin/rm -f -- \
+                   "${containers_conf}" \
+                   "${podman_info}" \
+                   "${podman_local}" || \
+                 [[ -e "${containers_conf}" || -L "${containers_conf}" || \
+                    -e "${podman_info}" || -L "${podman_info}" || \
+                    -e "${podman_local}" || -L "${podman_local}" ]]; then
+                cleanup_rc=1
+              fi
             fi
-            if [[ -e "${containers_conf}" || -L "${containers_conf}" || \
-                  -e "${podman_info}" || -L "${podman_info}" || \
-                  -e "${podman_local}" || -L "${podman_local}" ]]; then
+            if ! cleanup_arm_crun_runtime; then
               cleanup_rc=1
             fi
             return "${cleanup_rc}"
@@ -572,6 +821,28 @@ jobs:
             exit "${exit_rc}"
           }
           trap cleanup_arm_cgroup_session_on_exit EXIT
+
+          if [[ "${ARM_CRUN_PATH:-}" != "${expected_crun_path}" || \
+                "${ARM_CRUN_SHA256:-}" != "cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342" || \
+                ! "${ARM_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                ! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                ! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$ ]]; then
+            echo "ERROR: the native ARM64 crun exported identity is not exact." >&2
+            exit 1
+          fi
+          if ! attest_arm_crun_directory; then
+            echo "ERROR: the native ARM64 crun parent identity changed before use." >&2
+            exit 1
+          fi
+          test ! -e "${containers_conf}"
+          test ! -L "${containers_conf}"
+          test ! -e "${podman_info}"
+          test ! -L "${podman_info}"
+          test ! -e "${podman_local}"
+          test ! -L "${podman_local}"
+          if sudo -n systemctl is-active --quiet "${user_service}"; then
+            original_user_service_active=true
+          fi
 
           if sudo -n test -e "${delegate_drop_in}" || \
              sudo -n test -L "${delegate_drop_in}"; then
@@ -602,7 +873,7 @@ jobs:
             exit 1
           fi
           sudo -n systemctl daemon-reload
-          sudo -n systemctl stop "${user_service}" || true
+          sudo -n systemctl stop "${user_service}"
 
           umask 077
           printf '%s\n' \
@@ -612,7 +883,7 @@ jobs:
             'remote=false' \
             'runtime="crun"' \
             '[engine.runtimes]' \
-            'crun=["/usr/local/bin/crun"]' \
+            "crun=[\"${ARM_CRUN_PATH}\"]" \
             '[engine.platform_to_oci_runtime]' \
             '"linux/arm64"="crun"' > "${containers_conf}"
           if [[ ! -f "${containers_conf}" || -L "${containers_conf}" || \
@@ -643,57 +914,67 @@ jobs:
             exit 1
           fi
           podman_info_inode="$(stat -c '%d:%i' "${podman_info}")"
+          if ! attest_arm_crun; then
+            echo "ERROR: the native ARM64 crun runtime changed before delegated use." >&2
+            exit 1
+          fi
 
           unit_name="syswarden-arm64-lifecycle-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          set +e
-          sudo -n systemd-run \
-            --machine="${user_name}@" \
-            --user \
-            --unit="${unit_name}" \
-            --quiet \
-            --wait \
-            --collect \
-            --pipe \
-            --working-directory="${GITHUB_WORKSPACE}" \
-            --property='Type=exec' \
-            --property='Delegate=cpu io memory pids' \
-            --property='MemoryMax=1G' \
-            --property='TasksMax=512' \
-            --property='UMask=0077' \
-            --setenv="CONTAINERS_CONF=${containers_conf}" \
-            --setenv='CONTAINERS_CONF_OVERRIDE=' \
-            --setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus" \
-            --setenv="HOME=${HOME}" \
-            --setenv='PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
-            --setenv='PYTHONDONTWRITEBYTECODE=1' \
-            --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
-            --setenv="SYSWARDEN_PODMAN_INFO=${podman_info}" \
-            --setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}" \
-            --setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}" \
-            --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
-            /usr/bin/bash --noprofile --norc -e -o pipefail -c \
-            'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY; if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_LOCAL:-}" || ! -f "${SYSWARDEN_PODMAN_LOCAL}" || -L "${SYSWARDEN_PODMAN_LOCAL}" || ! -x "${SYSWARDEN_PODMAN_LOCAL}" ]]; then echo "ERROR: native ARM64 local-only Podman launcher is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_INFO:-}" || -z "${SYSWARDEN_PODMAN_INFO_INODE:-}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info target is unavailable." >&2; exit 1; fi; if ! /usr/local/bin/crun --version >/dev/null; then echo "ERROR: native ARM64 crun is not executable inside the delegated session." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! "${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" info --format json; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ ! -s "${SYSWARDEN_PODMAN_INFO}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" || "$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600" || "$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != "${SYSWARDEN_PODMAN_INFO_INODE}" ]]; then echo "ERROR: native ARM64 Podman info evidence changed identity or permissions." >&2; exit 1; fi; if ! jq -e -s '\''length == 1 and .[0].host.conmon.path == "/usr/local/lib/podman/conmon" and .[0].host.ociRuntime.path == "/usr/local/bin/crun" and .[0].host.cgroupManager == "systemd" and .[0].host.security.rootless == true and .[0].host.serviceIsRemote == false and .[0].host.arch == "arm64" and .[0].host.os == "linux"'\'' "${SYSWARDEN_PODMAN_INFO}" >/dev/null; then echo "ERROR: native ARM64 Podman resolved an unexpected local runtime configuration." >&2; exit 1; fi; exec "$@"' \
-            syswarden-arm64-lifecycle \
-            /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
-            --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
-            --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \
-            --podman "${podman_local}" \
-            --architecture-shard arm64 \
-            --qualification-repository "${GITHUB_REPOSITORY}" \
-            --qualification-release-sha "${RELEASE_SHA}" \
-            --qualification-release-tag "${RELEASE_TAG}" \
-            --qualification-previous-tag "${PREVIOUS_TAG}" \
-            --qualification-workflow-run-id "${GITHUB_RUN_ID}" \
-            --qualification-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
-            --qualification-candidate-run-id "${CANDIDATE_RUN_ID}" \
-            --qualification-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}" \
-            --qualification-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}" \
-            --qualification-previous-release-id "${PREVIOUS_RELEASE_ID}" \
-            --pull-policy always \
-            --output "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json" \
-            --pretty
-          shard_rc=$?
-          set -e
+          shard_rc=0
+          if sudo -n systemd-run \
+              --machine="${user_name}@" \
+              --user \
+              --unit="${unit_name}" \
+              --quiet \
+              --wait \
+              --collect \
+              --pipe \
+              --working-directory="${GITHUB_WORKSPACE}" \
+              --property='Type=exec' \
+              --property='Delegate=cpu io memory pids' \
+              --property='MemoryMax=1G' \
+              --property='TasksMax=512' \
+              --property='UMask=0077' \
+              --setenv="CONTAINERS_CONF=${containers_conf}" \
+              --setenv='CONTAINERS_CONF_OVERRIDE=' \
+              --setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus" \
+              --setenv="HOME=${HOME}" \
+              --setenv='PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
+              --setenv='PYTHONDONTWRITEBYTECODE=1' \
+              --setenv="RUNNER_TEMP=${RUNNER_TEMP}" \
+              --setenv="SYSWARDEN_CRUN_DIRECTORY_INODE=${ARM_CRUN_DIRECTORY_INODE}" \
+              --setenv="SYSWARDEN_CRUN_INODE=${ARM_CRUN_INODE}" \
+              --setenv="SYSWARDEN_CRUN_PATH=${ARM_CRUN_PATH}" \
+              --setenv="SYSWARDEN_CRUN_SHA256=${ARM_CRUN_SHA256}" \
+              --setenv="SYSWARDEN_PODMAN_INFO=${podman_info}" \
+              --setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}" \
+              --setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}" \
+              --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
+              /usr/bin/bash --noprofile --norc -e -o pipefail -c \
+              'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY; if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_LOCAL:-}" || ! -f "${SYSWARDEN_PODMAN_LOCAL}" || -L "${SYSWARDEN_PODMAN_LOCAL}" || ! -x "${SYSWARDEN_PODMAN_LOCAL}" ]]; then echo "ERROR: native ARM64 local-only Podman launcher is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_INFO:-}" || -z "${SYSWARDEN_PODMAN_INFO_INODE:-}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info target is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_CRUN_PATH:-}" || "${SYSWARDEN_CRUN_SHA256:-}" != "cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342" || ! "${SYSWARDEN_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$ || ! "${SYSWARDEN_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ ]]; then echo "ERROR: native ARM64 crun delegated identity is incomplete." >&2; exit 1; fi; crun_parent="${SYSWARDEN_CRUN_PATH%/*}"; if [[ ! -d "${crun_parent}" || -L "${crun_parent}" || "$(stat -c "%u:%g:%a:%d:%i" "${crun_parent}")" != "$(id -u):$(id -g):700:${SYSWARDEN_CRUN_DIRECTORY_INODE}" || ! -f "${SYSWARDEN_CRUN_PATH}" || -L "${SYSWARDEN_CRUN_PATH}" || ! -x "${SYSWARDEN_CRUN_PATH}" || "$(stat -c "%u:%g:%a:%s:%d:%i" "${SYSWARDEN_CRUN_PATH}")" != "$(id -u):$(id -g):700:3298128:${SYSWARDEN_CRUN_INODE}" ]]; then echo "ERROR: native ARM64 crun changed identity inside the delegated session." >&2; exit 1; fi; if ! printf "%s  %s\n" "${SYSWARDEN_CRUN_SHA256}" "${SYSWARDEN_CRUN_PATH}" | sha256sum --check --strict >/dev/null; then echo "ERROR: native ARM64 crun changed bytes inside the delegated session." >&2; exit 1; fi; if ! crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --version)"; then echo "ERROR: native ARM64 crun is not executable inside the delegated session." >&2; exit 1; fi; mapfile -t crun_version_lines <<< "${crun_version_output}"; if [[ "${#crun_version_lines[@]}" -ne 5 || "${crun_version_lines[0]:-}" != "crun version 1.28" || "${crun_version_lines[1]:-}" != "commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc" || ! "${crun_version_lines[2]:-}" =~ ^rundir:\ /run/(user/[0-9]+/)?crun$ || "${crun_version_lines[3]:-}" != "spec: 1.0.0" || ! "${crun_version_lines[4]:-}" =~ (^|[[:space:]])\+SYSTEMD($|[[:space:]]) ]]; then echo "ERROR: native ARM64 crun lacks the exact delegated version or systemd capability." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! "${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" info --format json; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ ! -s "${SYSWARDEN_PODMAN_INFO}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" || "$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600" || "$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != "${SYSWARDEN_PODMAN_INFO_INODE}" ]]; then echo "ERROR: native ARM64 Podman info evidence changed identity or permissions." >&2; exit 1; fi; if ! jq --arg crun_path "${SYSWARDEN_CRUN_PATH}" -e -s '\''length == 1 and .[0].host.conmon.path == "/usr/local/lib/podman/conmon" and .[0].host.ociRuntime.name == "crun" and .[0].host.ociRuntime.path == $crun_path and (.[0].host.ociRuntime.version | type) == "string" and (.[0].host.ociRuntime.version | startswith("crun version 1.28\ncommit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc\n")) and (.[0].host.ociRuntime.version | contains("\nspec: 1.0.0\n")) and (.[0].host.ociRuntime.version | contains("\n+SYSTEMD ")) and .[0].host.cgroupManager == "systemd" and .[0].host.security.rootless == true and .[0].host.serviceIsRemote == false and .[0].host.arch == "arm64" and .[0].host.os == "linux"'\'' "${SYSWARDEN_PODMAN_INFO}" >/dev/null; then echo "ERROR: native ARM64 Podman resolved an unexpected local runtime configuration." >&2; exit 1; fi; exec "$@"' \
+              syswarden-arm64-lifecycle \
+              /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
+              --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \
+              --previous-packages-dir "${ARM_PREVIOUS_PACKAGES_DIR}" \
+              --podman "${podman_local}" \
+              --architecture-shard arm64 \
+              --qualification-repository "${GITHUB_REPOSITORY}" \
+              --qualification-release-sha "${RELEASE_SHA}" \
+              --qualification-release-tag "${RELEASE_TAG}" \
+              --qualification-previous-tag "${PREVIOUS_TAG}" \
+              --qualification-workflow-run-id "${GITHUB_RUN_ID}" \
+              --qualification-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+              --qualification-candidate-run-id "${CANDIDATE_RUN_ID}" \
+              --qualification-candidate-artifact-id "${CANDIDATE_ARTIFACT_ID}" \
+              --qualification-candidate-artifact-name "${CANDIDATE_ARTIFACT_NAME}" \
+              --qualification-previous-release-id "${PREVIOUS_RELEASE_ID}" \
+              --pull-policy always \
+              --output "${ARM_EVIDENCE_DIR}/package-lifecycle-arm64.json" \
+              --pretty; then
+            shard_rc=0
+          else
+            shard_rc=$?
+          fi
           cleanup_rc=0
           if ! cleanup_arm_cgroup_session; then
             cleanup_rc=1
@@ -798,6 +1079,82 @@ jobs:
           ' "${report}" >/dev/null; then
             echo "ERROR: the native ARM64 package lifecycle report is not release-ready." >&2
             exit 1
+          fi
+
+      - name: Remove Exact Native ARM64 crun Runtime
+        if: ${{ always() && steps.arm_workspace.outcome == 'success' }}
+        shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          set -euo pipefail
+          user_id="$(id -u)"
+          user_group="$(id -g)"
+          crun_directory="${SHARD_ROOT}/runtime"
+          crun_download="${crun_directory}/.crun-1.28-linux-arm64.download"
+          expected_crun_path="${crun_directory}/crun-1.28-linux-arm64"
+
+          attest_final_arm_shard_root() {
+            if [[ -L "${SHARD_ROOT}" || ! -d "${SHARD_ROOT}" || \
+                  ! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                  "$(/usr/bin/stat -c '%u:%g:%a:%d:%i' "${SHARD_ROOT}")" != \
+                    "${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}" ]]; then
+              return 1
+            fi
+          }
+          attest_final_crun_directory() {
+            if ! attest_final_arm_shard_root || \
+               [[ -L "${crun_directory}" || ! -d "${crun_directory}" || \
+                  ! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
+                  "$(/usr/bin/stat -c '%u:%g:%a:%d:%i' "${crun_directory}")" != \
+                    "${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}" ]]; then
+              return 1
+            fi
+          }
+          cleanup_final_crun_runtime() {
+            if [[ -L "${SHARD_ROOT}" ]]; then
+              return 1
+            fi
+            if [[ ! -e "${SHARD_ROOT}" ]]; then
+              return 0
+            fi
+            if ! attest_final_arm_shard_root; then
+              return 1
+            fi
+            if [[ -L "${crun_directory}" ]]; then
+              if ! /usr/bin/rm -f -- "${crun_directory}" || \
+                 [[ -e "${crun_directory}" || -L "${crun_directory}" ]]; then
+                return 1
+              fi
+              return 0
+            fi
+            if [[ ! -e "${crun_directory}" ]]; then
+              return 0
+            fi
+            if ! attest_final_crun_directory; then
+              return 1
+            fi
+            if ! /usr/bin/rm -f -- "${expected_crun_path}" "${crun_download}" || \
+               [[ -e "${expected_crun_path}" || -L "${expected_crun_path}" || \
+                  -e "${crun_download}" || -L "${crun_download}" ]] || \
+               ! /usr/bin/rmdir -- "${crun_directory}" || \
+               [[ -e "${crun_directory}" || -L "${crun_directory}" ]]; then
+              return 1
+            fi
+          }
+
+          if ! cleanup_final_crun_runtime; then
+            echo "ERROR: final native ARM64 crun cleanup was not identity-safe." >&2
+            exit 1
+          fi
+          if [[ -L "${SHARD_ROOT}" ]]; then
+            echo "ERROR: final native ARM64 crun cleanup cannot attest a symlinked shard root." >&2
+            exit 1
+          fi
+          if [[ -e "${SHARD_ROOT}" ]]; then
+            if ! attest_final_arm_shard_root || \
+               [[ -e "${crun_directory}" || -L "${crun_directory}" ]]; then
+              echo "ERROR: final native ARM64 crun cleanup did not attest exact absence." >&2
+              exit 1
+            fi
           fi
 
   qualify-release:

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1439,13 +1439,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                11,
+                14,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 10)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 11)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 13)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 14)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 22,
-                "scripts/ci/release_gate_test.py": 22,
+                ".github/workflows/release-manager.yml": 24,
+                "scripts/ci/release_gate_test.py": 24,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -1482,6 +1482,18 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         pinned_contracts = (
+            (
+                'if [[ "${v4032_systemd_parent_sha}" != '
+                '"540bab73a477c76d6301d276383602db06d36acd" ]]; then'
+            ),
+            (
+                'if [[ "${v4032_cli_toml_parent_sha}" != '
+                '"4eacbae34561ae09611a7adb1f78717ca56e52a6" ]]; then'
+            ),
+            (
+                'if [[ "${v4032_core_toml_parent_sha}" != '
+                '"3513acaee928cdd0aa235024f6ebfc5b2efe1dff" ]]; then'
+            ),
             (
                 'if [[ "${v4032_crun_parent_sha}" != '
                 '"b74756b71e26e39b98c7fa60b65a3486adfde3e8" ]]; then'
@@ -1533,6 +1545,18 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        systemd_subject_contract = (
+            "v4032_systemd_expected_subject='Qualification : seal "
+            "systemd-capable ARM64 crun runtime (#109)'"
+        )
+        cli_toml_subject_contract = (
+            "v4032_cli_toml_expected_subject='Bump "
+            "github.com/pelletier/go-toml/v2 in /src/core/syswarden-cli (#105)'"
+        )
+        core_toml_subject_contract = (
+            "v4032_core_toml_expected_subject='Bump "
+            "github.com/pelletier/go-toml/v2 in /src/core/syswarden-core (#106)'"
+        )
         crun_subject_contract = (
             "v4032_crun_expected_subject='Qualification : restore v4.03.2 "
             "ARM64 lifecycle under crun (#108)'"
@@ -1572,6 +1596,20 @@ class ReleaseGateTests(unittest.TestCase):
         repair_subject_contract = (
             "v4032_expected_subject='Qualification : repair v4.03.2 "
             "package lifecycle qualification (#95) (#95)'"
+        )
+        systemd_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
+        )
+        cli_toml_paths = (
+            "src/core/syswarden-cli/go.mod",
+            "src/core/syswarden-cli/go.sum",
+        )
+        core_toml_paths = (
+            "src/core/syswarden-core/go.mod",
+            "src/core/syswarden-core/go.sum",
         )
         compliance_paths = (
             ".github/dependabot.yml",
@@ -1649,7 +1687,14 @@ class ReleaseGateTests(unittest.TestCase):
             "src/core/syswarden-cli/pkg/system/uninstall_prepare_linux_test.go",
         )
         expected_paths = tuple(
-            dict.fromkeys(compliance_paths + repair_paths + crun_paths)
+            dict.fromkeys(
+                compliance_paths
+                + repair_paths
+                + crun_paths
+                + systemd_paths
+                + cli_toml_paths
+                + core_toml_paths
+            )
         )
         unchanged_targets = (
             "changelog.md",
@@ -1661,6 +1706,9 @@ class ReleaseGateTests(unittest.TestCase):
             "src/core/syswarden-core/webhook/discord.go",
         )
         for block in blocks:
+            self.assertEqual(block.count(systemd_subject_contract), 1)
+            self.assertEqual(block.count(cli_toml_subject_contract), 1)
+            self.assertEqual(block.count(core_toml_subject_contract), 1)
             self.assertEqual(block.count(crun_subject_contract), 1)
             self.assertEqual(block.count(compliance_subject_contract), 1)
             self.assertEqual(block.count(init_runtime_subject_contract), 1)
@@ -1674,20 +1722,246 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_systemd_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_systemd_parent_sha="$(git rev-parse HEAD^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_systemd_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_systemd_head_line[@]} != 2"), 1
+            )
+            systemd_diff = block.split(
+                "# BEGIN exact v4.03.2 systemd-capable ARM64 crun runtime "
+                "correction diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 systemd-capable ARM64 crun runtime "
+                "correction diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                systemd_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(
+                systemd_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+            )
+            self.assertEqual(
+                systemd_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                systemd_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                systemd_diff.count(
+                    "! \"${tree_object}\" =~ ^[0-9a-f]{40}$"
+                ),
+                1,
+            )
+            self.assertEqual(
+                systemd_diff.count(
+                    "${#actual_v4032_systemd_diff[@]} != "
+                    "${#expected_v4032_systemd_diff[@]}"
+                ),
+                1,
+            )
+            for path in systemd_paths:
+                self.assertEqual(systemd_diff.count(f'"{path}"'), 2)
+                self.assertEqual(systemd_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_cli_toml_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_cli_toml_parent_sha="$(git rev-parse '
+                    '"${v4032_cli_toml_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_cli_toml_subject="$(git log -1 --format=%s '
+                    '"${v4032_cli_toml_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_cli_toml_subject}" != '
+                    '"${v4032_cli_toml_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_cli_toml_head_line <<< '
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_cli_toml_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_cli_toml_head_line[@]} != 2"), 1
+            )
+            cli_toml_diff = block.split(
+                "# BEGIN exact v4.03.2 syswarden-cli go-toml dependency "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 syswarden-cli go-toml dependency "
+                "diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                cli_toml_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z \\\n"
+                    '        "${v4032_cli_toml_ref}^" '
+                    '"${v4032_cli_toml_ref}"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                cli_toml_diff.count(
+                    'for tree_ref in "${v4032_cli_toml_ref}^" '
+                    '"${v4032_cli_toml_ref}"; do'
+                ),
+                1,
+            )
+            self.assertEqual(
+                cli_toml_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                cli_toml_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                cli_toml_diff.count(
+                    "! \"${tree_object}\" =~ ^[0-9a-f]{40}$"
+                ),
+                1,
+            )
+            for path in cli_toml_paths:
+                self.assertEqual(cli_toml_diff.count(f'"{path}"'), 2)
+                self.assertEqual(cli_toml_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(
+                block.count("v4032_core_toml_ref=HEAD^^\n"),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_core_toml_parent_sha="$(git rev-parse '
+                    '"${v4032_core_toml_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_core_toml_subject="$(git log -1 --format=%s '
+                    '"${v4032_core_toml_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_core_toml_subject}" != '
+                    '"${v4032_core_toml_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_core_toml_head_line <<< '
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_core_toml_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_core_toml_head_line[@]} != 2"), 1
+            )
+            core_toml_diff = block.split(
+                "# BEGIN exact v4.03.2 syswarden-core go-toml dependency "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 syswarden-core go-toml dependency "
+                "diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                core_toml_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z \\\n"
+                    '        "${v4032_core_toml_ref}^" '
+                    '"${v4032_core_toml_ref}"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                core_toml_diff.count(
+                    'for tree_ref in "${v4032_core_toml_ref}^" '
+                    '"${v4032_core_toml_ref}"; do'
+                ),
+                1,
+            )
+            self.assertEqual(
+                core_toml_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                core_toml_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                core_toml_diff.count(
+                    "! \"${tree_object}\" =~ ^[0-9a-f]{40}$"
+                ),
+                1,
+            )
+            for path in core_toml_paths:
+                self.assertEqual(core_toml_diff.count(f'"{path}"'), 2)
+                self.assertEqual(core_toml_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(
+                block.count("v4032_crun_ref=HEAD^^^\n"),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_crun_parent_sha="$(git rev-parse '
+                    '"${v4032_crun_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_crun_subject="$(git log -1 --format=%s '
+                    '"${v4032_crun_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_crun_subject}" != '
                     '"${v4032_crun_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_crun_parent_sha="$(git rev-parse HEAD^)"'
-                ),
-                1,
-            )
-            self.assertEqual(
-                block.count(
                     'v4032_crun_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_crun_ref}")"'
                 ),
                 1,
             )
@@ -1719,12 +1993,17 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 crun_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_crun_ref}^" "${v4032_crun_ref}"'
                 ),
                 1,
             )
             self.assertEqual(
-                crun_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+                crun_diff.count(
+                    'for tree_ref in "${v4032_crun_ref}^" '
+                    '"${v4032_crun_ref}"; do'
+                ),
+                1,
             )
             self.assertEqual(
                 crun_diff.count('"${tree_mode}" != "100644"'), 1
@@ -1742,7 +2021,12 @@ class ReleaseGateTests(unittest.TestCase):
             for path in crun_paths:
                 self.assertEqual(crun_diff.count(f'"{path}"'), 2)
                 self.assertEqual(crun_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_compliance_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_compliance_ref="${v4032_crun_ref}^"\n'
+                ),
+                1,
+            )
             self.assertEqual(
                 block.count(
                     'v4032_compliance_parent_sha="$(git rev-parse '
@@ -2474,7 +2758,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                9,
+                12,
             )
             self.assertEqual(
                 block.count(
@@ -2493,12 +2777,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                10,
+                13,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 10)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 13)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -2520,6 +2804,9 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in local_paths else 0
                 expected_count += 2 if path in stabilization_paths else 0
                 expected_count += 2 if path in init_runtime_paths else 0
+                expected_count += 2 if path in systemd_paths else 0
+                expected_count += 2 if path in cli_toml_paths else 0
+                expected_count += 2 if path in core_toml_paths else 0
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1 if path in repair_paths else 0
@@ -2532,6 +2819,9 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_status_count += 1 if path in local_paths else 0
                 expected_status_count += 1 if path in stabilization_paths else 0
                 expected_status_count += 1 if path in init_runtime_paths else 0
+                expected_status_count += 1 if path in systemd_paths else 0
+                expected_status_count += 1 if path in cli_toml_paths else 0
+                expected_status_count += 1 if path in core_toml_paths else 0
                 self.assertEqual(
                     block.count(f'M "{path}"'), expected_status_count
                 )
@@ -2663,6 +2953,106 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_systemd_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 systemd-capable ARM64 crun runtime "
+            "correction diff contract\n"
+        )
+        end = (
+            "# END exact v4.03.2 systemd-capable ARM64 crun runtime "
+            "correction diff contract"
+        )
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_systemd_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_systemd_expected_subject="
+        end = (
+            'read -r -a v4032_systemd_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
+    def exact_v4032_cli_toml_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 syswarden-cli go-toml dependency diff "
+            "contract\n"
+        )
+        end = "# END exact v4.03.2 syswarden-cli go-toml dependency diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return (
+            "set -euo pipefail\nv4032_cli_toml_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
+
+    def v4032_cli_toml_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_cli_toml_expected_subject="
+        subject_assignment = (
+            'v4032_cli_toml_subject="$(git log -1 --format=%s '
+            '"${v4032_cli_toml_ref}")"'
+        )
+        end = (
+            'read -r -a v4032_cli_toml_head_line <<< '
+            '"$(git rev-list --parents -n 1 "${v4032_cli_toml_ref}")"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_cli_toml_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
+
+    def exact_v4032_core_toml_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 syswarden-core go-toml dependency diff "
+            "contract\n"
+        )
+        end = "# END exact v4.03.2 syswarden-core go-toml dependency diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return (
+            "set -euo pipefail\nv4032_core_toml_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
+
+    def v4032_core_toml_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_core_toml_expected_subject="
+        subject_assignment = (
+            'v4032_core_toml_subject="$(git log -1 --format=%s '
+            '"${v4032_core_toml_ref}")"'
+        )
+        end = (
+            'read -r -a v4032_core_toml_head_line <<< '
+            '"$(git rev-list --parents -n 1 "${v4032_core_toml_ref}")"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_core_toml_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
+
     def exact_v4032_crun_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -2673,20 +3063,31 @@ class ReleaseGateTests(unittest.TestCase):
         end = "# END exact v4.03.2 ARM64 crun runtime restoration diff contract"
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_crun_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_crun_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_crun_expected_subject="
+        subject_assignment = (
+            'v4032_crun_subject="$(git log -1 --format=%s '
+            '"${v4032_crun_ref}")"'
+        )
         end = (
             'read -r -a v4032_crun_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 "${v4032_crun_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_crun_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_compliance_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -3218,6 +3619,221 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_v4032_systemd_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_systemd_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : seal systemd-capable ARM64 crun runtime (#109)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : seal systemd-capable ARM64 crun runtime",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : seal systemd-capable ARM64 crun runtime (#108)",
+                    False,
+                ),
+                "wrong verb": (
+                    "Qualification : repair systemd-capable ARM64 crun runtime (#109)",
+                    False,
+                ),
+                "previous scope": (
+                    "Qualification : restore v4.03.2 ARM64 lifecycle under crun (#109)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : seal systemd-capable ARM64 crun runtime (#109) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_systemd_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_systemd_diff_script(),
+            "v4032-systemd-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+            ),
+        )
+
+    def test_release_manager_v4032_cli_toml_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_cli_toml_subject_gate_script(),
+            {
+                "valid": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-cli (#105)",
+                    True,
+                ),
+                "bare": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-cli",
+                    False,
+                ),
+                "wrong pull request": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-cli (#106)",
+                    False,
+                ),
+                "wrong module": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-core (#105)",
+                    False,
+                ),
+                "trailing space": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-cli (#105) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_cli_toml_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_cli_toml_diff_script(),
+            "v4032-cli-toml-diff",
+            (
+                "src/core/syswarden-cli/go.mod",
+                "src/core/syswarden-cli/go.sum",
+            ),
+        )
+
+    def test_release_manager_v4032_core_toml_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_core_toml_subject_gate_script(),
+            {
+                "valid": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-core (#106)",
+                    True,
+                ),
+                "bare": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-core",
+                    False,
+                ),
+                "wrong pull request": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-core (#105)",
+                    False,
+                ),
+                "wrong module": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-cli (#106)",
+                    False,
+                ),
+                "trailing space": (
+                    "Bump github.com/pelletier/go-toml/v2 in "
+                    "/src/core/syswarden-core (#106) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_core_toml_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_core_toml_diff_script(),
+            "v4032-core-toml-diff",
+            (
+                "src/core/syswarden-core/go.mod",
+                "src/core/syswarden-core/go.sum",
+            ),
+        )
+
+    def test_release_manager_v4032_dependency_squashes_match_local_objects(
+        self,
+    ) -> None:
+        contracts = (
+            (
+                "540bab73a477c76d6301d276383602db06d36acd",
+                "4eacbae34561ae09611a7adb1f78717ca56e52a6",
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-cli (#105)",
+                {
+                    "src/core/syswarden-cli/go.mod": (
+                        "66f6623dabd59b30d48906180ab51faf2b3de617",
+                        "ff807092dd11a281e8cc08380bc5152aeb55ac61",
+                    ),
+                    "src/core/syswarden-cli/go.sum": (
+                        "c4f38878c8a489144a549a19de19f49fd7e600b3",
+                        "ce676e05fabca3828da4ef31f5e82ee0ce8a7223",
+                    ),
+                },
+            ),
+            (
+                "4eacbae34561ae09611a7adb1f78717ca56e52a6",
+                "3513acaee928cdd0aa235024f6ebfc5b2efe1dff",
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-core (#106)",
+                {
+                    "src/core/syswarden-core/go.mod": (
+                        "26e4105948f496ba8cbf8efea067c252c2b4d94d",
+                        "3181e179994324ae7ff5eb769051b529a9bc7a39",
+                    ),
+                    "src/core/syswarden-core/go.sum": (
+                        "b7e67fd6352f003613d3f4c63bc99203172d2449",
+                        "227d3d731718cf79ae9eb7e9841a52db283ba050",
+                    ),
+                },
+            ),
+        )
+        for commit, parent, subject, paths in contracts:
+            with self.subTest(commit=commit):
+                self.assertEqual(
+                    subprocess.run(
+                        ["git", "rev-parse", f"{commit}^"],
+                        cwd=REPOSITORY,
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    ).stdout.strip(),
+                    parent,
+                )
+                self.assertEqual(
+                    subprocess.run(
+                        ["git", "log", "-1", "--format=%s", commit],
+                        cwd=REPOSITORY,
+                        check=True,
+                        capture_output=True,
+                        text=True,
+                    ).stdout.strip(),
+                    subject,
+                )
+                for path, (parent_blob, commit_blob) in paths.items():
+                    for ref, expected_blob in (
+                        (parent, parent_blob),
+                        (commit, commit_blob),
+                    ):
+                        entry = subprocess.run(
+                            ["git", "ls-tree", ref, "--", path],
+                            cwd=REPOSITORY,
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        ).stdout.strip()
+                        self.assertEqual(
+                            entry,
+                            f"100644 blob {expected_blob}\t{path}",
+                        )
+
     def test_release_manager_v4032_crun_subject_is_exact_github_squash(
         self,
     ) -> None:
@@ -3651,9 +4267,101 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "systemd parent resolution": workflow.replace(
+                'v4032_systemd_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_systemd_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact systemd parent": workflow.replace(
+                "540bab73a477c76d6301d276383602db06d36acd",
+                "640bab73a477c76d6301d276383602db06d36acd",
+            ),
+            "systemd canonical subject": workflow.replace(
+                "Qualification : seal systemd-capable ARM64 crun runtime (#109)",
+                "Qualification : repair systemd-capable ARM64 crun runtime (#109)",
+            ),
+            "systemd subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "systemd linear head": workflow.replace(
+                'v4032_systemd_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_systemd_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "CLI dependency reference": workflow.replace(
+                "v4032_cli_toml_ref=HEAD^",
+                "v4032_cli_toml_ref=HEAD^^",
+            ),
+            "CLI dependency parent resolution": workflow.replace(
+                'v4032_cli_toml_parent_sha="$(git rev-parse '
+                '"${v4032_cli_toml_ref}^")"',
+                'v4032_cli_toml_parent_sha="$(git rev-parse '
+                '"${v4032_cli_toml_ref}^^")"',
+            ),
+            "exact CLI dependency parent": workflow.replace(
+                "4eacbae34561ae09611a7adb1f78717ca56e52a6",
+                "5eacbae34561ae09611a7adb1f78717ca56e52a6",
+            ),
+            "CLI dependency canonical subject": workflow.replace(
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-cli (#105)",
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-cli (#106)",
+            ),
+            "CLI dependency subject source": workflow.replace(
+                'v4032_cli_toml_subject="$(git log -1 --format=%s '
+                '"${v4032_cli_toml_ref}")"',
+                'v4032_cli_toml_subject="$(git log -1 --format=%s HEAD)"',
+            ),
+            "CLI dependency linear head": workflow.replace(
+                'v4032_cli_toml_head_line <<< '
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_cli_toml_ref}")"',
+                'v4032_cli_toml_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+            ),
+            "core dependency reference": workflow.replace(
+                "v4032_core_toml_ref=HEAD^^",
+                "v4032_core_toml_ref=HEAD^^^",
+            ),
+            "core dependency parent resolution": workflow.replace(
+                'v4032_core_toml_parent_sha="$(git rev-parse '
+                '"${v4032_core_toml_ref}^")"',
+                'v4032_core_toml_parent_sha="$(git rev-parse '
+                '"${v4032_core_toml_ref}^^")"',
+            ),
+            "exact core dependency parent": workflow.replace(
+                "3513acaee928cdd0aa235024f6ebfc5b2efe1dff",
+                "4513acaee928cdd0aa235024f6ebfc5b2efe1dff",
+            ),
+            "core dependency canonical subject": workflow.replace(
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-core (#106)",
+                "Bump github.com/pelletier/go-toml/v2 in "
+                "/src/core/syswarden-core (#105)",
+            ),
+            "core dependency subject source": workflow.replace(
+                'v4032_core_toml_subject="$(git log -1 --format=%s '
+                '"${v4032_core_toml_ref}")"',
+                'v4032_core_toml_subject="$(git log -1 --format=%s HEAD)"',
+            ),
+            "core dependency linear head": workflow.replace(
+                'v4032_core_toml_head_line <<< '
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_core_toml_ref}")"',
+                'v4032_core_toml_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+            ),
+            "crun reference": workflow.replace(
+                "v4032_crun_ref=HEAD^^^",
+                "v4032_crun_ref=HEAD^^^^",
+            ),
             "crun parent resolution": workflow.replace(
-                'v4032_crun_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_crun_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_crun_parent_sha="$(git rev-parse '
+                '"${v4032_crun_ref}^")"',
+                'v4032_crun_parent_sha="$(git rev-parse '
+                '"${v4032_crun_ref}^^")"',
             ),
             "exact crun parent": workflow.replace(
                 "b74756b71e26e39b98c7fa60b65a3486adfde3e8",
@@ -3664,18 +4372,20 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : repair v4.03.2 ARM64 lifecycle under crun (#108)",
             ),
             "crun subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_crun_subject="$(git log -1 --format=%s '
+                '"${v4032_crun_ref}")"',
+                'v4032_crun_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "crun linear head": workflow.replace(
                 'v4032_crun_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_crun_ref}")"',
                 'v4032_crun_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "compliance reference": workflow.replace(
-                "v4032_compliance_ref=HEAD^",
-                "v4032_compliance_ref=HEAD^^",
+                'v4032_compliance_ref="${v4032_crun_ref}^"',
+                'v4032_compliance_ref="${v4032_crun_ref}^^"',
             ),
             "compliance parent resolution": workflow.replace(
                 'v4032_compliance_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -772,6 +772,10 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "(( (8#${trusted_parent_mode} & 0022) != 0 ))",
             "/usr/bin/bash",
             "/usr/bin/chmod",
+            "/usr/bin/curl",
+            "/usr/bin/install",
+            "/usr/bin/rm",
+            "/usr/bin/rmdir",
             "/usr/bin/sha256sum",
             "/usr/bin/stat",
             "/usr/bin/sudo",
@@ -857,12 +861,340 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "./scripts/",
             "git ",
             "curl ",
+            "/usr/bin/curl --",
             "apt-get",
             "command -v",
             "chmod -R",
             "|| true",
         ):
             self.assertNotIn(forbidden, script)
+
+    def test_arm64_crun_runtime_is_pinned_attested_and_ordered(self) -> None:
+        step_name = "Install Exact Native ARM64 crun Runtime"
+        step = workflow_step(self.workflow, step_name)
+        self.assertIn(
+            "shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}", step
+        )
+        for contract in (
+            "CRUN_COMMIT: 54f16ffbefcd022bf032af768b5c5ce075c18bfc",
+            "CRUN_SHA256: cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342",
+            "CRUN_SIZE_BYTES: '3298128'",
+            "CRUN_SPEC_VERSION: 1.0.0",
+            "CRUN_URL: https://github.com/containers/crun/releases/download/1.28/crun-1.28-linux-arm64",
+            "CRUN_VERSION: '1.28'",
+        ):
+            self.assertIn(contract, step)
+        workspace_script = workflow_step_script(
+            self.workflow, "Create Native ARM64 Shard Workspace"
+        )
+        for contract in (
+            'shard_root_inode="$(stat -c \'%d:%i\' "${shard_root}")"',
+            '"$(stat -c \'%u:%g:%a:%d:%i\' "${shard_root}")" !=',
+            '"$(id -u):$(id -g):700:${shard_root_inode}"',
+            "printf 'ARM_SHARD_ROOT_INODE=%s\\n' \"${shard_root_inode}\"",
+        ):
+            self.assertIn(contract, workspace_script)
+        script = workflow_step_script(self.workflow, step_name)
+        for contract in (
+            'runtime_directory="${SHARD_ROOT}/runtime"',
+            'crun_download="${runtime_directory}/.crun-1.28-linux-arm64.download"',
+            'crun_path="${runtime_directory}/crun-1.28-linux-arm64"',
+            'runtime_directory_inode=""',
+            'install_completed=false',
+            'attest_install_shard_root() {',
+            '"${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}"',
+            'attest_install_runtime_directory() {',
+            '"${user_id}:${user_group}:700:${runtime_directory_inode}"',
+            'cleanup_failed_crun_install() {',
+            'if [[ -L "${runtime_directory}" ]]; then',
+            '/usr/bin/rm -f -- "${runtime_directory}"',
+            'if [[ ! -e "${runtime_directory}" ]]; then',
+            'cleanup_failed_crun_install_on_exit() {',
+            'trap cleanup_failed_crun_install_on_exit EXIT',
+            '-e "${runtime_directory}" || -L "${runtime_directory}"',
+            '/usr/bin/install -d -m 0700 -- "${runtime_directory}"',
+            'runtime_directory_inode="$(/usr/bin/stat -c \'%d:%i\' '
+            '"${runtime_directory}")"',
+            '/usr/bin/curl --disable --fail --location',
+            "--proto '=https'",
+            "--proto-redir '=https'",
+            "--tlsv1.2",
+            "--connect-timeout 10",
+            "--max-time 120",
+            "--max-redirs 5",
+            "--retry 3",
+            "--retry-all-errors",
+            "--retry-delay 1",
+            "--retry-max-time 120",
+            '--max-filesize "${CRUN_SIZE_BYTES}"',
+            "--remove-on-error",
+            "--silent",
+            "--show-error",
+            '--output "${crun_download}"',
+            '"${CRUN_URL}"',
+            '[[ ! -f "${crun_download}" || -L "${crun_download}"',
+            '"${user_id}:${user_group}:600:${CRUN_SIZE_BYTES}"',
+            '/usr/bin/install -m 0700 -- "${crun_download}" "${crun_path}"',
+            '/usr/bin/rm -f -- "${crun_download}"',
+            '[[ -e "${crun_download}" || -L "${crun_download}"',
+            '! -f "${crun_path}" || -L "${crun_path}"',
+            '"${user_id}:${user_group}:700:${CRUN_SIZE_BYTES}"',
+            'crun_inode="$(/usr/bin/stat -c \'%d:%i\' "${crun_path}")"',
+            '"${crun_inode}" =~ ^[0-9]+:[0-9]+$',
+            'crun_version_output="$("${crun_path}" --version)"',
+            '"${crun_version_lines[0]:-}" != "crun version ${CRUN_VERSION}"',
+            '"${crun_version_lines[1]:-}" != "commit: ${CRUN_COMMIT}"',
+            '"${crun_version_lines[3]:-}" != "spec: ${CRUN_SPEC_VERSION}"',
+            r'\+SYSTEMD($|[[:space:]])',
+            "printf 'ARM_CRUN_PATH=%s\\n' \"${crun_path}\"",
+            "printf 'ARM_CRUN_SHA256=%s\\n' \"${CRUN_SHA256}\"",
+            "printf 'ARM_CRUN_INODE=%s\\n' \"${crun_inode}\"",
+            "printf 'ARM_CRUN_DIRECTORY_INODE=%s\\n' "
+            '"${runtime_directory_inode}"',
+            '} >> "${GITHUB_ENV}"',
+            'install_completed=true',
+            'trap - EXIT',
+        ):
+            self.assertIn(contract, script)
+        for forbidden in ("set +e", "|| true", "--insecure"):
+            self.assertNotIn(forbidden, script)
+        self.assertEqual(script.count("/usr/bin/curl --disable"), 1)
+        self.assertEqual(script.count("/usr/bin/sha256sum --check --strict"), 2)
+        cleanup_trap = script.index("trap cleanup_failed_crun_install_on_exit EXIT")
+        runtime_create = script.index(
+            '/usr/bin/install -d -m 0700 -- "${runtime_directory}"'
+        )
+        runtime_inode = script.index(
+            'runtime_directory_inode="$(/usr/bin/stat -c \'%d:%i\''
+        )
+        target_guard = script.index('if [[ -e "${crun_download}"')
+        download = script.index("/usr/bin/curl --disable")
+        downloaded_identity = script.index(
+            '[[ ! -f "${crun_download}" || -L "${crun_download}"'
+        )
+        source_digest = script.index("/usr/bin/sha256sum --check --strict")
+        install = script.index('/usr/bin/install -m 0700 -- "${crun_download}"')
+        installed_identity = script.index('! -f "${crun_path}" || -L "${crun_path}"')
+        destination_digest = script.index(
+            "/usr/bin/sha256sum --check --strict", source_digest + 1
+        )
+        version = script.index('"${crun_path}" --version')
+        export = script.index("printf 'ARM_CRUN_PATH=%s\\n'")
+        mark_complete = script.index("install_completed=true")
+        disarm_trap = script.index("trap - EXIT", mark_complete)
+        self.assertLess(cleanup_trap, runtime_create)
+        self.assertLess(runtime_create, runtime_inode)
+        self.assertLess(runtime_inode, target_guard)
+        self.assertLess(target_guard, download)
+        self.assertLess(download, downloaded_identity)
+        self.assertLess(downloaded_identity, source_digest)
+        self.assertLess(source_digest, install)
+        self.assertLess(install, installed_identity)
+        self.assertLess(installed_identity, destination_digest)
+        self.assertLess(destination_digest, version)
+        self.assertLess(version, export)
+        self.assertLess(export, mark_complete)
+        self.assertLess(mark_complete, disarm_trap)
+
+        arm_job = workflow_job(self.workflow, "package-lifecycle-arm64")
+        checkout = arm_job.index("Checkout Exact ARM64 Candidate Commit")
+        workspace = arm_job.index("Create Native ARM64 Shard Workspace")
+        install_step = arm_job.index(step_name)
+        download_command = arm_job.index("/usr/bin/curl --disable")
+        lifecycle = arm_job.index("Run Native ARM64 Package Lifecycle Shard")
+        final_cleanup = arm_job.index("Remove Exact Native ARM64 crun Runtime")
+        self.assertLess(checkout, workspace)
+        self.assertLess(workspace, install_step)
+        self.assertLess(install_step, download_command)
+        self.assertLess(download_command, lifecycle)
+        self.assertLess(lifecycle, final_cleanup)
+        self.assertNotIn("/usr/local/bin/crun", script)
+
+    def test_arm64_crun_final_cleanup_is_fail_closed_and_symlink_safe(self) -> None:
+        step_name = "Remove Exact Native ARM64 crun Runtime"
+        step = workflow_step(self.workflow, step_name)
+        self.assertIn(
+            "if: ${{ always() && steps.arm_workspace.outcome == 'success' }}",
+            step,
+        )
+        self.assertIn(
+            "shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}", step
+        )
+        script = workflow_step_script(self.workflow, step_name)
+        required = (
+            'crun_directory="${SHARD_ROOT}/runtime"',
+            'attest_final_arm_shard_root() {',
+            '"${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}"',
+            'attest_final_crun_directory() {',
+            '"${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}"',
+            'cleanup_final_crun_runtime() {',
+            'if [[ -L "${SHARD_ROOT}" ]]; then',
+            'if [[ ! -e "${SHARD_ROOT}" ]]; then',
+            'if [[ -L "${crun_directory}" ]]; then',
+            '/usr/bin/rm -f -- "${crun_directory}"',
+            'if [[ ! -e "${crun_directory}" ]]; then',
+            'if ! attest_final_crun_directory; then',
+            '/usr/bin/rm -f -- "${expected_crun_path}" "${crun_download}"',
+            '/usr/bin/rmdir -- "${crun_directory}"',
+            'if ! cleanup_final_crun_runtime; then',
+            "final native ARM64 crun cleanup was not identity-safe",
+            '[[ -e "${crun_directory}" || -L "${crun_directory}" ]]',
+            "final native ARM64 crun cleanup did not attest exact absence",
+        )
+        expected_return_failures = script.count("return 1")
+        expected_exit_failures = script.count("exit 1")
+
+        def assert_fail_closed(candidate: str) -> None:
+            for contract in required:
+                self.assertIn(contract, candidate)
+            for forbidden in ("set +e", "|| true", "--insecure"):
+                self.assertNotIn(forbidden, candidate)
+            self.assertEqual(candidate.count("return 1"), expected_return_failures)
+            self.assertEqual(candidate.count("exit 1"), expected_exit_failures)
+
+        self.assertGreaterEqual(expected_return_failures, 5)
+        self.assertGreaterEqual(expected_exit_failures, 3)
+        assert_fail_closed(script)
+        mutations = (
+            script.replace("return 1", "return 0", 1),
+            script.replace(
+                "if ! attest_final_crun_directory; then",
+                "if attest_final_crun_directory; then",
+                1,
+            ),
+            script.replace(
+                '/usr/bin/rm -f -- "${crun_directory}"',
+                '/usr/bin/rm -rf -- "${crun_directory}/"',
+                1,
+            ),
+            script.replace("exit 1", "exit 0", 1),
+            script + "\nset +e\n",
+            script + "\ncleanup_final_crun_runtime || true\n",
+            script + "\ncurl --insecure https://example.invalid\n",
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation[-80:]), self.assertRaises(
+                AssertionError
+            ):
+                assert_fail_closed(mutation)
+
+        def inode(path: Path) -> str:
+            identity = path.stat()
+            return f"{identity.st_dev}:{identity.st_ino}"
+
+        def invoke(shard_root: Path, runtime_inode: str | None) -> subprocess.CompletedProcess[str]:
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "SHARD_ROOT": str(shard_root),
+                    "ARM_SHARD_ROOT_INODE": inode(shard_root),
+                }
+            )
+            if runtime_inode is None:
+                environment.pop("ARM_CRUN_DIRECTORY_INODE", None)
+            else:
+                environment["ARM_CRUN_DIRECTORY_INODE"] = runtime_inode
+            return subprocess.run(
+                ["/usr/bin/bash", "-c", script],
+                cwd=REPOSITORY,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sentinel = root / "sentinel-exact"
+            sentinel.write_text("preserve-exact\n", encoding="utf-8")
+            shard_root = root / "shard-exact"
+            shard_root.mkdir(mode=0o700)
+            shard_root.chmod(0o700)
+            runtime = shard_root / "runtime"
+            runtime.mkdir(mode=0o700)
+            runtime.chmod(0o700)
+            crun = runtime / "crun-1.28-linux-arm64"
+            crun.write_bytes(b"exact-runtime")
+            crun.chmod(0o700)
+            (runtime / ".crun-1.28-linux-arm64.download").symlink_to(sentinel)
+            result = invoke(shard_root, inode(runtime))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(runtime.exists())
+            self.assertFalse(runtime.is_symlink())
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve-exact\n")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sentinel = root / "sentinel-absent"
+            sentinel.write_text("preserve-absent\n", encoding="utf-8")
+            shard_root = root / "shard-absent"
+            shard_root.mkdir(mode=0o700)
+            shard_root.chmod(0o700)
+            result = invoke(shard_root, None)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((shard_root / "runtime").exists())
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve-absent\n")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            outside = root / "outside-runtime"
+            outside.mkdir(mode=0o700)
+            sentinel = outside / "sentinel-symlink"
+            sentinel.write_text("preserve-symlink\n", encoding="utf-8")
+            shard_root = root / "shard-symlink"
+            shard_root.mkdir(mode=0o700)
+            shard_root.chmod(0o700)
+            runtime = shard_root / "runtime"
+            runtime.symlink_to(outside, target_is_directory=True)
+            result = invoke(shard_root, None)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(runtime.exists())
+            self.assertFalse(runtime.is_symlink())
+            self.assertEqual(
+                sentinel.read_text(encoding="utf-8"), "preserve-symlink\n"
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sentinel = root / "sentinel-changed-inode"
+            sentinel.write_text("preserve-changed\n", encoding="utf-8")
+            shard_root = root / "shard-changed-inode"
+            shard_root.mkdir(mode=0o700)
+            shard_root.chmod(0o700)
+            runtime = shard_root / "runtime"
+            runtime.mkdir(mode=0o700)
+            runtime.chmod(0o700)
+            crun = runtime / "crun-1.28-linux-arm64"
+            crun.write_bytes(b"must-remain")
+            runtime_stat = runtime.stat()
+            changed_inode = f"{runtime_stat.st_dev}:{runtime_stat.st_ino + 1}"
+            result = invoke(shard_root, changed_inode)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue(runtime.is_dir())
+            self.assertEqual(crun.read_bytes(), b"must-remain")
+            self.assertEqual(
+                sentinel.read_text(encoding="utf-8"), "preserve-changed\n"
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            outside_shard = root / "outside-shard"
+            outside_shard.mkdir(mode=0o700)
+            outside_shard.chmod(0o700)
+            outside_runtime = outside_shard / "runtime"
+            outside_runtime.mkdir(mode=0o700)
+            sentinel = outside_runtime / "sentinel-parent-symlink"
+            sentinel.write_text("preserve-parent-symlink\n", encoding="utf-8")
+            shard_root = root / "shard-parent-symlink"
+            shard_root.symlink_to(outside_shard, target_is_directory=True)
+            result = invoke(shard_root, inode(outside_runtime))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertTrue(shard_root.is_symlink())
+            self.assertEqual(
+                sentinel.read_text(encoding="utf-8"),
+                "preserve-parent-symlink\n",
+            )
 
     def test_package_main_is_independently_resolved_on_hosted_runner(self) -> None:
         for step_name in (
@@ -1070,12 +1402,43 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'containers_conf="${SHARD_ROOT}/containers.conf"',
             'podman_info="${SHARD_ROOT}/podman-info.json"',
             'podman_local="${SHARD_ROOT}/podman-local"',
+            'crun_directory="${SHARD_ROOT}/runtime"',
+            'crun_download="${crun_directory}/.crun-1.28-linux-arm64.download"',
+            'expected_crun_path="${crun_directory}/crun-1.28-linux-arm64"',
+            '"${ARM_CRUN_PATH:-}" != "${expected_crun_path}"',
+            '"${ARM_CRUN_SHA256:-}" != '
+            '"cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342"',
+            '! "${ARM_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            '! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            '! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            'attest_arm_shard_root() {',
+            '"${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}"',
+            'attest_arm_crun_directory() {',
+            '"${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}"',
+            'attest_arm_crun() {',
+            '"$(stat -c \'%u:%g:%a:%s:%d:%i\' "${ARM_CRUN_PATH}")" !=',
+            '"${user_id}:${user_group}:700:3298128:${ARM_CRUN_INODE}"',
+            'printf \'%s  %s\\n\' "${ARM_CRUN_SHA256}" "${ARM_CRUN_PATH}"',
+            'crun_version_output="$("${ARM_CRUN_PATH}" --version)" || return 1',
+            '"${crun_version_lines[0]:-}" != "crun version 1.28"',
+            '"commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc"',
+            '"${crun_version_lines[3]:-}" != "spec: 1.0.0"',
+            r'\+SYSTEMD($|[[:space:]])',
+            'cleanup_arm_crun_runtime() {',
+            'if [[ -L "${crun_directory}" ]]; then',
+            '/usr/bin/rm -f -- "${crun_directory}"',
+            'if [[ ! -e "${crun_directory}" ]]; then',
+            'if ! attest_arm_crun_directory; then',
+            'if ! cleanup_arm_crun_runtime; then',
+            "native ARM64 crun parent identity changed before use",
+            'if ! attest_arm_crun; then',
+            "native ARM64 crun runtime changed before delegated use",
             "'cgroup_manager=\"systemd\"'",
             "'conmon_path=[\"/usr/local/lib/podman/conmon\"]'",
             "'remote=false'",
             "'runtime=\"crun\"'",
             "'[engine.runtimes]'",
-            "'crun=[\"/usr/local/bin/crun\"]'",
+            '"crun=[\\"${ARM_CRUN_PATH}\\"]"',
             "'[engine.platform_to_oci_runtime]'",
             "'\"linux/arm64\"=\"crun\"'",
             '"$(stat -c \'%a\' "${containers_conf}")" != "600"',
@@ -1100,6 +1463,10 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "--setenv='CONTAINERS_CONF_OVERRIDE='",
             '--setenv="DBUS_SESSION_BUS_ADDRESS=unix:path=${runtime_dir}/bus"',
             "--setenv='PYTHONDONTWRITEBYTECODE=1'",
+            '--setenv="SYSWARDEN_CRUN_DIRECTORY_INODE=${ARM_CRUN_DIRECTORY_INODE}"',
+            '--setenv="SYSWARDEN_CRUN_INODE=${ARM_CRUN_INODE}"',
+            '--setenv="SYSWARDEN_CRUN_PATH=${ARM_CRUN_PATH}"',
+            '--setenv="SYSWARDEN_CRUN_SHA256=${ARM_CRUN_SHA256}"',
             '--setenv="SYSWARDEN_PODMAN_INFO=${podman_info}"',
             '--setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}"',
             '--setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}"',
@@ -1112,8 +1479,24 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '-z "${SYSWARDEN_PODMAN_INFO:-}"',
             '-z "${SYSWARDEN_PODMAN_INFO_INODE:-}"',
             "native ARM64 Podman info target is unavailable",
-            "if ! /usr/local/bin/crun --version >/dev/null",
+            '-z "${SYSWARDEN_CRUN_PATH:-}"',
+            '"${SYSWARDEN_CRUN_SHA256:-}" != '
+            '"cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342"',
+            '! "${SYSWARDEN_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            '! "${SYSWARDEN_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            "native ARM64 crun delegated identity is incomplete",
+            'crun_parent="${SYSWARDEN_CRUN_PATH%/*}"',
+            '"$(stat -c "%u:%g:%a:%d:%i" "${crun_parent}")" != '
+            '"$(id -u):$(id -g):700:${SYSWARDEN_CRUN_DIRECTORY_INODE}"',
+            '"$(stat -c "%u:%g:%a:%s:%d:%i" "${SYSWARDEN_CRUN_PATH}")" != '
+            '"$(id -u):$(id -g):700:3298128:${SYSWARDEN_CRUN_INODE}"',
+            "native ARM64 crun changed identity inside the delegated session",
+            'printf "%s  %s\\n" "${SYSWARDEN_CRUN_SHA256}" '
+            '"${SYSWARDEN_CRUN_PATH}"',
+            "native ARM64 crun changed bytes inside the delegated session",
+            'crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --version)"',
             "native ARM64 crun is not executable inside the delegated session",
+            "native ARM64 crun lacks the exact delegated version or systemd capability",
             "if ! /usr/local/lib/podman/conmon --version >/dev/null",
             "native ARM64 conmon is not executable inside the delegated session",
             '"${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" '
@@ -1124,7 +1507,12 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"${SYSWARDEN_PODMAN_INFO_INODE}"',
             "native ARM64 Podman info evidence changed identity or permissions",
             '.host.conmon.path == "/usr/local/lib/podman/conmon"',
-            '.host.ociRuntime.path == "/usr/local/bin/crun"',
+            '.host.ociRuntime.name == "crun"',
+            '.host.ociRuntime.path == $crun_path',
+            'startswith("crun version 1.28\\ncommit: '
+            '54f16ffbefcd022bf032af768b5c5ce075c18bfc\\n")',
+            'contains("\\nspec: 1.0.0\\n")',
+            'contains("\\n+SYSTEMD ")',
             '.host.cgroupManager == "systemd"',
             ".host.security.rootless == true",
             ".host.serviceIsRemote == false",
@@ -1137,7 +1525,13 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--podman "${podman_local}"',
             'sudo -n rm -f -- "${delegate_drop_in}"',
             'sudo -n test -e "${delegate_drop_in}"',
-            'rm -f -- "${containers_conf}" "${podman_info}" "${podman_local}"',
+            'shard_rc=0',
+            'if sudo -n systemd-run',
+            'else\n  shard_rc=$?',
+            '"${crun_download}"',
+            '-e "${expected_crun_path}" || -L "${expected_crun_path}"',
+            '/usr/bin/rmdir -- "${crun_directory}"',
+            '[[ -e "${crun_directory}" || -L "${crun_directory}" ]]',
             'sudo -n systemctl start "${user_service}"',
             'cleanup_rc=0',
             'arm_cleanup_completed=true',
@@ -1157,6 +1551,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "runtime=\"/usr/local/bin/runc\"",
             "runtime=\"runc\"",
             "/usr/local/bin/runc",
+            "/usr/local/bin/crun",
             "OCIRuntime.Name",
             "podman_runtime=",
             "{{.Host.Conmon.Path}}",
@@ -1168,6 +1563,9 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "podman system migrate",
             "--setenv='CONTAINER_HOST='",
             "--setenv='CONTAINER_CONNECTION='",
+            "set +e",
+            "|| true",
+            "--insecure",
         ):
             self.assertNotIn(forbidden, script)
         self.assertEqual(script.count("sudo -n systemd-run"), 1)
@@ -1178,7 +1576,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertEqual(script.count("'remote=false'"), 1)
         self.assertEqual(script.count("'runtime=\"crun\"'"), 1)
         self.assertEqual(script.count("'[engine.runtimes]'"), 1)
-        self.assertEqual(script.count("'crun=[\"/usr/local/bin/crun\"]'"), 1)
+        self.assertEqual(script.count('"crun=[\\"${ARM_CRUN_PATH}\\"]"'), 1)
         self.assertEqual(script.count("'[engine.platform_to_oci_runtime]'"), 1)
         self.assertEqual(
             script.count("'\"linux/arm64\"=\"crun\"'"), 1
@@ -1201,6 +1599,41 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertEqual(
             script.count("--setenv='CONTAINERS_CONF_OVERRIDE='"), 1
         )
+        self.assertEqual(
+            script.count(
+                '--setenv="SYSWARDEN_CRUN_DIRECTORY_INODE=${ARM_CRUN_DIRECTORY_INODE}"'
+            ),
+            1,
+        )
+        self.assertEqual(
+            script.count('--setenv="SYSWARDEN_CRUN_INODE=${ARM_CRUN_INODE}"'), 1
+        )
+        self.assertEqual(
+            script.count('--setenv="SYSWARDEN_CRUN_PATH=${ARM_CRUN_PATH}"'), 1
+        )
+        self.assertEqual(
+            script.count('--setenv="SYSWARDEN_CRUN_SHA256=${ARM_CRUN_SHA256}"'), 1
+        )
+        self.assertEqual(script.count("if ! attest_arm_crun; then"), 1)
+        cleanup_start = script.index("cleanup_arm_cgroup_session() {")
+        cleanup_end = script.index("cleanup_arm_cgroup_session_on_exit() {")
+        cleanup_script = script[cleanup_start:cleanup_end]
+        self.assertIn('/usr/bin/rm -f --', cleanup_script)
+        self.assertIn('if ! cleanup_arm_crun_runtime; then', cleanup_script)
+        self.assertNotIn('"${ARM_CRUN_PATH}"', cleanup_script)
+        runtime_cleanup_start = script.index("cleanup_arm_crun_runtime() {")
+        runtime_cleanup_end = script.index("cleanup_arm_cgroup_session() {")
+        runtime_cleanup = script[runtime_cleanup_start:runtime_cleanup_end]
+        self.assertIn('"${expected_crun_path}"', runtime_cleanup)
+        self.assertIn('"${crun_download}"', runtime_cleanup)
+        self.assertIn('/usr/bin/rm -f -- "${crun_directory}"', runtime_cleanup)
+        self.assertIn('/usr/bin/rmdir -- "${crun_directory}"', runtime_cleanup)
+        self.assertNotIn('"${ARM_CRUN_PATH}"', runtime_cleanup)
+        cleanup_trap = script.index("trap cleanup_arm_cgroup_session_on_exit EXIT")
+        exported_identity_guard = script.index(
+            'if [[ "${ARM_CRUN_PATH:-}" != "${expected_crun_path}"'
+        )
+        self.assertLess(cleanup_trap, exported_identity_guard)
         self.assertNotIn("--podman /usr/bin/podman", self.workflow)
         self.assertNotIn("--podman /usr/local/bin/podman", script)
         ownership_guard = script.index(
@@ -1214,7 +1647,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         remote_pin = script.index("'remote=false'")
         runtime_pin = script.index("'runtime=\"crun\"'")
         runtime_table = script.index("'[engine.runtimes]'")
-        runtime_path = script.index("'crun=[\"/usr/local/bin/crun\"]'")
+        runtime_path = script.index('"crun=[\\"${ARM_CRUN_PATH}\\"]"')
         platform_table = script.index("'[engine.platform_to_oci_runtime]'")
         platform_pin = script.index("'\"linux/arm64\"=\"crun\"'")
         wrapper_unset = script.index(
@@ -1244,9 +1677,27 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         configuration_guard = script.index(
             "native ARM64 Podman configuration isolation is incomplete"
         )
-        crun_probe = script.index("/usr/local/bin/crun --version")
-        conmon_probe = script.index("/usr/local/lib/podman/conmon --version")
         info_target = script.index(': > "${podman_info}"')
+        host_crun_attestation = script.index("if ! attest_arm_crun; then")
+        delegated_crun_identity = script.index(
+            "native ARM64 crun changed identity inside the delegated session",
+            systemd_run,
+        )
+        delegated_crun_digest = script.index(
+            "native ARM64 crun changed bytes inside the delegated session",
+            systemd_run,
+        )
+        crun_probe = script.index(
+            'crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --version)"',
+            systemd_run,
+        )
+        crun_version_verdict = script.index(
+            "native ARM64 crun lacks the exact delegated version or systemd capability",
+            systemd_run,
+        )
+        conmon_probe = script.index(
+            "/usr/local/lib/podman/conmon --version", systemd_run
+        )
         podman_probe = script.index(
             '"${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" '
             "info --format json"
@@ -1266,10 +1717,15 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertLess(platform_pin, wrapper_unset)
         self.assertLess(wrapper_unset, wrapper_exec)
         self.assertLess(wrapper_exec, info_target)
-        self.assertLess(info_target, systemd_run)
+        self.assertLess(info_target, host_crun_attestation)
+        self.assertLess(host_crun_attestation, systemd_run)
         self.assertLess(platform_pin, systemd_run)
         self.assertLess(systemd_run, configuration_guard)
-        self.assertLess(configuration_guard, crun_probe)
+        self.assertLess(configuration_guard, delegated_crun_identity)
+        self.assertLess(delegated_crun_identity, delegated_crun_digest)
+        self.assertLess(delegated_crun_digest, crun_probe)
+        self.assertLess(crun_probe, crun_version_verdict)
+        self.assertLess(crun_version_verdict, conmon_probe)
         self.assertLess(crun_probe, conmon_probe)
         self.assertLess(conmon_probe, podman_probe)
         self.assertLess(podman_probe, podman_verdict)


### PR DESCRIPTION
## Summary

- Pin and attest the official systemd-capable crun 1.28 ARM64 runtime used by the native lifecycle shard.
- Preserve the existing Podman bundle seal while binding delegated execution to the exact runtime path, digest, inode, version, commit, spec, and SYSTEMD feature.
- Add bounded install and final cleanup that fail closed on identity changes and never traverse replaced symlink targets.
- Extend the exact v4.03.2 ancestry and changed-path contract through PR109, PR105, and PR106.

## Validation

- release qualification workflow tests: 33 passed
- release gate tests: 82 passed
- complete CI unittest discovery: 521 tests, with the sandbox-blocked Unix socket case passing in its exact unrestricted rerun
- YAML parse, Bash syntax, ShellCheck, and git diff checks passed
- independent post-fix review: no actionable findings

## Release impact

This repairs the native ARM64 qualification failure caused by the bundled crun build lacking systemd support. It does not change the stock Podman bundle trust seal or the SysWarden product runtime.