### PR TITLE
Security : preserve read-only config preflight and centralize v4.03.2 docs

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,87 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_systemd_parent_sha="$(git rev-parse HEAD^)"
+              v4032_docs_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_docs_parent_sha}" != "3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0" ]]; then
+                echo "ERROR: the v4.03.2 read-only and documentation correction is not based on the reviewed PR109 squash." >&2
+                exit 1
+              fi
+              v4032_docs_expected_subject='Security : preserve read-only config preflight and centralize v4.03.2 docs (#110)'
+              if [[ "${commit_subject}" != "${v4032_docs_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 read-only and documentation correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_docs_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_docs_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 read-only and documentation correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 read-only configuration and documentation diff contract
+              expected_v4032_docs_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "README.md"
+                M "assets/syswarden_hero.svg"
+                M "scripts/ci/documentation_contract.json"
+                M "scripts/ci/documentation_gate.py"
+                M "scripts/ci/documentation_gate_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/workflow_required_checks_test.py"
+                M "src/core/syswarden-cli/cmd/root.go"
+                M "src/core/syswarden-cli/cmd/root_config_guard_test.go"
+              )
+              mapfile -d '' -t actual_v4032_docs_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_docs_diff[@]} != ${#expected_v4032_docs_diff[@]} )); then
+                echo "ERROR: the v4.03.2 read-only and documentation correction must modify exactly the ten reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_docs_diff[@]}; index++)); do
+                if [[ "${actual_v4032_docs_diff[index]}" != "${expected_v4032_docs_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 read-only and documentation correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_docs_paths=(
+                ".github/workflows/release-manager.yml"
+                "README.md"
+                "assets/syswarden_hero.svg"
+                "scripts/ci/documentation_contract.json"
+                "scripts/ci/documentation_gate.py"
+                "scripts/ci/documentation_gate_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/workflow_required_checks_test.py"
+                "src/core/syswarden-cli/cmd/root.go"
+                "src/core/syswarden-cli/cmd/root_config_guard_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_docs_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 read-only and documentation correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 read-only configuration and documentation diff contract
+              v4032_systemd_ref=HEAD^
+              v4032_systemd_parent_sha="$(git rev-parse "${v4032_systemd_ref}^")"
               if [[ "${v4032_systemd_parent_sha}" != "540bab73a477c76d6301d276383602db06d36acd" ]]; then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction is not based on the reviewed PR105 squash." >&2
                 exit 1
               fi
               v4032_systemd_expected_subject='Qualification : seal systemd-capable ARM64 crun runtime (#109)'
-              if [[ "${commit_subject}" != "${v4032_systemd_expected_subject}" ]]; then
+              v4032_systemd_subject="$(git log -1 --format=%s "${v4032_systemd_ref}")"
+              if [[ "${v4032_systemd_subject}" != "${v4032_systemd_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 "${v4032_systemd_ref}")"
               if (( ${#v4032_systemd_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must be one linear commit." >&2
                 exit 1
@@ -159,7 +229,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_systemd_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_systemd_ref}^" "${v4032_systemd_ref}"
               )
               if (( ${#actual_v4032_systemd_diff[@]} != ${#expected_v4032_systemd_diff[@]} )); then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must modify exactly the four reviewed files." >&2
@@ -177,7 +248,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_systemd_ref}^" "${v4032_systemd_ref}"; do
                 for fix_path in "${v4032_systemd_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -192,7 +263,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
-              v4032_cli_toml_ref=HEAD^
+              v4032_cli_toml_ref="${v4032_systemd_ref}^"
               v4032_cli_toml_parent_sha="$(git rev-parse "${v4032_cli_toml_ref}^")"
               if [[ "${v4032_cli_toml_parent_sha}" != "4eacbae34561ae09611a7adb1f78717ca56e52a6" ]]; then
                 echo "ERROR: the reviewed syswarden-cli go-toml dependency update is not based on the reviewed PR106 squash." >&2
@@ -247,7 +318,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 syswarden-cli go-toml dependency diff contract
-              v4032_core_toml_ref=HEAD^^
+              v4032_core_toml_ref="${v4032_cli_toml_ref}^"
               v4032_core_toml_parent_sha="$(git rev-parse "${v4032_core_toml_ref}^")"
               if [[ "${v4032_core_toml_parent_sha}" != "3513acaee928cdd0aa235024f6ebfc5b2efe1dff" ]]; then
                 echo "ERROR: the reviewed syswarden-core go-toml dependency update is not based on the reviewed PR108 squash." >&2
@@ -302,7 +373,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 syswarden-core go-toml dependency diff contract
-              v4032_crun_ref=HEAD^^^
+              v4032_crun_ref="${v4032_core_toml_ref}^"
               v4032_crun_parent_sha="$(git rev-parse "${v4032_crun_ref}^")"
               if [[ "${v4032_crun_parent_sha}" != "b74756b71e26e39b98c7fa60b65a3486adfde3e8" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration is not based on the reviewed PR104 squash." >&2
@@ -1496,17 +1567,87 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_systemd_parent_sha="$(git rev-parse HEAD^)"
+              v4032_docs_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_docs_parent_sha}" != "3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0" ]]; then
+                echo "ERROR: the v4.03.2 read-only and documentation correction is not based on the reviewed PR109 squash." >&2
+                exit 1
+              fi
+              v4032_docs_expected_subject='Security : preserve read-only config preflight and centralize v4.03.2 docs (#110)'
+              if [[ "${commit_subject}" != "${v4032_docs_expected_subject}" ]]; then
+                echo "ERROR: the v4.03.2 read-only and documentation correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_docs_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_docs_head_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 read-only and documentation correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 read-only configuration and documentation diff contract
+              expected_v4032_docs_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "README.md"
+                M "assets/syswarden_hero.svg"
+                M "scripts/ci/documentation_contract.json"
+                M "scripts/ci/documentation_gate.py"
+                M "scripts/ci/documentation_gate_test.py"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/workflow_required_checks_test.py"
+                M "src/core/syswarden-cli/cmd/root.go"
+                M "src/core/syswarden-cli/cmd/root_config_guard_test.go"
+              )
+              mapfile -d '' -t actual_v4032_docs_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_docs_diff[@]} != ${#expected_v4032_docs_diff[@]} )); then
+                echo "ERROR: the v4.03.2 read-only and documentation correction must modify exactly the ten reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_docs_diff[@]}; index++)); do
+                if [[ "${actual_v4032_docs_diff[index]}" != "${expected_v4032_docs_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.2 read-only and documentation correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_docs_paths=(
+                ".github/workflows/release-manager.yml"
+                "README.md"
+                "assets/syswarden_hero.svg"
+                "scripts/ci/documentation_contract.json"
+                "scripts/ci/documentation_gate.py"
+                "scripts/ci/documentation_gate_test.py"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/workflow_required_checks_test.py"
+                "src/core/syswarden-cli/cmd/root.go"
+                "src/core/syswarden-cli/cmd/root_config_guard_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_docs_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.2 read-only and documentation correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 read-only configuration and documentation diff contract
+              v4032_systemd_ref=HEAD^
+              v4032_systemd_parent_sha="$(git rev-parse "${v4032_systemd_ref}^")"
               if [[ "${v4032_systemd_parent_sha}" != "540bab73a477c76d6301d276383602db06d36acd" ]]; then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction is not based on the reviewed PR105 squash." >&2
                 exit 1
               fi
               v4032_systemd_expected_subject='Qualification : seal systemd-capable ARM64 crun runtime (#109)'
-              if [[ "${commit_subject}" != "${v4032_systemd_expected_subject}" ]]; then
+              v4032_systemd_subject="$(git log -1 --format=%s "${v4032_systemd_ref}")"
+              if [[ "${v4032_systemd_subject}" != "${v4032_systemd_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_systemd_head_line <<< "$(git rev-list --parents -n 1 "${v4032_systemd_ref}")"
               if (( ${#v4032_systemd_head_line[@]} != 2 )); then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must be one linear commit." >&2
                 exit 1
@@ -1519,7 +1660,8 @@ jobs:
                 M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_systemd_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_systemd_ref}^" "${v4032_systemd_ref}"
               )
               if (( ${#actual_v4032_systemd_diff[@]} != ${#expected_v4032_systemd_diff[@]} )); then
                 echo "ERROR: the v4.03.2 systemd-capable ARM64 crun runtime correction must modify exactly the four reviewed files." >&2
@@ -1537,7 +1679,7 @@ jobs:
                 "scripts/ci/release_gate_test.py"
                 "scripts/ci/release_qualification_workflow_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_systemd_ref}^" "${v4032_systemd_ref}"; do
                 for fix_path in "${v4032_systemd_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1552,7 +1694,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 systemd-capable ARM64 crun runtime correction diff contract
-              v4032_cli_toml_ref=HEAD^
+              v4032_cli_toml_ref="${v4032_systemd_ref}^"
               v4032_cli_toml_parent_sha="$(git rev-parse "${v4032_cli_toml_ref}^")"
               if [[ "${v4032_cli_toml_parent_sha}" != "4eacbae34561ae09611a7adb1f78717ca56e52a6" ]]; then
                 echo "ERROR: the reviewed syswarden-cli go-toml dependency update is not based on the reviewed PR106 squash." >&2
@@ -1607,7 +1749,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 syswarden-cli go-toml dependency diff contract
-              v4032_core_toml_ref=HEAD^^
+              v4032_core_toml_ref="${v4032_cli_toml_ref}^"
               v4032_core_toml_parent_sha="$(git rev-parse "${v4032_core_toml_ref}^")"
               if [[ "${v4032_core_toml_parent_sha}" != "3513acaee928cdd0aa235024f6ebfc5b2efe1dff" ]]; then
                 echo "ERROR: the reviewed syswarden-core go-toml dependency update is not based on the reviewed PR108 squash." >&2
@@ -1662,7 +1804,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 syswarden-core go-toml dependency diff contract
-              v4032_crun_ref=HEAD^^^
+              v4032_crun_ref="${v4032_core_toml_ref}^"
               v4032_crun_parent_sha="$(git rev-parse "${v4032_crun_ref}^")"
               if [[ "${v4032_crun_parent_sha}" != "b74756b71e26e39b98c7fa60b65a3486adfde3e8" ]]; then
                 echo "ERROR: the v4.03.2 ARM64 crun runtime restoration is not based on the reviewed PR104 squash." >&2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
-  <img src="assets/syswarden_hero.svg" alt="SysWarden Linux host defense and release qualification overview" width="100%">
+  <img src="assets/syswarden_hero.svg" alt="Official SysWarden logo on a light background" width="100%">
 </div>
+
+<br>
 
 <div align="center">
   <a href="https://github.com/duggytuxy/syswarden/actions/workflows/package.yml">
@@ -25,818 +27,84 @@
 
 # SysWarden
 
-SysWarden is a Linux host firewall orchestrator and out-of-band security-log
-analysis toolkit. It combines an authoritative nftables policy with bounded
-firewalld or UFW compatibility, local threat-intelligence lists, WAAP log
-analysis, host telemetry, authenticated HA exchange and a native local terminal
-dashboard.
+**Host-local Linux defense with auditable, fail-closed enforcement.**
 
-It is not an inline HTTP proxy, a traffic sanitizer or a regulatory
+SysWarden is an open-source Linux security orchestrator that combines an
+authoritative nftables policy, host telemetry, threat-intelligence lists,
+out-of-band WAAP log analysis, authenticated high availability and a native
+terminal dashboard. It is designed for operators who want one reviewable host
+defense layer without placing another proxy in the application data path.
+
+SysWarden is not an inline HTTP proxy, a traffic sanitizer or a regulatory
 certification product.
 
 Current source version: **v4.03.2**.
 
-Target candidate: **v4.03.2**. This documentation describes the candidate
-contract. It does not claim that v4.03.2 is qualified, tagged or published.
-Publication remains blocked until every protected gate passes on one exact
-merged commit.
-
-LOT 2 combines the completed Linux-only surface reduction in LOT 2A, the
-six-package reproducibility work in LOT 2B and the bounded security remediation
-in LOT 2S. Its technical closure becomes effective only for the exact merged
-commit that passes the protected main and qualification gates. Closing LOT 2
-does not authorize a tag or public Release.
-
-The historical v4.03.1 candidate completed its protected technical
-qualification but was deliberately left untagged and unpublished. Its evidence
-does not authorize or replace a fresh v4.03.2 qualification.
-
-<div align="center">
-  <img src="assets/syswarden_architecture.svg" alt="SysWarden Linux host architecture with local TUI, nftables and authenticated HA migration fence" width="100%">
-</div>
-
-## Supported targets and qualification
-
-| Target | Candidate artifact | Required release proof |
-| --- | --- | --- |
-| Debian or Ubuntu amd64 | `syswarden_4.03.2_amd64.deb` | Native install, upgrade, restart, removal and rollback lifecycle |
-| Debian or Ubuntu arm64 | `syswarden_4.03.2_arm64.deb` | Native ARM64 lifecycle on the exact candidate package |
-| Fedora or RHEL-family x86_64 | `syswarden-4.03.2-1.x86_64.rpm` | Native install, upgrade, restart, removal and rollback lifecycle |
-| Fedora or RHEL-family aarch64 | `syswarden-4.03.2-1.aarch64.rpm` | Native ARM64 lifecycle on the exact candidate package |
-| Alpine x86_64 | `syswarden_4.03.2_x86_64.apk` | Native OpenRC lifecycle with the dedicated CGO-free executable |
-| Alpine aarch64 | `syswarden_4.03.2_aarch64.apk` | Native ARM64 OpenRC lifecycle with the dedicated CGO-free executable |
-
-The package workflow is configured to generate two DEB, two RPM and two APK
-packages plus `SHA256SUMS.txt`. No current package or updater route exists
-outside this Linux matrix. ARM64 qualification uses a native runner, not CPU
-emulation.
-
-## Exact release inventory
-
-A qualified v4.03.2 Release contains exactly thirteen public assets:
-
-1. `syswarden_4.03.2_amd64.deb`
-2. `syswarden_4.03.2_arm64.deb`
-3. `syswarden-4.03.2-1.x86_64.rpm`
-4. `syswarden-4.03.2-1.aarch64.rpm`
-5. `syswarden_4.03.2_x86_64.apk`
-6. `syswarden_4.03.2_aarch64.apk`
-7. `SHA256SUMS.txt`
-8. `RELEASE_SHA256SUMS.txt`
-9. `syswarden-release.tar.gz`
-10. `syswarden-sbom.spdx.json`
-11. `plumber-report.zip`
-12. `syswarden-update-manifest-v1.json`
-13. `syswarden-update-manifest-v1.json.sig`
-
-The release manager rejects missing, duplicate or unexpected assets. The
-package checksum inventory, release checksum inventory and detached Ed25519
-update signature are verified before publication.
-
-## Core behavior
-
-- The CLI maintains persistent whitelist, blocklist and SSH-exception
-  registries using exact canonical IP, CIDR and supported service entries, then
-  reapplies host firewall policy after controlled changes.
-- The core analyzes configured logs out of band and can persist WAAP decisions
-  into the host firewall state.
-- The current Linux package builds, validates and commits one authoritative
-  nftables ruleset. If exactly one supported firewalld or UFW frontend is
-  already active, SysWarden reconciles only its bounded trusted-source and
-  HA-port compatibility rules. Installed but inactive tools are not activated.
-- `core.firewall_backend = "keep"` is the fresh-install default and never
-  transitions an operator-managed firewall service. Policy mutation is refused
-  while an iptables-services or netfilter-persistent service is active or
-  enabled. Operational mutation requires an active, unambiguous supported
-  service manager. Package hooks running with no service-manager runtime defer
-  `install` and `reload` instead of invoking host firewall or kernel tools.
-  `nftables` is a validation-only assertion that requires an already active and
-  enabled nftables service. It refuses any active or enabled firewalld, UFW,
-  iptables-services or netfilter-persistent frontend and never performs an
-  automatic service transition.
-- The `iptables` value remains parseable for configuration compatibility, but
-  it is not an operational policy mode in v4.03.2. Operational firewall policy
-  mutation paths reject this choice before changing persistent policy inputs
-  or kernel firewall state. Automatic firewall service migration is outside
-  the qualified v4.03.2 contract.
-- WireGuard requires the explicit `nftables` backend. The bounded firewalld and
-  UFW compatibility path does not open the WireGuard UDP port or forwarding
-  rules.
-- The TUI reads local telemetry and HA status. It runs inside the invoking
-  terminal and opens no listening socket.
-- The HA API uses TLS 1.3, a bearer token and a configurable port whose default
-  is TCP 62026.
-- The BunkerWeb extension is disabled by default and requires authenticated HA
-  before TTL and provenance operations are enabled.
-
-## Local terminal boundary
-
-Run the native dashboard from a trusted local console or SSH session:
-
-```console
-sudo syswarden tui
-```
-
-The current product contains no browser terminal, HTTPS or WebSocket terminal
-bridge, remote PTY route, token-management command or network terminal service.
-SysWarden owns no listener and no generated firewall permission on TCP 62027.
-
-Upgrade cleanup is deliberately bounded: it removes only verified historical
-SysWarden state, preserves unrelated configuration and must not stop an
-unrelated process that happens to use the same port.
-
-## Installation and upgrade
-
-Use only assets attached to the intended GitHub Release. Replace the example
-version only after that tag is public and its complete inventory is visible.
-
-```console
-VERSION=4.03.2
-TAG="v${VERSION}"
-```
-
-Download exactly one package for the host plus `SHA256SUMS.txt`, then verify the
-package before invoking the native package manager:
-
-```console
-sha256sum --check --ignore-missing SHA256SUMS.txt
-```
-
-Stop if the selected package is not reported as valid. Then use the matching
-native command:
-
-```console
-sudo apt-get install -y ./syswarden_4.03.2_amd64.deb
-sudo dnf install -y ./syswarden-4.03.2-1.x86_64.rpm
-sudo apk add --allow-untrusted ./syswarden_4.03.2_x86_64.apk
-```
-
-Run only the command for the actual distribution and architecture. For APK,
-`--allow-untrusted` is acceptable only after the exact SHA-256 verification has
-succeeded.
-
-The historical public v4.02.8 binary predates the signed updater protocol. Its
-first hop to v4.03.2 must use a separately downloaded and checksum-verified
-Linux package. After a qualified signed-protocol release is installed,
-`syswarden update` verifies the canonical manifest, detached Ed25519 signature,
-platform identity, package size and SHA-256 digest before installation.
-
-Before any upgrade:
-
-1. retain verified local console or SSH access;
-2. back up `/etc/syswarden`, required list files and HA trust material;
-3. save the current firewall service state, nftables ruleset and package version;
-4. verify that TCP 62027 is blocked at the host boundary;
-5. test the rollback package and recovery access on a representative host.
-
-## Optional RHEL-compatible image staging extension
-
-The [RHEL image staging extension](extensions/rhel-image/README.md) is an
-additive, opt-in path for an extracted, fresh and unmounted RHEL-family 9 or
-newer image root. It is not called by the normal build, package installation,
-update or reload workflows.
-
-The extension accepts one local RPM and its expected SHA-256. It verifies the
-target RPM database, dependencies, packaged Cronie provider and persistent
-`crond.service` enablement, then installs only that RPM with package scripts,
-triggers and RPM plugins disabled. It never enters the image root or runs a
-product binary, dependency-resolving package manager, service manager,
-firewall command, kernel-policy command, cron command, network request or
-process signal while staging.
-
-Use this reference sequence for a RHEL-family 9 image. The root must be a fresh,
-disposable and unmounted directory tree:
-
-```bash
-set -euo pipefail
-IMAGE_ROOT=/srv/image-root
-CANDIDATE_RPM=/srv/image-input/syswarden-4.03.2-1.x86_64.rpm
-# Copy this value from the independently authenticated package inventory.
-EXPECTED_RPM_SHA256=REPLACE_WITH_64_LOWERCASE_HEX_CHARACTERS
-
-[[ "${EXPECTED_RPM_SHA256}" =~ ^[0-9a-f]{64}$ ]]
-printf '%s  %s\n' "${EXPECTED_RPM_SHA256}" "${CANDIDATE_RPM}" | sha256sum --check --strict -
-sudo extensions/rhel-image/stage-syswarden-rhel-image.sh \
-  --preflight-root \
-  --root "${IMAGE_ROOT}"
-
-sudo dnf -y --installroot="${IMAGE_ROOT}" --releasever=9 \
-  --setopt=install_weak_deps=False install \
-  nftables ipset curl wget rsyslog cronie bash-completion \
-  wireguard-tools qrencode jq checkpolicy policycoreutils-python-utils \
-  dnf-automatic procps-ng e2fsprogs firewalld
-sudo systemctl --root="${IMAGE_ROOT}" enable crond.service firewalld.service
-sudo systemctl --root="${IMAGE_ROOT}" disable nftables.service
-
-printf '%s  %s\n' "${EXPECTED_RPM_SHA256}" "${CANDIDATE_RPM}" | sha256sum --check --strict -
-sudo extensions/rhel-image/stage-syswarden-rhel-image.sh \
-  --root "${IMAGE_ROOT}" \
-  --rpm "${CANDIDATE_RPM}" \
-  --sha256 "${EXPECTED_RPM_SHA256}"
-```
-
-The read-only `--preflight-root` call must run before `dnf` or
-`systemctl --root`. It rejects `/`, a non-canonical or symlinked root, unsafe
-ancestor directories, mounts below the image root and live runtime markers.
-Stop on any failure. The extension performs no image or host mutation in this
-mode.
-
-The `dnf` and `systemctl --root` steps belong to the image recipe, not the
-extension. They prepare dependencies and persistent boot state without
-starting services on the builder. Unmount temporary image-builder mounts before
-invoking the extension. Do not install or enable `iptables-services` for this
-firewalld-preserving profile.
-
-Never derive `EXPECTED_RPM_SHA256` from the candidate RPM. Obtain it from the
-separately authenticated package inventory so the check establishes artifact
-identity rather than only detecting a later copy race.
-
-After the extension succeeds, prepare three protected source files under
-`/srv/image-input/syswarden-config`. This must happen after staging because the
-extension accepts only a fresh image at entry. Save this first block as
-`config.toml` with owner `root:root` and mode `0640`:
-
-```toml
-schema_version = 1
-
-[core]
-config_dir = "/etc/syswarden/config/modules"
-enterprise_mode = false
-log_level = "INFO"
-```
-
-Save this block as `modules/00-core.toml` with owner `root:root` and mode
-`0640`:
-
-```toml
-[core]
-firewall_backend = "keep"
-hardening_enabled = false
-cis_l2_hardening = false
-secure_wipe_conf = false
-ssh_port = ""
-```
-
-Save this block as `modules/10-network.toml` with owner `root:root` and mode
-`0640`. It selects standard
-blocklist choice `1`, automatic infrastructure protection and explicit country
-and ASN deny sets while keeping remote monitor allowlisting and WireGuard off:
-
-<!-- syswarden-doc-toml-expect-invalid-asn -->
-```toml
-[network]
-whitelist_infra = true
-lan_subnets = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-whitelist_ips = []
-interfaces = ""
-
-[network.geo]
-enabled = true
-blocked_countries = ["ru", "cn", "kp", "ir"]
-allowed_countries = []
-
-[network.asn]
-enabled = true
-# This intentionally invalid value blocks first boot until it is replaced.
-blocked_asns = ["REPLACE_WITH_APPROVED_HIGH_RISK_ASN"]
-allowed_asns = []
-
-[network.saas]
-allow_monitors = false
-
-[network.blocklists]
-list_choice = "1"
-custom_url = ""
-custom_url_ipv6 = ""
-custom_hash = ""
-custom_hash_ipv6 = ""
-use_spamhaus = false
-
-[network.wireguard]
-enabled = false
-port = "51820"
-subnet = ""
-```
-
-The country set is a reviewable example, not a universal traffic policy.
-Remove any country required by the deployed services. Replace the intentionally
-invalid ASN marker with the exact high-risk ASN values from the image owner's
-current approved risk register. Until it is replaced, configuration validation
-fails and the first-boot marker is retained.
-The repository does not label network operators as high risk.
-
-After replacing the ASN marker in the protected source file, publish all three
-configuration files as one directory transaction from a trusted root shell:
-
-```bash
-set -euo pipefail
-umask 077
-if (( EUID != 0 )) || [[ "${GROUPS[0]}" != 0 ]]; then
-  printf '%s\n' 'Run this complete configuration publication block as root.' >&2
-  exit 1
-fi
-unset BASH_ENV ENV CDPATH GLOBIGNORE LD_PRELOAD LD_LIBRARY_PATH PYTHONPATH
-PATH=/usr/bin:/bin
-LC_ALL=C
-export PATH LC_ALL
-IMAGE_ROOT=/srv/image-root
-CONFIG_SOURCE=/srv/image-input/syswarden-config
-CONFIG_DESTINATION="${IMAGE_ROOT}/etc/syswarden/config"
-CONFIG_STAGE="${IMAGE_ROOT}/etc/syswarden/.config.pending-v1"
-CONFIG_FILES=(config.toml modules/00-core.toml modules/10-network.toml)
-
-extensions/rhel-image/stage-syswarden-rhel-image.sh \
-  --preflight-root \
-  --root "${IMAGE_ROOT}"
-for SOURCE_DIRECTORY in \
-  /srv \
-  /srv/image-input \
-  "${CONFIG_SOURCE}" \
-  "${CONFIG_SOURCE}/modules"; do
-  [[ -d "${SOURCE_DIRECTORY}" && ! -L "${SOURCE_DIRECTORY}" ]]
-  [[ "$(/usr/bin/stat -c '%u:%g' -- "${SOURCE_DIRECTORY}")" == "0:0" ]]
-  SOURCE_MODE=$(/usr/bin/stat -c '%a' -- "${SOURCE_DIRECTORY}")
-  (( (8#${SOURCE_MODE} & 8#022) == 0 ))
-done
-for CONFIG_FILE in "${CONFIG_FILES[@]}"; do
-  SOURCE_FILE="${CONFIG_SOURCE}/${CONFIG_FILE}"
-  [[ -f "${SOURCE_FILE}" && ! -L "${SOURCE_FILE}" ]]
-  [[ "$(/usr/bin/stat -c '%u:%g:%a:%h' -- "${SOURCE_FILE}")" == "0:0:640:1" ]]
-done
-
-SYSWARDEN_PARENT="${IMAGE_ROOT}/etc/syswarden"
-[[ ! -L "${SYSWARDEN_PARENT}" ]]
-[[ ! -e "${SYSWARDEN_PARENT}" || -d "${SYSWARDEN_PARENT}" ]]
-/usr/bin/install -d -o root -g root -m 0750 "${SYSWARDEN_PARENT}"
-[[ ! -e "${CONFIG_DESTINATION}" && ! -L "${CONFIG_DESTINATION}" ]]
-[[ ! -e "${CONFIG_STAGE}" && ! -L "${CONFIG_STAGE}" ]]
-/usr/bin/install -d -o root -g root -m 0750 "${CONFIG_STAGE}/modules"
-for CONFIG_FILE in "${CONFIG_FILES[@]}"; do
-  /usr/bin/install -o root -g root -m 0640 \
-    "${CONFIG_SOURCE}/${CONFIG_FILE}" "${CONFIG_STAGE}/${CONFIG_FILE}"
-  /usr/bin/cmp --silent -- \
-    "${CONFIG_SOURCE}/${CONFIG_FILE}" "${CONFIG_STAGE}/${CONFIG_FILE}"
-done
-/usr/bin/mv --no-clobber --no-target-directory \
-  "${CONFIG_STAGE}" "${CONFIG_DESTINATION}"
-[[ ! -e "${CONFIG_STAGE}" && -d "${CONFIG_DESTINATION}" && ! -L "${CONFIG_DESTINATION}" ]]
-[[ "$(/usr/bin/stat -c '%u:%g:%a' -- "${CONFIG_DESTINATION}")" == "0:0:750" ]]
-[[ "$(/usr/bin/stat -c '%u:%g:%a' -- "${CONFIG_DESTINATION}/modules")" == "0:0:750" ]]
-for CONFIG_FILE in "${CONFIG_FILES[@]}"; do
-  [[ "$(/usr/bin/stat -c '%u:%g:%a:%h' -- "${CONFIG_DESTINATION}/${CONFIG_FILE}")" == "0:0:640:1" ]]
-  /usr/bin/cmp --silent -- \
-    "${CONFIG_SOURCE}/${CONFIG_FILE}" "${CONFIG_DESTINATION}/${CONFIG_FILE}"
-done
-```
-
-If this block fails or leaves a pending directory, discard and rebuild the
-disposable image root.
-
-Each configured country and ASN requires a matching non-empty IPv4 and IPv6
-file in `/etc/syswarden/lists`, for example `ru.ipv4`, `ru.ipv6`, and one pair
-named after each approved ASN. Generate canonical CIDRs through an authenticated
-local pipeline and verify an exact `SHA256SUMS` manifest before publishing the
-list directory. Runtime validation rejects missing or empty files,
-mixed-family entries, default routes, IPv4 prefixes broader than `/24`, and
-IPv6 prefixes broader than `/64` before nftables policy publication. The
-general persistent-list grammar permits canonical private unicast ranges. For
-these country and ASN deny files, the authenticated image-owner pipeline must
-exclude private and other non-public ranges because they do not establish
-country or ASN ownership. Direct GeoIP, RADB or single-origin ASN reputation is
-not accepted as authenticated authority for deny policy.
-
-Publish the exact policy set as one exclusive transaction from a trusted root
-shell. The block refuses partial per-command elevation. Replace the invalid ASN
-in both the TOML and `APPROVED_ASNS` before running it:
-
-```bash
-set -euo pipefail
-umask 077
-if (( EUID != 0 )) || [[ "${GROUPS[0]}" != 0 ]]; then
-  printf '%s\n' 'Run this complete policy publication block as root.' >&2
-  exit 1
-fi
-unset BASH_ENV ENV CDPATH GLOBIGNORE LD_PRELOAD LD_LIBRARY_PATH PYTHONPATH
-PATH=/usr/bin:/bin
-LC_ALL=C
-export PATH LC_ALL
-IMAGE_ROOT=/srv/image-root
-POLICY_SOURCE=/srv/image-input/policy-lists
-extensions/rhel-image/stage-syswarden-rhel-image.sh \
-  --preflight-root \
-  --root "${IMAGE_ROOT}"
-POLICY_DESTINATION="${IMAGE_ROOT}/etc/syswarden/lists"
-POLICY_STAGE="${IMAGE_ROOT}/etc/syswarden/.lists.pending-v1"
-# Copy this value from the authenticated image-owner policy inventory.
-EXPECTED_POLICY_MANIFEST_SHA256=REPLACE_WITH_64_LOWERCASE_HEX_CHARACTERS
-COUNTRY_CODES=(ru cn kp ir)
-APPROVED_ASNS=(REPLACE_WITH_APPROVED_HIGH_RISK_ASN)
-
-[[ "${EXPECTED_POLICY_MANIFEST_SHA256}" =~ ^[0-9a-f]{64}$ ]]
-printf '%s  %s\n' "${EXPECTED_POLICY_MANIFEST_SHA256}" \
-  "${POLICY_SOURCE}/SHA256SUMS" | /usr/bin/sha256sum --check --strict -
-
-POLICY_FILES=()
-for COUNTRY_CODE in "${COUNTRY_CODES[@]}"; do
-  [[ "${COUNTRY_CODE}" =~ ^[a-z]{2}$ ]]
-  POLICY_FILES+=("${COUNTRY_CODE}.ipv4" "${COUNTRY_CODE}.ipv6")
-done
-for APPROVED_ASN in "${APPROVED_ASNS[@]}"; do
-  [[ "${APPROVED_ASN}" =~ ^AS[1-9][0-9]{0,9}$ ]]
-  ASN_NUMBER="${APPROVED_ASN#AS}"
-  (( 10#${ASN_NUMBER} <= 4294967295 ))
-  POLICY_FILES+=("${APPROVED_ASN}.ipv4" "${APPROVED_ASN}.ipv6")
-done
-
-mapfile -t MANIFEST_LINES < "${POLICY_SOURCE}/SHA256SUMS"
-MANIFEST_FILES=()
-declare -A EXPECTED_POLICY_SET=()
-for POLICY_FILE in "${POLICY_FILES[@]}"; do
-  [[ -z "${EXPECTED_POLICY_SET[${POLICY_FILE}]+x}" ]]
-  EXPECTED_POLICY_SET["${POLICY_FILE}"]=1
-done
-declare -A MANIFEST_POLICY_SET=()
-for MANIFEST_LINE in "${MANIFEST_LINES[@]}"; do
-  [[ "${MANIFEST_LINE}" =~ ^[0-9a-f]{64}\ \ ([A-Za-z0-9]+\.(ipv4|ipv6))$ ]]
-  MANIFEST_FILE="${BASH_REMATCH[1]}"
-  [[ -z "${MANIFEST_POLICY_SET[${MANIFEST_FILE}]+x}" ]]
-  MANIFEST_POLICY_SET["${MANIFEST_FILE}"]=1
-  MANIFEST_FILES+=("${MANIFEST_FILE}")
-done
-(( ${#EXPECTED_POLICY_SET[@]} == ${#MANIFEST_POLICY_SET[@]} ))
-for POLICY_FILE in "${POLICY_FILES[@]}"; do
-  [[ -n "${MANIFEST_POLICY_SET[${POLICY_FILE}]+x}" ]]
-done
-
-(
-  cd "${POLICY_SOURCE}"
-  /usr/bin/sha256sum --check --strict SHA256SUMS
-)
-[[ ! -e "${POLICY_DESTINATION}" && ! -L "${POLICY_DESTINATION}" ]]
-[[ ! -e "${POLICY_STAGE}" && ! -L "${POLICY_STAGE}" ]]
-/usr/bin/install -d -o root -g root -m 0750 "${POLICY_STAGE}"
-for POLICY_FILE in "${POLICY_FILES[@]}"; do
-  [[ -f "${POLICY_SOURCE}/${POLICY_FILE}" && ! -L "${POLICY_SOURCE}/${POLICY_FILE}" ]]
-  /usr/bin/install -o root -g root -m 0640 \
-    "${POLICY_SOURCE}/${POLICY_FILE}" "${POLICY_STAGE}/${POLICY_FILE}"
-done
-/usr/bin/install -o root -g root -m 0640 \
-  "${POLICY_SOURCE}/SHA256SUMS" "${POLICY_STAGE}/SHA256SUMS"
-printf '%s  %s\n' "${EXPECTED_POLICY_MANIFEST_SHA256}" \
-  "${POLICY_STAGE}/SHA256SUMS" | /usr/bin/sha256sum --check --strict -
-(
-  cd "${POLICY_STAGE}"
-  /usr/bin/sha256sum --check --strict SHA256SUMS
-)
-/usr/bin/mv --no-clobber --no-target-directory \
-  "${POLICY_STAGE}" "${POLICY_DESTINATION}"
-[[ ! -e "${POLICY_STAGE}" && -d "${POLICY_DESTINATION}" && ! -L "${POLICY_DESTINATION}" ]]
-printf '%s  %s\n' "${EXPECTED_POLICY_MANIFEST_SHA256}" \
-  "${POLICY_DESTINATION}/SHA256SUMS" | /usr/bin/sha256sum --check --strict -
-(
-  cd "${POLICY_DESTINATION}"
-  /usr/bin/sha256sum --check --strict SHA256SUMS
-)
-```
-
-The block copies no glob and no unlisted input. If it fails or leaves a pending
-directory, discard and rebuild the disposable image root.
-
-After payload verification, the extension enables a marker-guarded first-boot
-unit that requires `crond.service`. The real host then runs the normal `install`
-and `reload` workflows. The pinned `keep` profile preserves firewalld. If
-exactly one supported firewalld frontend is active, the bounded compatibility
-path may use it without changing its service state. nftables remains the
-authoritative SysWarden policy engine.
-
-Run the image builder's normal SELinux relabel, ownership, bootloader and ISO
-assembly stages, then boot a disposable target. Verify `crond.service` and
-`firewalld.service` are active and enabled, inspect
-`syswarden-image-firstboot.service`, run `syswarden config validate`, inspect
-`nft -j list table inet syswarden`, and confirm
-`/var/lib/syswarden/image/firstboot.pending` is absent. Offline staging does not
-establish runtime readiness or widen the qualified package matrix. Image assembly,
-signing and target-host validation remain image-builder responsibilities. The
-extension README contains the exact list-file and recovery checks.
-
-## Configuration
-
-The modular configuration root is `/etc/syswarden/config`. Later module
-filenames have higher precedence. Back up the complete directory before an
-edit, validate the candidate and apply it only after reviewing the effective
-diff.
-
-`schema_version = 1` is the current modular schema. When `schema_version` is
-absent, the configuration is treated as historical input. An explicit future,
-negative or non-integer schema version fails closed.
-
-Validate without editing files or applying environment overrides:
-
-```console
-sudo syswarden config validate --path /etc/syswarden/config
-```
-
-`syswarden config validate` is read-only. All unknown and deprecated keys are
-reported as diagnostics; a semantic or structural violation still fails
-validation. The CLI validator and core loader enforce the same semantic matrix
-for blocklist choice, URL and hash combinations, Wazuh endpoint completeness,
-compliance intervals, SHA-256 prefixes, trimmed HA peers and SSH/HA port
-separation while WireGuard is enabled.
-
-Preview a historical-to-modular migration before publishing any file:
-
-```console
-sudo syswarden config migrate \
-  --source /opt/syswarden/syswarden-auto.conf \
-  --output /etc/syswarden/config \
-  --dry-run
-```
-
-`syswarden config migrate --dry-run` performs zero source or destination
-writes, including when a previous migration transaction requires recovery.
-`syswarden migrate-config` remains a compatibility alias with the same
-transactional and dry-run contract.
-
-A historical `SYSWARDEN_FIREWALL_BACKEND="firewalld"` value migrates to
-`core.firewall_backend = "keep"` so the existing service is preserved without
-an automatic transition. A historical configuration that enables WireGuard
-with any backend other than `nftables` is rejected for operator remediation;
-the migration never changes that security choice silently.
-
-The official SaaS monitor setting is disabled unless explicitly enabled:
-
-```toml
-[network.saas]
-allow_monitors = false
-```
-
-`network.saas.allow_monitors` takes precedence over the deprecated
-`integrations.saas.enabled` alias; if neither is set, monitor allowlisting is
-disabled. Enabled monitor feeds must use absolute HTTPS URLs without
-credentials or fragments. TLS 1.3 is required, redirects are rejected and each
-download is bounded to 10 seconds, 1 MiB, 1,024 bytes per line, 20,000 lines
-and 10,000 entries. A required-feed, syntax or bound failure preserves the
-previous lists. Valid canonical IPv4 and IPv6 results are published as one
-lock-coordinated atomic pair with an SHA-256 pair manifest and rollback on
-publication failure.
-
-WAAP log settings use canonical single-space-separated absolute patterns.
-Configured globs are reduced to verified exact real regular-file matches. The
-core opens them descriptor-relative without following links and revalidates the
-file identity and type after every rotation; it never creates a missing target.
-Rsyslog inputs are emitted only for paths that pass the same validation at
-configuration time, but rsyslog later reopens those names itself, so operators
-must keep every parent directory protected against untrusted replacement.
-Rsyslog strings and WireGuard values are validated and encoded for their
-destination grammars before configuration publication.
-
-## Persistent list grammar
-
-Blocklist, whitelist and SSH-exception values use exact canonical IPv4 or IPv6
-addresses and masked CIDRs. Hostnames, address zones, IPv4-mapped IPv6 values,
-invalid ports, control characters and ambiguous substring matches are rejected.
-The address family must match the destination list.
-
-Use the explicit flag to limit a whitelist entry to one TCP service:
-
-```console
-sudo syswarden whitelist 192.0.2.10 --port 443
-```
-
-`--port` scopes a whitelist entry to one TCP service; omitting it creates an
-address-wide whitelist entry. SSH exceptions are rendered only for the
-effective SSH port. A port-qualified SSH entry must equal that effective port,
-and a changed-port mismatch fails closed before candidate policy application.
-Reconcile the SSH exception registry from verified console access before
-applying an SSH port change.
-
-Minimal authenticated HA and BunkerWeb example:
-
-```toml
-[integrations.ha]
-enabled = true
-peer_ips = ["192.0.2.10", "192.0.2.11"]
-peer_port = 62026
-token = "replace-with-a-secret-from-a-protected-channel"
-
-[integrations.bunkerweb]
-enabled = true
-```
-
-Do not commit a real HA token. Exact peer IPs may be dialed. Canonical CIDRs are
-inbound authorization ranges only and are never outbound destinations. When
-`/etc/syswarden/ha-ca.pem` exists, clients use that explicit trust bundle;
-otherwise they use the system trust store.
-
-## HA dialect and ownership rules
-
-One authenticated `GET /ha/status` selects the dialect independently for each
-peer and for one serialized synchronization cycle. Enriched operations require
-both `sync_ttl` and `sync_provenance`. A missing, partial, malformed or failed
-capability response stops the handoff for that peer and never downgrades TLS or
-bearer authentication.
-
-The ownership stores and delete operations remain separate:
-
-- `DELETE {"bans": [...]}` removes provenance ledger entries only;
-- `DELETE {"ips": [...]}` explicitly removes historical static entries;
-- neither operation cascades into another peer;
-- the integrator cleans only addresses present in its durable, peer-specific
-  record of historical submissions;
-- ownership is never inferred from `GET /ha/sync`, provenance pagination or an
-  effective union returned by a peer.
-
-This separation prevents an integrator from deleting a local operator entry,
-a WAAP-owned entry or another producer's durable claim.
-
-## HA migration fence
-
-Historical-to-provenance cleanup is a cluster campaign, even though every HA
-mutation remains peer-scoped. The operator owns the complete member and
-external-writer inventory. SysWarden owns the per-node native-sync fence. The
-integrator owns the durable per-peer journal, explicit cleanup requests and
-completion decision.
-
-### Operator workflow
-
-One trusted control host creates one protected activation manifest and
-distributes that same file to every member and to the integrator:
-
-```console
-sudo syswarden ha-fence manifest create \
-  --inventory /root/syswarden-ha-inventory.json \
-  --output /root/syswarden-ha-manifest.json \
-  --assert-complete
-sudo syswarden ha-fence manifest verify \
-  --manifest /root/syswarden-ha-manifest.json
-sudo syswarden ha-fence engage \
-  --manifest /root/syswarden-ha-manifest.json
-sudo syswarden ha-fence status --json
-```
-
-Manifest files are strict, canonical, owner-only inputs. Creation performs a
-fresh authenticated and challenge-bound status request to every exact member,
-verifies the live TLS leaf identity and records one random campaign epoch. A
-member, endpoint, certificate or external-writer change requires a new
-manifest and resets every partner observation window.
-
-Release is root-only and requires the unchanged manifest plus durable terminal
-closure evidence for every external legacy writer:
-
-```console
-sudo syswarden ha-fence release \
-  --manifest /root/syswarden-ha-manifest.json \
-  --writer-closure /root/syswarden-ha-writer-closure.json
-```
-
-Use `ha-fence recover` with the same manifest after an interrupted engagement.
-Never engage a retired epoch and never reconstruct a manifest from peer output.
-
-### Integrator verification
-
-The capability `native_sync_fence_v1` announces schema support only. It is not
-evidence that a fence is active or drained.
-
-For every manifest member, the integrator obtains one fresh authenticated,
-challenge-bound `GET /ha/status` response over the verified and leaf-pinned TLS
-connection. It accepts fence evidence only when all of these values match the
-operator manifest and the same response:
-
-- `native_sync_fence.state` is `active_drained`;
-- the challenge echo matches the unique request challenge;
-- the live leaf certificate SHA-256 matches the manifest member;
-- `epoch` equals the manifest epoch;
-- `membership_sha256` equals the manifest membership digest;
-- `legacy_writer_inventory_sha256` equals the manifest writer digest;
-- the `X-SysWarden-HA-Fence-Condition` response header equals the JSON
-  `condition` value;
-- server instance, generation, condition and membership remain stable for the
-  accepted observation.
-
-The integrator treats the epoch and both digest values as opaque,
-case-sensitive strings. It compares them for exact equality and does not
-recalculate either digest or reimplement SysWarden canonicalization.
-
-Every explicit historical cleanup request sends the observed value in:
-
-```text
-X-SysWarden-HA-Fence-Condition: <condition>
-```
-
-While the fence is active and drained, a missing condition receives HTTP 428,
-a malformed condition receives HTTP 400 and a stale condition receives HTTP
-412. Each rejection performs no mutation. HTTP 412 means the fence changed;
-the integrator stops, refreshes the complete all-member proof and requires an
-operator decision instead of blindly retrying.
-
-An unavailable member, blind interval, changed membership, changed certificate,
-changed server instance, changed generation or reappearing address resets the
-partner observation. A one-hour continuous absence window is additional
-evidence only. It is never proof of drain and never permits claim release from
-a partial cluster view.
-
-## Operator commands
-
-The table lists product commands only. Cobra help and shell-completion utilities
-remain available separately.
-
-| Command | Purpose |
+The source describes the v4.03.2 candidate and does not claim that the release
+has been qualified, tagged or published.
+
+## Features
+
+- Authoritative nftables enforcement with bounded firewalld and UFW
+  compatibility when exactly one supported frontend is already active.
+- Persistent blocklists, whitelists and SSH exceptions with canonical IP,
+  CIDR and service-scoped entries.
+- Host telemetry and out-of-band WAAP log analysis for local detection and
+  response workflows.
+- Bounded threat-intelligence feeds with last-known-good publication behavior.
+- Native local terminal dashboard with no browser service or listening port.
+- Authenticated HA synchronization over TLS 1.3 with explicit ownership and
+  migration-fence controls.
+- Optional BunkerWeb integration with authenticated HA and provenance-aware
+  cleanup.
+- Native DEB, RPM and APK packaging for supported amd64 and arm64 Linux hosts.
+
+## Capabilities
+
+| Area | What SysWarden provides |
 | --- | --- |
-| `alerts` | Stream kernel and WAAP alert events |
-| `allow-ssh` | Add an address to the SSH exception registry |
-| `audit` | Run a bounded local operational diagnostic |
-| `block` | Add addresses or CIDRs to the persistent blocklist |
-| `check` | Inspect recorded firewall state for an address |
-| `config` | Validate, inspect and migrate modular configuration |
-| `config-get` | Read one effective configuration key |
-| `ha-fence` | Administer a cluster migration fence |
-| `ha-sync` | Push missing local durable entries to exact peers |
-| `install` | Run the host-mutating installation pipeline |
-| `list` | Display local registries and active HA bans |
-| `manual` | Display the built-in operator reference |
-| `migrate-config` | Run the compatible legacy configuration migration entry point |
-| `reload` | Reapply policy and normally restart the core |
-| `revoke-ssh` | Remove an address from the SSH exception registry |
-| `tui` | Launch the native local terminal dashboard |
-| `unblock` | Remove addresses or CIDRs from the blocklist |
-| `uninstall` | Delete SysWarden services, rules, configuration, data and logs |
-| `unwhitelist` | Remove addresses or CIDRs from the whitelist |
-| `update` | Install an update verified by the signed manifest |
-| `update-feeds` | Download configured feeds and reapply firewall policy |
-| `whitelist` | Add addresses or CIDRs to the persistent whitelist |
-| `whitelist-infra` | Detect and add local infrastructure addresses |
+| HIDS | Host-local telemetry, security-log analysis and alert visibility |
+| HIPS | Validated policy decisions enforced through authoritative nftables rules |
+| WAAP | Out-of-band analysis of logs written by a supported upstream service |
+| Threat intelligence | Canonical local lists and bounded external feed updates |
+| High availability | TLS 1.3, bearer authentication and peer-scoped synchronization |
+| Operations | Local CLI and TUI, modular configuration, audit and lifecycle controls |
+| Supply chain | Checksummed Linux packages, signed update metadata and release evidence |
 
-Use `syswarden <command> --help` before any host-mutating action.
+## Why Choose SysWarden
 
-## Files, services and ports
+- **Host-local by design.** Security decisions stay close to the protected
+  Linux host, without an inline proxy or remote terminal listener.
+- **Fail-closed boundaries.** Ambiguous configuration, identity, feed or HA
+  state is rejected before security policy is published.
+- **Operator control.** Existing firewall service ownership is preserved, and
+  host mutation remains explicit and reviewable.
+- **Auditable delivery.** Source, package, security, compliance and release
+  qualification gates expose the evidence behind each release decision.
+- **Open source.** The implementation and its operational boundaries can be
+  inspected, tested and improved by the community.
 
-| Surface | Linux path or default |
+## Documentation
+
+Operational procedures are centralized in the
+[SysWarden wiki](https://github.com/duggytuxy/syswarden/wiki).
+
+| Goal | Documentation |
 | --- | --- |
-| Modular configuration | `/etc/syswarden/config` |
-| Legacy configuration input | `/opt/syswarden/syswarden-auto.conf` |
-| HA client trust bundle | `/etc/syswarden/ha-ca.pem` |
-| HA server identity | `/var/lib/syswarden/ha/server.crt` and `server.key` |
-| Local telemetry | `/var/lib/syswarden/ui/data.json` |
-| Persistent IP registries | `/etc/syswarden/lists` |
-| Logs | `/var/log/syswarden` |
-| Core service | `syswarden-core.service` or OpenRC equivalent |
-| Firewall service | `syswarden-firewall.service` or OpenRC equivalent |
-| HA API | TCP 62026 by default, configurable |
-| Native TUI | No listening port |
+| Verify and install a package | [Installation procedure](https://github.com/duggytuxy/syswarden/wiki/Deployment-Tutorial#4-verify-and-install-one-package) |
+| Upgrade from historical v4.02.8 to v4.03.2 | [Migration procedure](https://github.com/duggytuxy/syswarden/wiki/Migration-v4.02.8-to-v4.03.2) |
+| Configure SysWarden | [Configuration guide](https://github.com/duggytuxy/syswarden/wiki/Deployment-Tutorial#7-configuration-layout) |
+| Integrate SysWarden into RHEL 9+ images | [RHEL 9+ image integration](https://github.com/duggytuxy/syswarden/wiki/RHEL-9-Image-Extensions) |
+| Operate, audit or remove SysWarden | [Command and lifecycle reference](https://github.com/duggytuxy/syswarden/wiki/Deployment-Tutorial#11-command-inventory) |
+| Review bounded deployment scenarios | [Use cases](https://github.com/duggytuxy/syswarden/wiki/Use-cases) |
+| Configure the BunkerWeb integration | [BunkerWeb integration](https://github.com/duggytuxy/syswarden/wiki/BunkerWeb-Integration) |
 
-Never copy `server.key` to a client. Transfer only the public certificate or CA
-material through a trusted channel and verify its fingerprint before trust is
-enabled.
+## Project
 
-## Security posture and limitations
+[Security policy](SECURITY.md) | [Contributing](CONTRIBUTING.md) |
+[Releases](https://github.com/duggytuxy/syswarden/releases) | [License](LICENSE)
 
-- Keep recovery access before applying firewall, SSH, package or migration
-  changes. Test from a second session before closing the first.
-- `reload` validates the configured backend before host mutation, commits a
-  validated nftables candidate, reconciles at most one active firewalld or UFW
-  compatibility frontend and normally restarts the core. It is not a
-  zero-interruption guarantee.
-- `audit` inspects selected local services, files, firewall state and
-  configuration. It is not a compliance certification.
-- WAAP decisions are derived from logs already written by another service.
-  SysWarden does not proxy or sanitize live HTTP requests.
-- Log-driven enforcement requires one validated authoritative source address.
-  Ambiguous, conflicting or hostless records fail closed before firewall
-  mutation.
-- SysWarden internal security records use process-local authentication and do
-  not copy raw attacker-controlled payloads into the ingestion path.
-- Feed and SaaS allowlist publication is bounded and retains the last known
-  good state when source authority, quorum, integrity or target policy fails.
-- HA requires a complete operator inventory. A peer list, status response or
-  effective union cannot prove cluster completeness.
-- BunkerWeb migration cleanup remains limited to the partner's durable
-  ownership journal. Ambiguous co-ownership requires operator review.
-- SIEM, webhook and external feed security also depends on the configured
-  remote endpoint, trust material and network policy.
-- On Alpine Linux, SysWarden does not configure automatic operating-system
-  security updates. Repository selection and the `apk` update policy remain
-  an explicit operator responsibility.
-- `uninstall` removes configuration, state and logs and does not restore every
-  prior host setting. Back up required data before use.
-- A downgrade is a controlled emergency action. Keep TCP 62027 blocked and do
-  not restore retired authentication material.
-- Support and qualification claims apply only to the exact package matrix and
-  evidence described in this document.
+Developing and maintaining SysWarden requires infrastructure, testing and
+ongoing security work. Community support helps sustain the project.
 
-## Release evidence and report
-
-The [v4.03.2 public release readiness report](docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.2.md)
-records the exact package and asset inventory, migration contract, security
-limits and remaining release gates.
-
-Maintainers must complete the
-[local release preflight and prequalification procedure](docs/maintainers/LOCAL_RELEASE_PREFLIGHT.md)
-before pushing a release candidate or dispatching protected qualification. The
-local mirror never authorizes a tag or public Release.
-
-The report and this README remain candidate documentation until protected
-qualification passes and the maintainer authorizes the immutable tag.
-
-## License
-
-See [LICENSE](LICENSE).
+[![Support on Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/laurentmduggytuxy)

--- a/assets/syswarden_hero.svg
+++ b/assets/syswarden_hero.svg
@@ -1,36 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="720" viewBox="0 0 1600 720" role="img" aria-labelledby="title description" data-theme="dark" data-theme-status="legacy">
-  <title id="title">SysWarden Linux host defense</title>
-  <desc id="description">Linux security signals flow through the SysWarden decision engine into nftables enforcement, local terminal operations and an authenticated HA migration fence. Six Linux packages produce an exact thirteen-asset Release.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="340" viewBox="0 0 1600 340" role="img" aria-labelledby="title description" data-theme="light">
+  <title id="title">Official SysWarden logo</title>
+  <desc id="description">The official SysWarden Linux host defense logo on a clean light banner.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#07111f"/>
-      <stop offset="0.52" stop-color="#0b2033"/>
-      <stop offset="1" stop-color="#081727"/>
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#eef6fb"/>
     </linearGradient>
     <linearGradient id="officialShieldGradient" x1="0" y1="0" x2="0" y2="100">
       <stop offset="0%" stop-color="#00A3FF"/>
       <stop offset="100%" stop-color="#0055FF"/>
     </linearGradient>
-    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#112c42" stop-opacity="0.98"/>
-      <stop offset="1" stop-color="#0c1e31" stop-opacity="0.98"/>
-    </linearGradient>
-    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-      <feDropShadow dx="0" dy="16" stdDeviation="20" flood-color="#020617" flood-opacity="0.55"/>
-    </filter>
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
-      <feGaussianBlur stdDeviation="22"/>
+    <filter id="cardShadow" x="-20%" y="-30%" width="140%" height="170%">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#1e3a5f" flood-opacity="0.10"/>
     </filter>
     <filter id="officialLogoGlow" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur stdDeviation="6" result="blur"/>
       <feComposite in="SourceGraphic" in2="blur" operator="over"/>
     </filter>
-    <!-- Official brand geometry copied verbatim from assets/syswarden_logo.svg. -->
     <g id="syswardenOfficialMark">
-        <path d="M50 0 L100 20 V60 C100 90 75 110 50 120 C25 110 0 90 0 60 V20 L50 0 Z" fill="#161B22" stroke="url(#officialShieldGradient)" stroke-width="4" filter="url(#officialLogoGlow)"/>
-        <path d="M50 15 L85 30 V55 C85 75 65 90 50 100 C35 90 15 75 15 55 V30 L50 15 Z" fill="none" stroke="#00A3FF" stroke-width="1.5" opacity="0.5"/>
-        <path d="M35 45 L50 60 L35 75" fill="none" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-        <line x1="55" y1="75" x2="70" y2="75" stroke="#00A3FF" stroke-width="4" stroke-linecap="round" filter="url(#officialLogoGlow)"/>
+      <path d="M50 0 L100 20 V60 C100 90 75 110 50 120 C25 110 0 90 0 60 V20 L50 0 Z" fill="#161B22" stroke="url(#officialShieldGradient)" stroke-width="4" filter="url(#officialLogoGlow)"/>
+      <path d="M50 15 L85 30 V55 C85 75 65 90 50 100 C35 90 15 75 15 55 V30 L50 15 Z" fill="none" stroke="#00A3FF" stroke-width="1.5" opacity="0.5"/>
+      <path d="M35 45 L50 60 L35 75" fill="none" stroke="#FFFFFF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+      <line x1="55" y1="75" x2="70" y2="75" stroke="#00A3FF" stroke-width="4" stroke-linecap="round" filter="url(#officialLogoGlow)"/>
     </g>
     <g id="syswardenOfficialLogo" data-brand-source="assets/syswarden_logo.svg">
       <use href="#syswardenOfficialMark" transform="translate(30, 15)"/>
@@ -38,111 +29,29 @@
       <text x="165" y="118" class="official-logo-sub">ACTIVE DEFENSE HIDS/HIPS</text>
     </g>
     <style>
-      .label { font: 700 18px Inter,Segoe UI,Arial,sans-serif; fill: #f8fafc; }
-      .small { font: 500 14px Inter,Segoe UI,Arial,sans-serif; fill: #a8bed0; }
-      .mono { font: 700 14px ui-monospace,SFMono-Regular,Consolas,monospace; fill: #d8f6ff; letter-spacing: .4px; }
-      .chip { fill: #102c42; stroke: #2d5872; stroke-width: 1.5; }
-      .official-logo-text { font: 700 64px "Fira Code",ui-monospace,SFMono-Regular,Consolas,monospace; fill: #ffffff; letter-spacing: -1px; }
-      .official-logo-sub { font: 400 14px "Fira Code",ui-monospace,SFMono-Regular,Consolas,monospace; fill: #ffffff; letter-spacing: 5px; }
+      .official-logo-text {
+        font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-weight: 700;
+        font-size: 64px;
+        fill: #FFFFFF;
+        letter-spacing: -1px;
+      }
+      .official-logo-sub {
+        font-family: "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-weight: 400;
+        font-size: 14px;
+        fill: #FFFFFF;
+        letter-spacing: 5px;
+      }
     </style>
   </defs>
 
-  <rect width="1600" height="720" rx="30" fill="url(#background)"/>
-  <circle cx="1345" cy="82" r="190" fill="#0ea5e9" opacity="0.09" filter="url(#glow)"/>
-  <circle cx="230" cy="650" r="210" fill="#14b8a6" opacity="0.08" filter="url(#glow)"/>
-  <path d="M0 560 C260 500 420 650 700 585 S1190 500 1600 590 V720 H0 Z" fill="#0a1b2c" opacity="0.72"/>
-
-  <g transform="translate(70 48) scale(1.2)" filter="url(#shadow)">
+  <rect width="1600" height="340" rx="24" fill="url(#background)"/>
+  <circle cx="530" cy="75" r="155" fill="#dff4ff" opacity="0.62"/>
+  <circle cx="1115" cy="270" r="170" fill="#e5f0ff" opacity="0.58"/>
+  <rect x="350" y="50" width="900" height="240" rx="28" fill="#0b1f33" stroke="#25445f" stroke-width="2" filter="url(#cardShadow)"/>
+  <path d="M414 270 H1186" stroke="#294760" stroke-width="2" stroke-linecap="round"/>
+  <g transform="translate(500 95)">
     <use href="#syswardenOfficialLogo"/>
-  </g>
-  <text x="92" y="235" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="19" font-weight="500" fill="#a8bed0">Linux host defense | local enforcement | authenticated HA | fail-closed release gates</text>
-
-  <g transform="translate(90 292)" filter="url(#shadow)">
-    <rect width="320" height="214" rx="22" fill="url(#panel)" stroke="#22455e" stroke-width="2"/>
-    <text x="26" y="40" class="small" fill="#5eead4">SECURITY INPUTS</text>
-    <g transform="translate(24 64)">
-      <rect width="272" height="38" rx="10" class="chip"/>
-      <circle cx="22" cy="19" r="6" fill="#38bdf8"/>
-      <text x="40" y="24" class="label" font-size="16">HIDS and host telemetry</text>
-    </g>
-    <g transform="translate(24 112)">
-      <rect width="272" height="38" rx="10" class="chip"/>
-      <circle cx="22" cy="19" r="6" fill="#2dd4bf"/>
-      <text x="40" y="24" class="label" font-size="16">WAAP logs, out of band</text>
-    </g>
-    <g transform="translate(24 160)">
-      <rect width="272" height="38" rx="10" class="chip"/>
-      <circle cx="22" cy="19" r="6" fill="#f59e0b"/>
-      <text x="40" y="24" class="label" font-size="16">Threat-intelligence feeds</text>
-    </g>
-  </g>
-
-  <g transform="translate(492 255)" filter="url(#shadow)">
-    <rect width="426" height="288" rx="28" fill="#0d293e" stroke="#2dd4bf" stroke-width="2.5"/>
-    <rect x="20" y="20" width="386" height="248" rx="20" fill="#091d2f" stroke="#24506a"/>
-    <text x="213" y="64" text-anchor="middle" class="small" fill="#5eead4">HOST-LOCAL DECISION ENGINE</text>
-    <text x="213" y="111" text-anchor="middle" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="31" font-weight="800" fill="#f8fafc">Policy and provenance</text>
-    <path d="M79 150 H347" stroke="#284a61" stroke-width="2"/>
-    <g transform="translate(48 173)">
-      <rect width="150" height="58" rx="14" fill="#102e43"/>
-      <text x="75" y="25" text-anchor="middle" class="mono">CLI + CORE</text>
-      <text x="75" y="44" text-anchor="middle" class="small">validated config</text>
-    </g>
-    <g transform="translate(228 173)">
-      <rect width="150" height="58" rx="14" fill="#102e43"/>
-      <text x="75" y="25" text-anchor="middle" class="mono">LOCAL TUI</text>
-      <text x="75" y="44" text-anchor="middle" class="small">no listener</text>
-    </g>
-  </g>
-
-  <path d="M410 399 H472" stroke="#38bdf8" stroke-width="4" stroke-linecap="round"/>
-  <path d="M460 389 L476 399 L460 409" fill="none" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <g transform="translate(1000 292)" filter="url(#shadow)">
-    <rect width="510" height="214" rx="22" fill="url(#panel)" stroke="#22455e" stroke-width="2"/>
-    <text x="26" y="40" class="small" fill="#5eead4">VERIFIED OUTPUTS</text>
-    <g transform="translate(24 64)">
-      <rect width="222" height="62" rx="13" class="chip"/>
-      <text x="18" y="27" class="mono">NFTABLES</text>
-      <text x="18" y="48" class="small">atomic Linux policy</text>
-    </g>
-    <g transform="translate(264 64)">
-      <rect width="222" height="62" rx="13" class="chip"/>
-      <text x="18" y="27" class="mono">HA API : 62026</text>
-      <text x="18" y="48" class="small">TLS 1.3 + bearer</text>
-    </g>
-    <g transform="translate(24 142)">
-      <rect width="462" height="48" rx="12" fill="#0e3548" stroke="#2dd4bf" stroke-width="1.5"/>
-      <text x="20" y="21" class="mono">MIGRATION FENCE</text>
-      <text x="190" y="21" class="small">challenge + condition bound</text>
-      <text x="20" y="40" class="small">Opaque epoch and digest equality | peer scoped</text>
-    </g>
-  </g>
-
-  <path d="M920 399 H980" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round"/>
-  <path d="M968 389 L984 399 L968 409" fill="none" stroke="#2dd4bf" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <g transform="translate(90 586)">
-    <text x="0" y="18" class="small" fill="#5eead4">QUALIFIED RELEASE CONTRACT</text>
-    <g transform="translate(0 34)">
-      <rect width="218" height="48" rx="12" class="chip"/>
-      <text x="109" y="29" text-anchor="middle" class="mono">DEB | amd64 + arm64</text>
-    </g>
-    <g transform="translate(232 34)">
-      <rect width="234" height="48" rx="12" class="chip"/>
-      <text x="117" y="29" text-anchor="middle" class="mono">RPM | x86_64 + aarch64</text>
-    </g>
-    <g transform="translate(480 34)">
-      <rect width="234" height="48" rx="12" class="chip"/>
-      <text x="117" y="29" text-anchor="middle" class="mono">APK | x86_64 + aarch64</text>
-    </g>
-    <g transform="translate(728 34)">
-      <rect width="260" height="48" rx="12" fill="#103446" stroke="#2dd4bf" stroke-width="1.5"/>
-      <text x="130" y="29" text-anchor="middle" class="mono">6 PACKAGES | 13 ASSETS</text>
-    </g>
-    <g transform="translate(1002 34)">
-      <rect width="418" height="48" rx="12" class="chip"/>
-      <text x="209" y="29" text-anchor="middle" class="mono">NATIVE ARM64 | ED25519 | EXACT SHA</text>
-    </g>
   </g>
 </svg>

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -48,45 +48,17 @@
   ],
   "required_readme_phrases": [
     "Current source version: **{version}**.",
-    "Target candidate: **v4.03.2**.",
-    "The package workflow is configured to generate two DEB, two RPM and two APK packages plus `SHA256SUMS.txt`.",
-    "A qualified v4.03.2 Release contains exactly thirteen public assets:",
-    "The TUI reads local telemetry and HA status. It runs inside the invoking terminal and opens no listening socket.",
-    "The current Linux package builds, validates and commits one authoritative nftables ruleset.",
-    "`core.firewall_backend = \"keep\"` is the fresh-install default",
-    "The `iptables` value remains parseable for configuration compatibility",
-    "SysWarden owns no listener and no generated firewall permission on TCP 62027.",
-    "`DELETE {{\"bans\": [...]}}` removes provenance ledger entries only",
-    "`DELETE {{\"ips\": [...]}}` explicitly removes historical static entries",
-    "The capability `native_sync_fence_v1` announces schema support only.",
-    "`native_sync_fence.state` is `active_drained`",
-    "`X-SysWarden-HA-Fence-Condition` response header equals the JSON `condition` value",
-    "The integrator treats the epoch and both digest values as opaque, case-sensitive strings.",
-    "does not recalculate either digest or reimplement SysWarden canonicalization",
-    "a missing condition receives HTTP 428, a malformed condition receives HTTP 400 and a stale condition receives HTTP 412",
-    "A one-hour continuous absence window is additional evidence only.",
-    "It is never proof of drain",
-    "`schema_version = 1` is the current modular schema.",
-    "When `schema_version` is absent, the configuration is treated as historical input.",
-    "`syswarden config validate` is read-only.",
-    "unknown and deprecated keys are reported as diagnostics",
-    "`syswarden config migrate --dry-run` performs zero source or destination writes",
-    "`syswarden migrate-config` remains a compatibility alias",
-    "`network.saas.allow_monitors` takes precedence over the deprecated `integrations.saas.enabled` alias; if neither is set, monitor allowlisting is disabled.",
-    "Valid canonical IPv4 and IPv6 results are published as one lock-coordinated atomic pair with an SHA-256 pair manifest",
-    "Log-driven enforcement requires one validated authoritative source address.",
-    "SysWarden internal security records use process-local authentication",
-    "Feed and SaaS allowlist publication is bounded",
-    "`--port` scopes a whitelist entry to one TCP service",
-    "SSH exceptions are rendered only for the effective SSH port.",
-    "a changed-port mismatch fails closed before candidate policy application",
-    "The core opens them descriptor-relative without following links and revalidates the file identity and type after every rotation",
-    "operators must keep every parent directory protected against untrusted replacement",
-    "Rsyslog strings and WireGuard values are validated and encoded for their destination grammars",
-    "SSH/HA port separation while WireGuard is enabled.",
-    "The [RHEL image staging extension](extensions/rhel-image/README.md) is an additive, opt-in path",
-    "Offline staging does not establish runtime readiness or widen the qualified package matrix.",
-    "The report and this README remain candidate documentation until protected qualification passes"
+    "The source describes the v4.03.2 candidate and does not claim that the release has been qualified, tagged or published.",
+    "SysWarden is an open-source Linux security orchestrator",
+    "SysWarden is not an inline HTTP proxy, a traffic sanitizer or a regulatory certification product.",
+    "Authoritative nftables enforcement with bounded firewalld and UFW compatibility",
+    "Native local terminal dashboard with no browser service or listening port.",
+    "Authenticated HA synchronization over TLS 1.3",
+    "Checksummed Linux packages, signed update metadata and release evidence",
+    "Operational procedures are centralized in the [SysWarden wiki](https://github.com/duggytuxy/syswarden/wiki).",
+    "[Migration procedure](https://github.com/duggytuxy/syswarden/wiki/Migration-v4.02.8-to-v4.03.2)",
+    "[RHEL 9+ image integration](https://github.com/duggytuxy/syswarden/wiki/RHEL-9-Image-Extensions)",
+    "[![Support on Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/laurentmduggytuxy)"
   ],
   "required_manual_phrases": [
     "it is not a compliance certification",
@@ -124,13 +96,54 @@
       "Offline staging is not runtime-readiness evidence."
     ],
     "Deployment-Tutorial.md": [
+      "The package workflow is configured to generate two DEB, two RPM and two APK packages plus `SHA256SUMS.txt`.",
       "## 5. Optional RHEL-compatible image staging",
       "The extension installs that RPM with plugins, package scripts and triggers disabled.",
-      "Offline staging is not runtime-readiness evidence."
+      "Offline staging is not runtime-readiness evidence.",
+      "`schema_version = 1` is the current modular schema.",
+      "When `schema_version` is absent, the configuration is treated as historical input.",
+      "`syswarden config validate` is read-only.",
+      "unknown and deprecated keys are reported as diagnostics",
+      "`syswarden config migrate --dry-run` performs zero source or destination writes",
+      "`syswarden migrate-config` remains a compatibility alias",
+      "`network.saas.allow_monitors` takes precedence over the deprecated `integrations.saas.enabled` alias; if neither is set, monitor allowlisting is disabled.",
+      "Valid canonical IPv4 and IPv6 results are published as one lock-coordinated atomic pair with an SHA-256 pair manifest",
+      "`--port` scopes a whitelist entry to one TCP service",
+      "SSH exceptions are rendered only for the effective SSH port.",
+      "a changed-port mismatch fails closed before candidate policy application",
+      "The core opens them descriptor-relative without following links and revalidates the file identity and type after every rotation",
+      "operators must keep every parent directory protected against untrusted replacement",
+      "Rsyslog strings and WireGuard values are validated and encoded for their destination grammars",
+      "SSH/HA port separation while WireGuard is enabled."
     ],
     "Use-cases.md": [
       "## 9. Stage a fresh RHEL-compatible image root",
       "No product binary, service manager, firewall tool, kernel-policy tool, cron command, network endpoint or process signal runs during offline staging."
+    ],
+    "BunkerWeb-Integration.md": [
+      "`DELETE {{\"bans\": [...]}}` removes provenance ledger entries only",
+      "`DELETE {{\"ips\": [...]}}` explicitly removes historical static entries",
+      "The capability `native_sync_fence_v1` announces schema support only.",
+      "`native_sync_fence.state` is `active_drained`",
+      "`X-SysWarden-HA-Fence-Condition` response header equals the JSON `condition` value",
+      "The integrator treats the epoch and both digest values as opaque, case-sensitive strings.",
+      "does not recalculate either digest or reimplement SysWarden canonicalization",
+      "a missing condition receives HTTP 428, a malformed condition receives HTTP 400 and a stale condition receives HTTP 412",
+      "A one-hour continuous absence window is additional evidence only.",
+      "It is never proof of drain"
+    ],
+    "Migration-v4.02.8-to-v4.03.2.md": [
+      "The historical v4.02.8 binary predates the signed updater protocol.",
+      "The first hop to v4.03.2 must use a separately downloaded and checksum-verified Linux package.",
+      "Back up `/etc/syswarden`, required list files and HA trust material.",
+      "Keep verified local console or SSH recovery access throughout the migration.",
+      "SysWarden package rollback is an explicit package and configuration recovery procedure, not a general host-state reversal."
+    ],
+    "RHEL-9-Image-Extensions.md": [
+      "The offline RPM staging extension is the only currently available RHEL 9+ image extension.",
+      "The runtime-only, package-owned system-integration extension is not available in v4.03.2.",
+      "The future extension must keep the Go binaries runtime-only while the RPM owns firewall and systemd configuration.",
+      "Offline staging does not establish runtime readiness or widen the qualified package matrix."
     ]
   },
   "approved_cli_process_differences": [
@@ -644,46 +657,46 @@
       }
     ],
     "inventory_phrases": {
-      "README.md": "The package workflow is configured to generate two DEB, two RPM and two APK packages plus `SHA256SUMS.txt`."
+      "wiki/Deployment-Tutorial.md": "The package workflow is configured to generate two DEB, two RPM and two APK packages plus `SHA256SUMS.txt`."
     },
     "tables": {
-      "README.md": {
-        "heading": "Supported targets and qualification",
+      "wiki/Deployment-Tutorial.md": {
+        "heading": "1. Supported package matrix",
         "header": [
-          "Target",
-          "Candidate artifact",
-          "Required release proof"
+          "Distribution family",
+          "Architecture",
+          "Expected package"
         ],
         "rows": [
           [
-            "Debian or Ubuntu amd64",
-            "`syswarden_4.03.2_amd64.deb`",
-            "Native install, upgrade, restart, removal and rollback lifecycle"
+            "Debian or Ubuntu",
+            "amd64",
+            "`syswarden_4.03.2_amd64.deb`"
           ],
           [
-            "Debian or Ubuntu arm64",
-            "`syswarden_4.03.2_arm64.deb`",
-            "Native ARM64 lifecycle on the exact candidate package"
+            "Debian or Ubuntu",
+            "arm64",
+            "`syswarden_4.03.2_arm64.deb`"
           ],
           [
-            "Fedora or RHEL-family x86_64",
-            "`syswarden-4.03.2-1.x86_64.rpm`",
-            "Native install, upgrade, restart, removal and rollback lifecycle"
+            "Fedora or RHEL family",
+            "x86_64",
+            "`syswarden-4.03.2-1.x86_64.rpm`"
           ],
           [
-            "Fedora or RHEL-family aarch64",
-            "`syswarden-4.03.2-1.aarch64.rpm`",
-            "Native ARM64 lifecycle on the exact candidate package"
+            "Fedora or RHEL family",
+            "aarch64",
+            "`syswarden-4.03.2-1.aarch64.rpm`"
           ],
           [
-            "Alpine x86_64",
-            "`syswarden_4.03.2_x86_64.apk`",
-            "Native OpenRC lifecycle with the dedicated CGO-free executable"
+            "Alpine",
+            "x86_64",
+            "`syswarden_4.03.2_x86_64.apk`"
           ],
           [
-            "Alpine aarch64",
-            "`syswarden_4.03.2_aarch64.apk`",
-            "Native ARM64 OpenRC lifecycle with the dedicated CGO-free executable"
+            "Alpine",
+            "aarch64",
+            "`syswarden_4.03.2_aarch64.apk`"
           ]
         ]
       }

--- a/scripts/ci/documentation_gate.py
+++ b/scripts/ci/documentation_gate.py
@@ -67,6 +67,14 @@ CURRENT_SURFACE_RETIRED_TERMS = (
     "web" + "_tui",
     "." + "txz",
 )
+REQUIRED_OPERATIONAL_WIKI_PAGES = frozenset(
+    {
+        "Deployment-Tutorial.md",
+        "BunkerWeb-Integration.md",
+        "Migration-v4.02.8-to-v4.03.2.md",
+        "RHEL-9-Image-Extensions.md",
+    }
+)
 FRENCH_RE = re.compile(
     r"[àâçéèêëîïôùûüÿœ]|\b(?:aucune|ceci|cliquez|doit|français|"
     r"installation\s+sécurisée|mise\s+à\s+jour|paramètres|pré-requis|"
@@ -500,8 +508,8 @@ def resolve_local_target(document: Path, target: str, wiki_root: Path | None) ->
     candidate = document.parent / path_part
     if candidate.exists():
         return candidate
-    if wiki_root is not None and candidate.suffix == "":
-        markdown_candidate = candidate.with_suffix(".md")
+    if wiki_root is not None and not candidate.name.casefold().endswith(".md"):
+        markdown_candidate = candidate.parent / f"{candidate.name}.md"
         if markdown_candidate.exists():
             return markdown_candidate
     return candidate
@@ -630,7 +638,9 @@ def validate_package_source_contract(repo_root: Path, value: object) -> list[str
     errors: list[str] = []
     release_names: list[str] = []
     workflow_names: list[str] = []
+    table_rows: list[list[str]] = []
     coordinates: set[tuple[str, str]] = set()
+    current_version = source_version(repo_root).removeprefix("v")
     for index, artifact in enumerate(artifacts):
         if not isinstance(artifact, dict) or not all(
             isinstance(artifact.get(key), str) and artifact[key]
@@ -665,6 +675,19 @@ def validate_package_source_contract(repo_root: Path, value: object) -> list[str
             )
         release_names.append(release_name)
         workflow_names.append(artifact["workflow_name"])
+        distribution = {
+            "DEB": "Debian or Ubuntu",
+            "RPM": "Fedora or RHEL family",
+            "APK": "Alpine",
+        }.get(family)
+        if distribution is not None:
+            table_rows.append(
+                [
+                    distribution,
+                    architecture,
+                    f"`{artifact['release_name'].format(version=current_version)}`",
+                ]
+            )
 
     expected_release_names = release_gate.package_names("9.99.9")
     if release_names != expected_release_names:
@@ -685,7 +708,7 @@ def validate_package_source_contract(repo_root: Path, value: object) -> list[str
         return number_words.get(count, str(count))
 
     expected_inventory_phrases = {
-        "README.md": (
+        "wiki/Deployment-Tutorial.md": (
             "The package workflow is configured to generate "
             f"{count_word('DEB')} DEB, {count_word('RPM')} RPM "
             f"and {count_word('APK')} APK packages plus "
@@ -697,6 +720,25 @@ def validate_package_source_contract(repo_root: Path, value: object) -> list[str
         errors.append(
             "documentation package count statements do not match the exact release inventory; "
             f"expected={expected_inventory_phrases}, actual={inventory_phrases}"
+        )
+
+    expected_tables = {
+        "wiki/Deployment-Tutorial.md": {
+            "heading": "1. Supported package matrix",
+            "header": [
+                "Distribution family",
+                "Architecture",
+                "Expected package",
+            ],
+            "rows": table_rows,
+        }
+    }
+    tables = value.get("tables")
+    if tables != expected_tables:
+        errors.append(
+            "documentation package table contract does not match the exact "
+            "source package matrix; "
+            f"expected={expected_tables}, actual={tables}"
         )
 
     workflow = read_text(repo_root / ".github/workflows/package.yml")
@@ -1169,6 +1211,41 @@ def require_phrases(
     return errors
 
 
+def validate_wiki_phrase_contract(value: object) -> list[str]:
+    """Validate the repository-owned contract for separately published wiki pages."""
+
+    if not isinstance(value, dict) or not value:
+        return ["documentation contract required_wiki_phrases must be a non-empty object"]
+
+    errors: list[str] = []
+    pages = set(value)
+    missing = REQUIRED_OPERATIONAL_WIKI_PAGES - pages
+    if missing:
+        errors.append(
+            "documentation contract is missing required operational wiki pages: "
+            f"{sorted(missing)}"
+        )
+
+    for page, phrases in value.items():
+        if not isinstance(page, str) or not page.endswith(".md") or "/" in page:
+            errors.append(f"invalid wiki contract page: {page!r}")
+            continue
+        if not isinstance(phrases, list) or not phrases or not all(
+            isinstance(phrase, str) and phrase.strip() for phrase in phrases
+        ):
+            errors.append(
+                f"documentation contract required_wiki_phrases[{page!r}] "
+                "must be a non-empty string list"
+            )
+            continue
+        if len(phrases) != len(set(phrases)):
+            errors.append(
+                f"documentation contract required_wiki_phrases[{page!r}] "
+                "contains duplicates"
+            )
+    return errors
+
+
 def validate_source_assertions(repo_root: Path, contract: dict[str, object]) -> list[str]:
     errors: list[str] = []
     assertions = contract.get("source_assertions")
@@ -1374,6 +1451,7 @@ def validate_repository(
     if not isinstance(manual_required, list) or not all(isinstance(item, str) for item in manual_required):
         errors.append("documentation contract required_manual_phrases must be a string list")
         manual_required = []
+    errors.extend(validate_wiki_phrase_contract(wiki_required))
     if not isinstance(product_command_count, int) or product_command_count <= 0:
         errors.append("documentation contract product_command_count must be a positive integer")
     elif len(source_commands) != product_command_count:
@@ -1450,16 +1528,6 @@ def validate_repository(
     )
     errors.extend(require_phrases(readme, readme_required, version, "README.md"))
     errors.extend(require_phrases(manual, manual_required, version, "manual.go"))
-    errors.extend(
-        validate_package_documentation(
-            readme, "README.md", package_platform_contract
-        )
-    )
-    errors.extend(
-        validate_command_inventory(
-            readme, "Operator commands", source_commands, "README.md"
-        )
-    )
     errors.extend(validate_source_assertions(repo_root, contract))
     errors.extend(
         validate_active_public_surfaces(

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -30,13 +30,30 @@ class DocumentationGateTest(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual([record.path for record in records], ["README.md"])
 
+    def test_operational_wiki_contract_is_required_without_network_access(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        wiki_contract = contract["required_wiki_phrases"]
+        self.assertEqual(
+            documentation_gate.validate_wiki_phrase_contract(wiki_contract), []
+        )
+        changed = json.loads(json.dumps(wiki_contract))
+        changed.pop("RHEL-9-Image-Extensions.md")
+        errors = documentation_gate.validate_wiki_phrase_contract(changed)
+        self.assertTrue(any("missing required operational wiki pages" in error for error in errors))
+
     def test_current_version_and_candidate_status_are_explicit(self) -> None:
         self.assertEqual(documentation_gate.source_version(REPO_ROOT), "v4.03.2")
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         changelog = (REPO_ROOT / "changelog.md").read_text(encoding="utf-8")
         report = REPORT.read_text(encoding="utf-8")
-        self.assertIn("Current source version: **v4.03.2**.", readme)
-        self.assertIn("does not claim that v4.03.2 is qualified", readme)
+        self.assertEqual(
+            readme.splitlines().count("Current source version: **v4.03.2**."),
+            1,
+        )
+        self.assertIn(
+            "does not claim that the release has been qualified, tagged or published",
+            documentation_gate.normalized(readme),
+        )
         self.assertIn(
             "does not authorize a tag or publication",
             documentation_gate.normalized(changelog),
@@ -153,11 +170,11 @@ class DocumentationGateTest(unittest.TestCase):
         documented_workflows = set(re.findall(r"`([a-z0-9-]+\.yml)`", procedure))
         self.assertEqual(documented_workflows, actual_workflows)
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("docs/maintainers/LOCAL_RELEASE_PREFLIGHT.md", readme)
+        self.assertNotIn("docs/maintainers/LOCAL_RELEASE_PREFLIGHT.md", readme)
 
     def test_optional_image_policy_manifest_set_is_exact_and_executable(self) -> None:
         recipes: list[str] = []
-        for relative in ("README.md", "extensions/rhel-image/README.md"):
+        for relative in ("extensions/rhel-image/README.md",):
             errors: list[str] = []
             blocks = documentation_gate.extract_fenced_blocks(
                 (REPO_ROOT / relative).read_text(encoding="utf-8"),
@@ -189,7 +206,7 @@ class DocumentationGateTest(unittest.TestCase):
             start = recipe.index("POLICY_FILES=()")
             end = recipe.index(marker, start)
             segments.append(recipe[start:end])
-        self.assertEqual(segments[0], segments[1])
+        self.assertEqual(len(segments), 1)
 
         expected_files = [
             "ru.ipv4",
@@ -245,7 +262,7 @@ class DocumentationGateTest(unittest.TestCase):
         stage_command = (
             "sudo extensions/rhel-image/stage-syswarden-rhel-image.sh"
         )
-        for relative in ("README.md", "extensions/rhel-image/README.md"):
+        for relative in ("extensions/rhel-image/README.md",):
             errors: list[str] = []
             blocks = documentation_gate.extract_fenced_blocks(
                 (REPO_ROOT / relative).read_text(encoding="utf-8"),
@@ -273,11 +290,11 @@ class DocumentationGateTest(unittest.TestCase):
                     recipe.index(stage_command),
                     relative,
                 )
-        self.assertGreaterEqual(checked, 4)
+        self.assertGreaterEqual(checked, 3)
 
     def test_optional_image_configuration_publication_is_exact(self) -> None:
         recipes: list[str] = []
-        for relative in ("README.md", "extensions/rhel-image/README.md"):
+        for relative in ("extensions/rhel-image/README.md",):
             errors: list[str] = []
             blocks = documentation_gate.extract_fenced_blocks(
                 (REPO_ROOT / relative).read_text(encoding="utf-8"),
@@ -311,7 +328,7 @@ class DocumentationGateTest(unittest.TestCase):
             ):
                 self.assertIn(command, recipe)
             recipes.append(recipe)
-        self.assertEqual(recipes[0], recipes[1])
+        self.assertEqual(len(recipes), 1)
 
     def test_report_numbered_asset_inventory_matches_release_gate_order(self) -> None:
         report = REPORT.read_text(encoding="utf-8")
@@ -339,10 +356,9 @@ class DocumentationGateTest(unittest.TestCase):
         )
         self.assertTrue(any("exact release gate" in error for error in errors))
 
-    def test_package_contract_matches_workflow_and_readme(self) -> None:
+    def test_package_contract_matches_workflow_and_wiki_contract(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
         package_contract = contract["package_platform_contract"]
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertEqual(
             documentation_gate.validate_package_source_contract(
                 REPO_ROOT, package_contract
@@ -350,10 +366,12 @@ class DocumentationGateTest(unittest.TestCase):
             [],
         )
         self.assertEqual(
-            documentation_gate.validate_package_documentation(
-                readme, "README.md", package_contract
-            ),
-            [],
+            set(package_contract["inventory_phrases"]),
+            {"wiki/Deployment-Tutorial.md"},
+        )
+        self.assertEqual(
+            set(package_contract["tables"]),
+            {"wiki/Deployment-Tutorial.md"},
         )
         self.assertEqual(len(package_contract["artifacts"]), 6)
         self.assertEqual(
@@ -364,10 +382,11 @@ class DocumentationGateTest(unittest.TestCase):
     def test_package_count_and_architecture_mutations_are_rejected(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
         package_contract = contract["package_platform_contract"]
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-        wrong_count = readme.replace("two DEB, two RPM", "nine DEB, two RPM")
+        label = "wiki/Deployment-Tutorial.md"
+        documented_count = package_contract["inventory_phrases"][label]
+        wrong_count = documented_count.replace("two DEB, two RPM", "nine DEB, two RPM")
         errors = documentation_gate.validate_package_documentation(
-            wrong_count, "README.md", package_contract
+            wrong_count, label, package_contract
         )
         self.assertTrue(any("artifact count statement changed" in error for error in errors))
 
@@ -382,10 +401,9 @@ class DocumentationGateTest(unittest.TestCase):
         normalized_readme = documentation_gate.normalized(readme)
         normalized_report = documentation_gate.normalized(report)
         self.assertIn(
-            "runs inside the invoking terminal and opens no listening socket",
+            "Native local terminal dashboard with no browser service or listening port.",
             normalized_readme,
         )
-        self.assertIn("SysWarden owns no listener", readme)
         self.assertIn("native local TUI", normalized_report)
 
         contract = documentation_gate.load_contract(REPO_ROOT)
@@ -405,9 +423,8 @@ class DocumentationGateTest(unittest.TestCase):
         self.assertTrue(any("retired platform" in error for error in errors))
 
     def test_ha_partner_contract_is_unambiguous(self) -> None:
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         report = REPORT.read_text(encoding="utf-8")
-        for text in (readme, report):
+        for text in (report,):
             text = documentation_gate.normalized(text)
             self.assertIn("X-SysWarden-HA-Fence-Condition", text)
             self.assertIn("active_drained", text)
@@ -420,27 +437,49 @@ class DocumentationGateTest(unittest.TestCase):
             self.assertIn("HTTP 412", text)
             self.assertIn("one-hour", text)
             self.assertIn("It is never proof of drain", text)
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        wiki_contract = documentation_gate.normalized(
+            "\n".join(
+                contract["required_wiki_phrases"]["BunkerWeb-Integration.md"]
+            )
+        )
+        for phrase in (
+            "X-SysWarden-HA-Fence-Condition",
+            "active_drained",
+            "opaque, case-sensitive strings",
+            "does not recalculate",
+            "HTTP 428",
+            "HTTP 400",
+            "HTTP 412",
+            "one-hour",
+            "It is never proof of drain",
+        ):
+            self.assertIn(phrase, wiki_contract)
 
     def test_ha_delete_semantics_are_explicit(self) -> None:
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         report = REPORT.read_text(encoding="utf-8")
-        for text in (readme, report):
+        for text in (report,):
             self.assertIn('DELETE {"bans": [...]}` removes provenance ledger entries only', text)
             self.assertIn('DELETE {"ips": [...]}`', text)
             self.assertIn("durable", text)
             self.assertIn("ownership is never inferred", text.casefold())
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        wiki_contract = documentation_gate.normalized(
+            "\n".join(
+                contract["required_wiki_phrases"]["BunkerWeb-Integration.md"]
+            )
+        ).format()
+        self.assertIn('DELETE {"bans": [...]}', wiki_contract)
+        self.assertIn('DELETE {"ips": [...]}', wiki_contract)
 
     def test_config_saas_and_persistent_list_contract_is_source_bound(self) -> None:
-        readme = documentation_gate.normalized(
-            (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-        )
         report = documentation_gate.normalized(REPORT.read_text(encoding="utf-8"))
         manual = documentation_gate.normalized(
             (REPO_ROOT / "src/core/syswarden-cli/cmd/manual.go").read_text(
                 encoding="utf-8"
             )
         )
-        for text in (readme, report):
+        for text in (report,):
             self.assertIn("schema_version = 1", text)
             self.assertIn("historical input", text)
             self.assertIn("config validate", text)
@@ -474,6 +513,30 @@ class DocumentationGateTest(unittest.TestCase):
             self.assertIn(phrase, manual)
 
         contract = documentation_gate.load_contract(REPO_ROOT)
+        deployment_contract = documentation_gate.normalized(
+            "\n".join(
+                contract["required_wiki_phrases"]["Deployment-Tutorial.md"]
+            )
+        )
+        for phrase in (
+            "schema_version = 1",
+            "historical input",
+            "config validate",
+            "unknown and deprecated",
+            "config migrate --dry-run",
+            "zero source or destination writes",
+            "network.saas.allow_monitors",
+            "integrations.saas.enabled",
+            "lock-coordinated atomic pair",
+            "--port",
+            "effective SSH port",
+            "fails closed",
+            "revalidates the file identity and type after every rotation",
+            "parent directory protected against untrusted replacement",
+            "destination grammars",
+            "SSH/HA port separation",
+        ):
+            self.assertIn(phrase, deployment_contract)
         source_assertion_ids = {
             assertion["id"] for assertion in contract["source_assertions"]
         }
@@ -499,20 +562,45 @@ class DocumentationGateTest(unittest.TestCase):
             }.issubset(source_assertion_ids)
         )
 
+    def test_migration_and_rhel_wiki_boundaries_are_explicit(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        wiki = contract["required_wiki_phrases"]
+        migration = documentation_gate.normalized(
+            "\n".join(wiki["Migration-v4.02.8-to-v4.03.2.md"])
+        )
+        for phrase in (
+            "historical v4.02.8 binary predates the signed updater protocol",
+            "checksum-verified Linux package",
+            "Back up `/etc/syswarden`",
+            "verified local console or SSH recovery access",
+            "SysWarden package rollback is an explicit package and configuration recovery procedure, not a general host-state reversal.",
+        ):
+            self.assertIn(phrase, migration)
+
+        rhel = documentation_gate.normalized(
+            "\n".join(wiki["RHEL-9-Image-Extensions.md"])
+        )
+        self.assertIn("only currently available RHEL 9+ image extension", rhel)
+        self.assertIn(
+            "runtime-only, package-owned system-integration extension is not available",
+            rhel,
+        )
+        self.assertIn("Go binaries runtime-only", rhel)
+        self.assertIn("RPM owns firewall and systemd configuration", rhel)
+
     def test_cli_command_inventory_and_exact_add_remove_approvals(self) -> None:
         commands = documentation_gate.cobra_commands(REPO_ROOT)
         self.assertEqual(len(commands), 23)
         self.assertIn("ha-fence", commands)
         self.assertIn("tui", commands)
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+        contract = documentation_gate.load_contract(REPO_ROOT)
         self.assertEqual(
-            documentation_gate.validate_command_inventory(
-                readme, "Operator commands", commands, "README.md"
+            documentation_gate.validate_wiki_phrase_contract(
+                contract["required_wiki_phrases"]
             ),
             [],
         )
-
-        contract = documentation_gate.load_contract(REPO_ROOT)
         command_approvals = {
             item["path"]: (item["before"], item["after"])
             for item in contract["approved_cli_public_differences"]
@@ -575,7 +663,10 @@ class DocumentationGateTest(unittest.TestCase):
             text = path.read_text(encoding="utf-8")
             root = ET.fromstring(text)
             self.assertEqual(root.tag.rsplit("}", 1)[-1], "svg")
-            self.assertIn(f'assets/{name}', readme)
+            if name == "syswarden_hero.svg":
+                self.assertIn(f'assets/{name}', readme)
+            else:
+                self.assertNotIn(f'assets/{name}', readme)
             for element in root.iter():
                 self.assertNotIn(
                     element.tag.rsplit("}", 1)[-1].casefold(),
@@ -614,6 +705,23 @@ class DocumentationGateTest(unittest.TestCase):
             )
         self.assertTrue(any("unclosed Markdown fence" in error for error in errors))
         self.assertTrue(any("missing local link target" in error for error in errors))
+
+    def test_versioned_wiki_page_link_resolves_without_md_suffix(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            source = wiki_root / "Home.md"
+            target = wiki_root / "Migration-v4.02.8-to-v4.03.2.md"
+            source.write_text(
+                "# Home\n\n[Migration](Migration-v4.02.8-to-v4.03.2)\n",
+                encoding="utf-8",
+            )
+            target.write_text("# Migration\n", encoding="utf-8")
+            resolved = documentation_gate.resolve_local_target(
+                source,
+                "Migration-v4.02.8-to-v4.03.2",
+                wiki_root,
+            )
+        self.assertEqual(resolved, target)
 
     def test_report_writer_is_machine_readable_and_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1439,13 +1439,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                14,
+                15,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 13)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 14)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 14)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 15)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 24,
-                "scripts/ci/release_gate_test.py": 24,
+                ".github/workflows/release-manager.yml": 26,
+                "scripts/ci/release_gate_test.py": 26,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -1482,6 +1482,10 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         pinned_contracts = (
+            (
+                'if [[ "${v4032_docs_parent_sha}" != '
+                '"3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0" ]]; then'
+            ),
             (
                 'if [[ "${v4032_systemd_parent_sha}" != '
                 '"540bab73a477c76d6301d276383602db06d36acd" ]]; then'
@@ -1545,6 +1549,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        docs_subject_contract = (
+            "v4032_docs_expected_subject='Security : preserve read-only config "
+            "preflight and centralize v4.03.2 docs (#110)'"
+        )
         systemd_subject_contract = (
             "v4032_systemd_expected_subject='Qualification : seal "
             "systemd-capable ARM64 crun runtime (#109)'"
@@ -1596,6 +1604,18 @@ class ReleaseGateTests(unittest.TestCase):
         repair_subject_contract = (
             "v4032_expected_subject='Qualification : repair v4.03.2 "
             "package lifecycle qualification (#95) (#95)'"
+        )
+        docs_paths = (
+            ".github/workflows/release-manager.yml",
+            "README.md",
+            "assets/syswarden_hero.svg",
+            "scripts/ci/documentation_contract.json",
+            "scripts/ci/documentation_gate.py",
+            "scripts/ci/documentation_gate_test.py",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/workflow_required_checks_test.py",
+            "src/core/syswarden-cli/cmd/root.go",
+            "src/core/syswarden-cli/cmd/root_config_guard_test.go",
         )
         systemd_paths = (
             ".github/workflows/release-manager.yml",
@@ -1691,6 +1711,7 @@ class ReleaseGateTests(unittest.TestCase):
                 compliance_paths
                 + repair_paths
                 + crun_paths
+                + docs_paths
                 + systemd_paths
                 + cli_toml_paths
                 + core_toml_paths
@@ -1706,6 +1727,7 @@ class ReleaseGateTests(unittest.TestCase):
             "src/core/syswarden-core/webhook/discord.go",
         )
         for block in blocks:
+            self.assertEqual(block.count(docs_subject_contract), 1)
             self.assertEqual(block.count(systemd_subject_contract), 1)
             self.assertEqual(block.count(cli_toml_subject_contract), 1)
             self.assertEqual(block.count(core_toml_subject_contract), 1)
@@ -1722,20 +1744,94 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_docs_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_docs_parent_sha="$(git rev-parse HEAD^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_docs_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_docs_head_line[@]} != 2"), 1
+            )
+            docs_diff = block.split(
+                "# BEGIN exact v4.03.2 read-only configuration and documentation "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 read-only configuration and documentation "
+                "diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                docs_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(
+                docs_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+            )
+            self.assertEqual(
+                docs_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                docs_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                docs_diff.count(
+                    "! \"${tree_object}\" =~ ^[0-9a-f]{40}$"
+                ),
+                1,
+            )
+            self.assertEqual(
+                docs_diff.count(
+                    "${#actual_v4032_docs_diff[@]} != "
+                    "${#expected_v4032_docs_diff[@]}"
+                ),
+                1,
+            )
+            for path in docs_paths:
+                self.assertEqual(docs_diff.count(f'"{path}"'), 2)
+                self.assertEqual(docs_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(block.count("v4032_systemd_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_systemd_parent_sha="$(git rev-parse '
+                    '"${v4032_systemd_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_systemd_subject="$(git log -1 --format=%s '
+                    '"${v4032_systemd_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_systemd_subject}" != '
                     '"${v4032_systemd_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_systemd_parent_sha="$(git rev-parse HEAD^)"'
-                ),
-                1,
-            )
-            self.assertEqual(
-                block.count(
                     'v4032_systemd_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_systemd_ref}")"'
                 ),
                 1,
             )
@@ -1754,12 +1850,18 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 systemd_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_systemd_ref}^" '
+                    '"${v4032_systemd_ref}"'
                 ),
                 1,
             )
             self.assertEqual(
-                systemd_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+                systemd_diff.count(
+                    'for tree_ref in "${v4032_systemd_ref}^" '
+                    '"${v4032_systemd_ref}"; do'
+                ),
+                1,
             )
             self.assertEqual(
                 systemd_diff.count('"${tree_mode}" != "100644"'), 1
@@ -1783,7 +1885,12 @@ class ReleaseGateTests(unittest.TestCase):
             for path in systemd_paths:
                 self.assertEqual(systemd_diff.count(f'"{path}"'), 2)
                 self.assertEqual(systemd_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_cli_toml_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_cli_toml_ref="${v4032_systemd_ref}^"\n'
+                ),
+                1,
+            )
             self.assertEqual(
                 block.count(
                     'v4032_cli_toml_parent_sha="$(git rev-parse '
@@ -1857,7 +1964,9 @@ class ReleaseGateTests(unittest.TestCase):
                 self.assertEqual(cli_toml_diff.count(f'"{path}"'), 2)
                 self.assertEqual(cli_toml_diff.count(f'M "{path}"'), 1)
             self.assertEqual(
-                block.count("v4032_core_toml_ref=HEAD^^\n"),
+                block.count(
+                    'v4032_core_toml_ref="${v4032_cli_toml_ref}^"\n'
+                ),
                 1,
             )
             self.assertEqual(
@@ -1933,7 +2042,9 @@ class ReleaseGateTests(unittest.TestCase):
                 self.assertEqual(core_toml_diff.count(f'"{path}"'), 2)
                 self.assertEqual(core_toml_diff.count(f'M "{path}"'), 1)
             self.assertEqual(
-                block.count("v4032_crun_ref=HEAD^^^\n"),
+                block.count(
+                    'v4032_crun_ref="${v4032_core_toml_ref}^"\n'
+                ),
                 1,
             )
             self.assertEqual(
@@ -2758,7 +2869,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                12,
+                13,
             )
             self.assertEqual(
                 block.count(
@@ -2777,12 +2888,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                13,
+                14,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 13)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 14)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -2795,6 +2906,7 @@ class ReleaseGateTests(unittest.TestCase):
             )
             for path in expected_paths:
                 expected_count = 2 if path in repair_paths else 0
+                expected_count += 2 if path in docs_paths else 0
                 expected_count += 2 if path in crun_paths else 0
                 expected_count += 2 if path in compliance_paths else 0
                 expected_count += 2 if path in merge_paths else 0
@@ -2810,6 +2922,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 1 if path == "build_packages.sh" else 0
                 self.assertEqual(block.count(f'"{path}"'), expected_count)
                 expected_status_count = 1 if path in repair_paths else 0
+                expected_status_count += 1 if path in docs_paths else 0
                 expected_status_count += 1 if path in crun_paths else 0
                 expected_status_count += 1 if path in compliance_paths else 0
                 expected_status_count += 1 if path in merge_paths else 0
@@ -2953,6 +3066,34 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_docs_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 read-only configuration and documentation "
+            "diff contract\n"
+        )
+        end = (
+            "# END exact v4.03.2 read-only configuration and documentation "
+            "diff contract"
+        )
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_docs_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_docs_expected_subject="
+        end = (
+            'read -r -a v4032_docs_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_systemd_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -2966,20 +3107,31 @@ class ReleaseGateTests(unittest.TestCase):
         )
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_systemd_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_systemd_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_systemd_expected_subject="
+        subject_assignment = (
+            'v4032_systemd_subject="$(git log -1 --format=%s '
+            '"${v4032_systemd_ref}")"'
+        )
         end = (
             'read -r -a v4032_systemd_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 "${v4032_systemd_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment, 'v4032_systemd_subject="${COMMIT_SUBJECT:?}"'
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_cli_toml_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -3618,6 +3770,59 @@ class ReleaseGateTests(unittest.TestCase):
             check=True,
         )
         return repository
+
+    def test_release_manager_v4032_docs_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_docs_subject_gate_script(),
+            {
+                "valid": (
+                    "Security : preserve read-only config preflight and centralize v4.03.2 docs (#110)",
+                    True,
+                ),
+                "bare": (
+                    "Security : preserve read-only config preflight and centralize v4.03.2 docs",
+                    False,
+                ),
+                "previous pull request": (
+                    "Security : preserve read-only config preflight and centralize v4.03.2 docs (#109)",
+                    False,
+                ),
+                "wrong version": (
+                    "Security : preserve read-only config preflight and centralize v4.03.3 docs (#110)",
+                    False,
+                ),
+                "wrong scope": (
+                    "Security : weaken config preflight and centralize v4.03.2 docs (#110)",
+                    False,
+                ),
+                "trailing space": (
+                    "Security : preserve read-only config preflight and centralize v4.03.2 docs (#110) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_docs_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_docs_diff_script(),
+            "v4032-docs-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                "README.md",
+                "assets/syswarden_hero.svg",
+                "scripts/ci/documentation_contract.json",
+                "scripts/ci/documentation_gate.py",
+                "scripts/ci/documentation_gate_test.py",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/workflow_required_checks_test.py",
+                "src/core/syswarden-cli/cmd/root.go",
+                "src/core/syswarden-cli/cmd/root_config_guard_test.go",
+            ),
+        )
 
     def test_release_manager_v4032_systemd_subject_is_exact_github_squash(
         self,
@@ -4267,9 +4472,37 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "documentation parent resolution": workflow.replace(
+                'v4032_docs_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_docs_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact documentation parent": workflow.replace(
+                "3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0",
+                "4d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0",
+            ),
+            "documentation canonical subject": workflow.replace(
+                "Security : preserve read-only config preflight and centralize v4.03.2 docs (#110)",
+                "Security : preserve read-only config preflight and centralize v4.03.3 docs (#110)",
+            ),
+            "documentation subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "documentation linear head": workflow.replace(
+                'v4032_docs_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_docs_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "systemd reference": workflow.replace(
+                "v4032_systemd_ref=HEAD^",
+                "v4032_systemd_ref=HEAD^^",
+            ),
             "systemd parent resolution": workflow.replace(
-                'v4032_systemd_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_systemd_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_systemd_parent_sha="$(git rev-parse '
+                '"${v4032_systemd_ref}^")"',
+                'v4032_systemd_parent_sha="$(git rev-parse '
+                '"${v4032_systemd_ref}^^")"',
             ),
             "exact systemd parent": workflow.replace(
                 "540bab73a477c76d6301d276383602db06d36acd",
@@ -4280,18 +4513,20 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : repair systemd-capable ARM64 crun runtime (#109)",
             ),
             "systemd subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_systemd_subject="$(git log -1 --format=%s '
+                '"${v4032_systemd_ref}")"',
+                'v4032_systemd_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "systemd linear head": workflow.replace(
                 'v4032_systemd_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_systemd_ref}")"',
                 'v4032_systemd_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "CLI dependency reference": workflow.replace(
-                "v4032_cli_toml_ref=HEAD^",
-                "v4032_cli_toml_ref=HEAD^^",
+                'v4032_cli_toml_ref="${v4032_systemd_ref}^"',
+                'v4032_cli_toml_ref="${v4032_systemd_ref}^^"',
             ),
             "CLI dependency parent resolution": workflow.replace(
                 'v4032_cli_toml_parent_sha="$(git rev-parse '
@@ -4322,8 +4557,8 @@ class ReleaseGateTests(unittest.TestCase):
                 '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "core dependency reference": workflow.replace(
-                "v4032_core_toml_ref=HEAD^^",
-                "v4032_core_toml_ref=HEAD^^^",
+                'v4032_core_toml_ref="${v4032_cli_toml_ref}^"',
+                'v4032_core_toml_ref="${v4032_cli_toml_ref}^^"',
             ),
             "core dependency parent resolution": workflow.replace(
                 'v4032_core_toml_parent_sha="$(git rev-parse '
@@ -4354,8 +4589,8 @@ class ReleaseGateTests(unittest.TestCase):
                 '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "crun reference": workflow.replace(
-                "v4032_crun_ref=HEAD^^^",
-                "v4032_crun_ref=HEAD^^^^",
+                'v4032_crun_ref="${v4032_core_toml_ref}^"',
+                'v4032_crun_ref="${v4032_core_toml_ref}^^"',
             ),
             "crun parent resolution": workflow.replace(
                 'v4032_crun_parent_sha="$(git rev-parse '

--- a/scripts/ci/workflow_required_checks_test.py
+++ b/scripts/ci/workflow_required_checks_test.py
@@ -33,7 +33,6 @@ EMBEDDED_MARK_PRESENTATION = (
 LEGACY_DARK_VISUALS = {
     "syswarden_architecture.svg",
     "syswarden_bunkerweb_integration.svg",
-    "syswarden_hero.svg",
 }
 
 
@@ -179,7 +178,20 @@ class RequiredCheckWorkflowTests(unittest.TestCase):
             self.readme.count('src="assets/syswarden_hero.svg"'), 1
         )
         self.assertEqual(
-            self.readme.count('src="assets/syswarden_architecture.svg"'), 1
+            self.readme.count('src="assets/syswarden_architecture.svg"'), 0
+        )
+        self.assertEqual(
+            self.readme.count(
+                '</div>\n\n<br>\n\n<div align="center">'
+            ),
+            1,
+        )
+        self.assertEqual(
+            self.readme.count(
+                "[![Support on Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)]"
+                "(https://ko-fi.com/laurentmduggytuxy)"
+            ),
+            1,
         )
 
     def test_published_visuals_embed_the_exact_official_syswarden_brand(self) -> None:
@@ -235,6 +247,12 @@ class RequiredCheckWorkflowTests(unittest.TestCase):
                 else:
                     self.assertIn('data-theme="light"', visual)
                     self.assertNotIn('data-theme-status="legacy"', visual)
+        hero = visuals["syswarden_hero.svg"]
+        self.assertIn('<stop offset="0" stop-color="#f8fafc"/>', hero)
+        self.assertIn('fill="#0b1f33"', hero)
+        self.assertEqual(hero.count("fill: #FFFFFF;"), 2)
+        self.assertNotIn("fill: #0f2740;", hero)
+        self.assertNotIn("fill: #34506b;", hero)
 
     def test_bunkerweb_visual_routes_and_labels_do_not_reintroduce_overlaps(self) -> None:
         visual = self.brand_visuals["syswarden_bunkerweb_integration.svg"]

--- a/src/core/syswarden-cli/cmd/root.go
+++ b/src/core/syswarden-cli/cmd/root.go
@@ -18,6 +18,9 @@ var rootCmd = &cobra.Command{
 	Short: "SYSWARDEN Security Orchestrator",
 	Long:  "SYSWARDEN is a host firewall orchestrator and out-of-band security-log analysis toolkit; it is not an inline WAF.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if commandRequiresAutomaticConfigLoad(cmd) {
+			initConfigHook()
+		}
 		if err := enforceRemovalState(cmd); err != nil {
 			return err
 		}
@@ -42,11 +45,24 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(func() { initConfigHook() })
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", platformpaths.LegacyConfig, "config file")
 }
 
 var initConfigHook = initConfig
+
+// Configuration inspection and migration commands load their explicitly
+// selected inputs themselves. Loading the process-wide runtime configuration
+// first would let compatibility normalization modify operator files before a
+// read-only validation or dry-run migration starts.
+func commandRequiresAutomaticConfigLoad(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	if cmd == configValidateCmd || cmd == configMigrateCmd || cmd == migrateConfigCmd {
+		return false
+	}
+	return true
+}
 
 var inspectRemovalTombstone = system.InspectRemovalTombstone
 

--- a/src/core/syswarden-cli/cmd/root_config_guard_test.go
+++ b/src/core/syswarden-cli/cmd/root_config_guard_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -81,5 +83,251 @@ func TestDegradedConfigurationGuardHasExplicitRepairAllowlist_SW_CFG_001(t *test
 	testRoot.AddCommand(blocked)
 	if err := enforceValidatedConfiguration(blocked); err == nil {
 		t.Fatal("degraded guard accepted a command outside the repair/help allowlist")
+	}
+}
+
+func executeRootCobraLifecycle(t *testing.T, args []string, initialize func()) (string, error) {
+	t.Helper()
+	previousInit := initConfigHook
+	previousInspect := inspectRemovalTombstone
+	previousSilenceErrors := rootCmd.SilenceErrors
+	previousSilenceUsage := rootCmd.SilenceUsage
+	initConfigHook = initialize
+	inspectRemovalTombstone = func() (bool, error) { return false, nil }
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+	var output bytes.Buffer
+	rootCmd.SetOut(&output)
+	rootCmd.SetErr(&output)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		initConfigHook = previousInit
+		inspectRemovalTombstone = previousInspect
+		rootCmd.SilenceErrors = previousSilenceErrors
+		rootCmd.SilenceUsage = previousSilenceUsage
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	// ExecuteC deliberately exercises Cobra's complete lifecycle. Calling RunE
+	// directly would miss the root PersistentPreRunE initialization policy and
+	// would not protect the read-only contract against the original regression.
+	_, err := rootCmd.ExecuteC()
+	return output.String(), err
+}
+
+func preserveCommandFlags(t *testing.T, command *cobra.Command, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		flag := command.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("command %s is missing --%s", command.CommandPath(), name)
+		}
+		previousValue := flag.Value.String()
+		previousChanged := flag.Changed
+		t.Cleanup(func() {
+			if err := flag.Value.Set(previousValue); err != nil {
+				t.Errorf("restore --%s: %v", name, err)
+			}
+			flag.Changed = previousChanged
+		})
+	}
+}
+
+func readV4028CommandFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	fixtureRoot, err := os.OpenRoot(filepath.Join("..", "config", "testdata", "v4.02.8"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, readErr := fixtureRoot.ReadFile(name)
+	closeErr := fixtureRoot.Close()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	return content
+}
+
+func snapshotRegularFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	secureRoot, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := secureRoot.Close(); err != nil {
+			t.Errorf("close snapshot root: %v", err)
+		}
+	})
+	if err := fs.WalkDir(secureRoot.FS(), ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		content, err := secureRoot.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		snapshot[path] = string(content)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func TestConfigValidateCobraLifecycleDoesNotNormalizeHistoricalModularFiles_SW_CFG_002(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "config")
+	if err := config.InitializeDefaults(root); err != nil {
+		t.Fatal(err)
+	}
+	integrationPath := filepath.Join(root, "modules", "40-integrations.toml")
+	fixture := readV4028CommandFixture(t, "40-integrations.toml")
+	if !bytes.Contains(fixture, []byte("[integrations.ha]\nenabled = true")) ||
+		bytes.Contains(fixture, []byte("[integrations.bunkerweb]")) {
+		t.Fatal("v4.02.8 modular fixture no longer exercises persistent HA compatibility normalization")
+	}
+	if err := os.WriteFile(integrationPath, fixture, 0600); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotRegularFiles(t, root)
+	initializations := 0
+	var initializationErr error
+	preserveCommandFlags(t, configValidateCmd, "path")
+	_, err := executeRootCobraLifecycle(
+		t,
+		[]string{"config", "validate", "--path", root},
+		func() {
+			initializations++
+			initializationErr = config.ParseConfig(root)
+		},
+	)
+	if err != nil {
+		t.Fatalf("config validate lifecycle error = %v", err)
+	}
+	if initializations != 0 {
+		t.Fatalf("config validate ran %d automatic configuration initializations (last error: %v)", initializations, initializationErr)
+	}
+	if after := snapshotRegularFiles(t, root); !reflect.DeepEqual(after, before) {
+		t.Fatalf("config validate changed historical modular bytes:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestConfigMigrationDryRunCobraLifecycleDoesNotNormalizeHistoricalFiles_SW_CFG_002(t *testing.T) {
+	tests := []struct {
+		name               string
+		command            *cobra.Command
+		arguments          func(source, output string) []string
+		withModularRuntime bool
+	}{
+		{
+			name:    "config migrate",
+			command: configMigrateCmd,
+			arguments: func(source, output string) []string {
+				return []string{"config", "migrate", "--source", source, "--output", output, "--dry-run"}
+			},
+		},
+		{
+			name:               "migrate-config compatibility alias",
+			command:            migrateConfigCmd,
+			withModularRuntime: true,
+			arguments: func(source, output string) []string {
+				return []string{"migrate-config", "--source", source, "--output", output, "--dry-run"}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			source := filepath.Join(root, "syswarden-auto.conf")
+			legacyFixture := readV4028CommandFixture(t, "legacy-ha-default.conf")
+			if !bytes.Contains(legacyFixture, []byte(`SYSWARDEN_HA_ENABLED="y"`)) ||
+				bytes.Contains(legacyFixture, []byte("SYSWARDEN_BUNKERWEB_ENABLED=")) {
+				t.Fatal("v4.02.8 legacy fixture no longer exercises persistent HA compatibility normalization")
+			}
+			if err := os.WriteFile(source, legacyFixture, 0600); err != nil {
+				t.Fatal(err)
+			}
+			output := filepath.Join(root, "migrated")
+			initializationTarget := source
+			var modularBefore map[string]string
+			if test.withModularRuntime {
+				initializationTarget = filepath.Join(root, "runtime-config")
+				if err := config.InitializeDefaults(initializationTarget); err != nil {
+					t.Fatal(err)
+				}
+				integrationPath := filepath.Join(initializationTarget, "modules", "40-integrations.toml")
+				if err := os.WriteFile(integrationPath, readV4028CommandFixture(t, "40-integrations.toml"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				modularBefore = snapshotRegularFiles(t, initializationTarget)
+			}
+
+			initializations := 0
+			var initializationErr error
+			preserveCommandFlags(t, test.command, "source", "output", "dry-run")
+			_, err := executeRootCobraLifecycle(t, test.arguments(source, output), func() {
+				initializations++
+				initializationErr = config.ParseConfig(initializationTarget)
+			})
+			if err != nil {
+				t.Fatalf("%s --dry-run lifecycle error = %v", test.name, err)
+			}
+			if initializations != 0 {
+				t.Fatalf("%s --dry-run ran %d automatic configuration initializations (last error: %v)", test.name, initializations, initializationErr)
+			}
+			afterSource, err := os.ReadFile(source) // #nosec G304 -- source is rooted in t.TempDir
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(afterSource, legacyFixture) {
+				t.Fatalf("%s --dry-run changed historical legacy bytes", test.name)
+			}
+			if _, err := os.Lstat(output); !os.IsNotExist(err) {
+				t.Fatalf("%s --dry-run created destination state: %v", test.name, err)
+			}
+			if test.withModularRuntime {
+				if modularAfter := snapshotRegularFiles(t, initializationTarget); !reflect.DeepEqual(modularAfter, modularBefore) {
+					t.Fatalf("%s --dry-run changed unrelated historical modular runtime bytes", test.name)
+				}
+			}
+		})
+	}
+}
+
+func TestRootCobraLifecycleStillInitializesNormalCommands_SW_CFG_001(t *testing.T) {
+	const commandName = "config-initialization-probe"
+	initializations := 0
+	ran := false
+	probe := &cobra.Command{
+		Use: commandName,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+	rootCmd.AddCommand(probe)
+	degradedConfigAllowlist[commandName] = struct{}{}
+	t.Cleanup(func() {
+		rootCmd.RemoveCommand(probe)
+		delete(degradedConfigAllowlist, commandName)
+	})
+	_, err := executeRootCobraLifecycle(t, []string{commandName}, func() { initializations++ })
+	if err != nil {
+		t.Fatalf("normal command lifecycle error = %v", err)
+	}
+	if initializations != 1 || !ran {
+		t.Fatalf("normal lifecycle initialization/run = %d/%t, want 1/true", initializations, ran)
+	}
+	if !commandRequiresAutomaticConfigLoad(probe) {
+		t.Fatal("normal command unexpectedly opted out of automatic configuration loading")
 	}
 }


### PR DESCRIPTION
## Summary

- Keep `config validate`, `config migrate --dry-run`, and `migrate-config --dry-run` read-only through the complete Cobra lifecycle.
- Preserve automatic configuration initialization for normal operational commands.
- Replace the overloaded README with a concise product overview, feature and capability summary, reasons to choose SysWarden, and direct Wiki routes.
- Preserve the exact official SysWarden logo in a clean light-theme hero, restore the Plumber Score badge, add spacing, and restore the Ko-fi link.
- Centralize installation, configuration, v4.02.8 to v4.03.2 migration, lifecycle, and RHEL 9+ image integration procedures in the Wiki.

## Security impact

The previous Cobra initialization path could persist historical compatibility normalization before a validation or dry-run command entered its explicit read-only implementation. The new command-identity guard prevents that global load for the three inspection and migration commands, with full-lifecycle regression tests against historical v4.02.8 fixtures.

The migration runbook also rejects the immutable PR109 package artifact and both known PR109 DEB digests. Release provenance must resolve to the signed PR110 squash with PR109 as its sole parent, and the packages must be freshly rebuilt and requalified from that corrected commit.

## Validation

- `git diff --check`
- `go test -mod=readonly -count=1 ./cmd ./config`
- `go vet -mod=readonly ./cmd ./config`
- 133 focused documentation, release-gate, and workflow tests
- Full deterministic README plus six-page Wiki validation, including external HTTPS links
- 37 migration Bash fences accepted by `bash -n` and ShellCheck at error severity
- Exact DEB payload checks exercised against both PR109 architectures for disqualification evidence
- Independent source and migration-runbook reviews completed with no remaining actionable findings

## Provenance

This branch is exactly one signed commit above the signed PR109 squash and modifies exactly the ten reviewed regular files declared by the v4.03.2 release provenance gate.