### PR TITLE
Qualification : preserve ARM64 crun owner across delegation

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -136,17 +136,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_arm64_attestation_parent_sha="$(git rev-parse HEAD^)"
+              v4032_delegated_owner_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_delegated_owner_parent_sha}" != "5d20d2c4cbd1b249fc36b25025db280f25f7eb32" ]]; then
+                echo "ERROR: the delegated ARM64 crun owner correction is not based on the reviewed PR111 squash." >&2
+                exit 1
+              fi
+              v4032_delegated_owner_expected_subject='Qualification : preserve ARM64 crun owner across delegation (#112)'
+              if [[ "${commit_subject}" != "${v4032_delegated_owner_expected_subject}" ]]; then
+                echo "ERROR: the delegated ARM64 crun owner correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_delegated_owner_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_delegated_owner_head_line[@]} != 2 )); then
+                echo "ERROR: the delegated ARM64 crun owner correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 delegated ARM64 crun owner diff contract
+              expected_v4032_delegated_owner_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_delegated_owner_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_delegated_owner_diff[@]} != ${#expected_v4032_delegated_owner_diff[@]} )); then
+                echo "ERROR: the delegated ARM64 crun owner correction must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_delegated_owner_diff[@]}; index++)); do
+                if [[ "${actual_v4032_delegated_owner_diff[index]}" != "${expected_v4032_delegated_owner_diff[index]}" ]]; then
+                  echo "ERROR: the delegated ARM64 crun owner correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_delegated_owner_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_delegated_owner_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed delegated ARM64 crun owner correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 delegated ARM64 crun owner diff contract
+              v4032_arm64_attestation_ref=HEAD^
+              v4032_arm64_attestation_parent_sha="$(git rev-parse "${v4032_arm64_attestation_ref}^")"
               if [[ "${v4032_arm64_attestation_parent_sha}" != "8e3ef2a0f50e4833f3078a7a09c2d07bf984f6ef" ]]; then
                 echo "ERROR: the deterministic ARM64 crun attestation correction is not based on the reviewed PR110 squash." >&2
                 exit 1
               fi
               v4032_arm64_attestation_expected_subject='Qualification : stabilize ARM64 crun version attestation (#111)'
-              if [[ "${commit_subject}" != "${v4032_arm64_attestation_expected_subject}" ]]; then
+              v4032_arm64_attestation_subject="$(git log -1 --format=%s "${v4032_arm64_attestation_ref}")"
+              if [[ "${v4032_arm64_attestation_subject}" != "${v4032_arm64_attestation_expected_subject}" ]]; then
                 echo "ERROR: the deterministic ARM64 crun attestation correction requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_arm64_attestation_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_arm64_attestation_head_line <<< "$(git rev-list --parents -n 1 "${v4032_arm64_attestation_ref}")"
               if (( ${#v4032_arm64_attestation_head_line[@]} != 2 )); then
                 echo "ERROR: the deterministic ARM64 crun attestation correction must be one linear commit." >&2
                 exit 1
@@ -162,7 +220,8 @@ jobs:
                 M "scripts/ci/workflow_required_checks_test.py"
               )
               mapfile -d '' -t actual_v4032_arm64_attestation_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_arm64_attestation_ref}^" "${v4032_arm64_attestation_ref}"
               )
               if (( ${#actual_v4032_arm64_attestation_diff[@]} != ${#expected_v4032_arm64_attestation_diff[@]} )); then
                 echo "ERROR: the deterministic ARM64 crun attestation correction must modify exactly the seven reviewed files." >&2
@@ -183,7 +242,7 @@ jobs:
                 "scripts/ci/release_qualification_workflow_test.py"
                 "scripts/ci/workflow_required_checks_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_arm64_attestation_ref}^" "${v4032_arm64_attestation_ref}"; do
                 for fix_path in "${v4032_arm64_attestation_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -198,7 +257,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 deterministic ARM64 crun attestation diff contract
-              v4032_docs_ref=HEAD^
+              v4032_docs_ref="${v4032_arm64_attestation_ref}^"
               v4032_docs_parent_sha="$(git rev-parse "${v4032_docs_ref}^")"
               if [[ "${v4032_docs_parent_sha}" != "3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0" ]]; then
                 echo "ERROR: the v4.03.2 read-only and documentation correction is not based on the reviewed PR109 squash." >&2
@@ -1632,17 +1691,75 @@ jobs:
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
-              v4032_arm64_attestation_parent_sha="$(git rev-parse HEAD^)"
+              v4032_delegated_owner_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_delegated_owner_parent_sha}" != "5d20d2c4cbd1b249fc36b25025db280f25f7eb32" ]]; then
+                echo "ERROR: the delegated ARM64 crun owner correction is not based on the reviewed PR111 squash." >&2
+                exit 1
+              fi
+              v4032_delegated_owner_expected_subject='Qualification : preserve ARM64 crun owner across delegation (#112)'
+              if [[ "${commit_subject}" != "${v4032_delegated_owner_expected_subject}" ]]; then
+                echo "ERROR: the delegated ARM64 crun owner correction requires the exact reviewed squash subject." >&2
+                exit 1
+              fi
+              read -r -a v4032_delegated_owner_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              if (( ${#v4032_delegated_owner_head_line[@]} != 2 )); then
+                echo "ERROR: the delegated ARM64 crun owner correction must be one linear commit." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.2 delegated ARM64 crun owner diff contract
+              expected_v4032_delegated_owner_diff=(
+                M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
+              )
+              mapfile -d '' -t actual_v4032_delegated_owner_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4032_delegated_owner_diff[@]} != ${#expected_v4032_delegated_owner_diff[@]} )); then
+                echo "ERROR: the delegated ARM64 crun owner correction must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4032_delegated_owner_diff[@]}; index++)); do
+                if [[ "${actual_v4032_delegated_owner_diff[index]}" != "${expected_v4032_delegated_owner_diff[index]}" ]]; then
+                  echo "ERROR: the delegated ARM64 crun owner correction contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4032_delegated_owner_paths=(
+                ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4032_delegated_owner_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed delegated ARM64 crun owner correction ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.2 delegated ARM64 crun owner diff contract
+              v4032_arm64_attestation_ref=HEAD^
+              v4032_arm64_attestation_parent_sha="$(git rev-parse "${v4032_arm64_attestation_ref}^")"
               if [[ "${v4032_arm64_attestation_parent_sha}" != "8e3ef2a0f50e4833f3078a7a09c2d07bf984f6ef" ]]; then
                 echo "ERROR: the deterministic ARM64 crun attestation correction is not based on the reviewed PR110 squash." >&2
                 exit 1
               fi
               v4032_arm64_attestation_expected_subject='Qualification : stabilize ARM64 crun version attestation (#111)'
-              if [[ "${commit_subject}" != "${v4032_arm64_attestation_expected_subject}" ]]; then
+              v4032_arm64_attestation_subject="$(git log -1 --format=%s "${v4032_arm64_attestation_ref}")"
+              if [[ "${v4032_arm64_attestation_subject}" != "${v4032_arm64_attestation_expected_subject}" ]]; then
                 echo "ERROR: the deterministic ARM64 crun attestation correction requires the exact reviewed squash subject." >&2
                 exit 1
               fi
-              read -r -a v4032_arm64_attestation_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4032_arm64_attestation_head_line <<< "$(git rev-list --parents -n 1 "${v4032_arm64_attestation_ref}")"
               if (( ${#v4032_arm64_attestation_head_line[@]} != 2 )); then
                 echo "ERROR: the deterministic ARM64 crun attestation correction must be one linear commit." >&2
                 exit 1
@@ -1658,7 +1775,8 @@ jobs:
                 M "scripts/ci/workflow_required_checks_test.py"
               )
               mapfile -d '' -t actual_v4032_arm64_attestation_diff < <(
-                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                git diff-tree --no-commit-id --name-status -r --no-renames -z \
+                  "${v4032_arm64_attestation_ref}^" "${v4032_arm64_attestation_ref}"
               )
               if (( ${#actual_v4032_arm64_attestation_diff[@]} != ${#expected_v4032_arm64_attestation_diff[@]} )); then
                 echo "ERROR: the deterministic ARM64 crun attestation correction must modify exactly the seven reviewed files." >&2
@@ -1679,7 +1797,7 @@ jobs:
                 "scripts/ci/release_qualification_workflow_test.py"
                 "scripts/ci/workflow_required_checks_test.py"
               )
-              for tree_ref in HEAD^ HEAD; do
+              for tree_ref in "${v4032_arm64_attestation_ref}^" "${v4032_arm64_attestation_ref}"; do
                 for fix_path in "${v4032_arm64_attestation_paths[@]}"; do
                   tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
                   IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
@@ -1694,7 +1812,7 @@ jobs:
                 done
               done
               # END exact v4.03.2 deterministic ARM64 crun attestation diff contract
-              v4032_docs_ref=HEAD^
+              v4032_docs_ref="${v4032_arm64_attestation_ref}^"
               v4032_docs_parent_sha="$(git rev-parse "${v4032_docs_ref}^")"
               if [[ "${v4032_docs_parent_sha}" != "3d95b9e53fabf01f73ed36b7fb7dcdaaec0dc4a0" ]]; then
                 echo "ERROR: the v4.03.2 read-only and documentation correction is not based on the reviewed PR109 squash." >&2

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -669,6 +669,7 @@ jobs:
           user_id="$(id -u)"
           user_group="$(id -g)"
           user_name="$(id -un)"
+          host_owner_identity="${user_id}:${user_group}"
           user_service="user@${user_id}.service"
           runtime_dir="/run/user/${user_id}"
           delegate_directory="/etc/systemd/system/user@.service.d"
@@ -683,9 +684,11 @@ jobs:
           original_user_service_active=false
           arm_cleanup_completed=false
 
-          if [[ "${user_id}" -eq 0 || "${user_name}" != "runner" || \
+          if [[ ! "${host_owner_identity}" =~ ^[1-9][0-9]*:[0-9]+$ || \
+                "${user_name}" != "runner" || \
                 "${HOME}" != "/home/runner" || ! -d "${HOME}" || \
-                -L "${HOME}" || "$(stat -c '%u' "${HOME}")" != "${user_id}" ]]; then
+                -L "${HOME}" || "$(stat -c '%u' "${HOME}")" != \
+                  "${user_id}" ]]; then
             echo "ERROR: ARM64 qualification requires the exact non-root hosted runner identity." >&2
             exit 1
           fi
@@ -702,7 +705,7 @@ jobs:
             if [[ -L "${SHARD_ROOT}" || ! -d "${SHARD_ROOT}" || \
                   ! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
                   "$(stat -c '%u:%g:%a:%d:%i' "${SHARD_ROOT}")" != \
-                    "${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}" ]]; then
+                    "${host_owner_identity}:700:${ARM_SHARD_ROOT_INODE}" ]]; then
               return 1
             fi
           }
@@ -711,7 +714,7 @@ jobs:
                [[ -L "${crun_directory}" || ! -d "${crun_directory}" || \
                   ! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ || \
                   "$(stat -c '%u:%g:%a:%d:%i' "${crun_directory}")" != \
-                    "${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}" ]]; then
+                    "${host_owner_identity}:700:${ARM_CRUN_DIRECTORY_INODE}" ]]; then
               return 1
             fi
           }
@@ -724,7 +727,7 @@ jobs:
                   ! -f "${ARM_CRUN_PATH}" || -L "${ARM_CRUN_PATH}" || \
                   ! -x "${ARM_CRUN_PATH}" || \
                   "$(stat -c '%u:%g:%a:%s:%d:%i' "${ARM_CRUN_PATH}")" != \
-                    "${user_id}:${user_group}:700:3298128:${ARM_CRUN_INODE}" ]]; then
+                    "${host_owner_identity}:700:3298128:${ARM_CRUN_INODE}" ]]; then
               return 1
             fi
             if ! printf '%s  %s\n' "${ARM_CRUN_SHA256}" "${ARM_CRUN_PATH}" | \
@@ -888,8 +891,8 @@ jobs:
             '[engine.platform_to_oci_runtime]' \
             '"linux/arm64"="crun"' > "${containers_conf}"
           if [[ ! -f "${containers_conf}" || -L "${containers_conf}" || \
-                "$(stat -c '%u' "${containers_conf}")" != "${user_id}" || \
-                "$(stat -c '%a' "${containers_conf}")" != "600" ]]; then
+                "$(stat -c '%u:%g:%a' "${containers_conf}")" != \
+                  "${host_owner_identity}:600" ]]; then
             echo "ERROR: the isolated Podman configuration is not a private runner-owned file." >&2
             exit 1
           fi
@@ -901,16 +904,16 @@ jobs:
           chmod 0700 "${podman_local}"
           if [[ ! -f "${podman_local}" || -L "${podman_local}" || \
                 ! -x "${podman_local}" || \
-                "$(stat -c '%u' "${podman_local}")" != "${user_id}" || \
-                "$(stat -c '%a' "${podman_local}")" != "700" ]]; then
+                "$(stat -c '%u:%g:%a' "${podman_local}")" != \
+                  "${host_owner_identity}:700" ]]; then
             echo "ERROR: the local-only Podman launcher is not a private runner-owned executable." >&2
             exit 1
           fi
           : > "${podman_info}"
           chmod 0600 "${podman_info}"
           if [[ ! -f "${podman_info}" || -L "${podman_info}" || \
-                "$(stat -c '%u' "${podman_info}")" != "${user_id}" || \
-                "$(stat -c '%a' "${podman_info}")" != "600" ]]; then
+                "$(stat -c '%u:%g:%a' "${podman_info}")" != \
+                  "${host_owner_identity}:600" ]]; then
             echo "ERROR: the native ARM64 Podman info target is not a private runner-owned file." >&2
             exit 1
           fi
@@ -947,12 +950,14 @@ jobs:
               --setenv="SYSWARDEN_CRUN_INODE=${ARM_CRUN_INODE}" \
               --setenv="SYSWARDEN_CRUN_PATH=${ARM_CRUN_PATH}" \
               --setenv="SYSWARDEN_CRUN_SHA256=${ARM_CRUN_SHA256}" \
+              --setenv="SYSWARDEN_HOST_OWNER=${host_owner_identity}" \
+              --setenv="SYSWARDEN_HOST_UID=${user_id}" \
               --setenv="SYSWARDEN_PODMAN_INFO=${podman_info}" \
               --setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}" \
               --setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}" \
               --setenv="XDG_RUNTIME_DIR=${runtime_dir}" \
               /usr/bin/bash --noprofile --norc -e -o pipefail -c \
-              'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY; if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_LOCAL:-}" || ! -f "${SYSWARDEN_PODMAN_LOCAL}" || -L "${SYSWARDEN_PODMAN_LOCAL}" || ! -x "${SYSWARDEN_PODMAN_LOCAL}" ]]; then echo "ERROR: native ARM64 local-only Podman launcher is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_INFO:-}" || -z "${SYSWARDEN_PODMAN_INFO_INODE:-}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info target is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_CRUN_PATH:-}" || "${SYSWARDEN_CRUN_SHA256:-}" != "cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342" || ! "${SYSWARDEN_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$ || ! "${SYSWARDEN_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ ]]; then echo "ERROR: native ARM64 crun delegated identity is incomplete." >&2; exit 1; fi; crun_parent="${SYSWARDEN_CRUN_PATH%/*}"; if [[ ! -d "${crun_parent}" || -L "${crun_parent}" || "$(stat -c "%u:%g:%a:%d:%i" "${crun_parent}")" != "$(id -u):$(id -g):700:${SYSWARDEN_CRUN_DIRECTORY_INODE}" || ! -f "${SYSWARDEN_CRUN_PATH}" || -L "${SYSWARDEN_CRUN_PATH}" || ! -x "${SYSWARDEN_CRUN_PATH}" || "$(stat -c "%u:%g:%a:%s:%d:%i" "${SYSWARDEN_CRUN_PATH}")" != "$(id -u):$(id -g):700:3298128:${SYSWARDEN_CRUN_INODE}" ]]; then echo "ERROR: native ARM64 crun changed identity inside the delegated session." >&2; exit 1; fi; if ! printf "%s  %s\n" "${SYSWARDEN_CRUN_SHA256}" "${SYSWARDEN_CRUN_PATH}" | sha256sum --check --strict >/dev/null; then echo "ERROR: native ARM64 crun changed bytes inside the delegated session." >&2; exit 1; fi; if ! crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --root "${crun_parent}" --version)"; then echo "ERROR: native ARM64 crun is not executable inside the delegated session." >&2; exit 1; fi; mapfile -t crun_version_lines <<< "${crun_version_output}"; if [[ "${#crun_version_lines[@]}" -ne 5 || "${crun_version_lines[0]:-}" != "crun version 1.28" || "${crun_version_lines[1]:-}" != "commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc" || "${crun_version_lines[2]:-}" != "rundir: ${crun_parent}" || "${crun_version_lines[3]:-}" != "spec: 1.0.0" || ! "${crun_version_lines[4]:-}" =~ (^|[[:space:]])\+SYSTEMD($|[[:space:]]) ]]; then echo "ERROR: native ARM64 crun lacks the exact delegated version or systemd capability." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! "${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" info --format json; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ ! -s "${SYSWARDEN_PODMAN_INFO}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" || "$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600" || "$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != "${SYSWARDEN_PODMAN_INFO_INODE}" ]]; then echo "ERROR: native ARM64 Podman info evidence changed identity or permissions." >&2; exit 1; fi; if ! jq --arg crun_path "${SYSWARDEN_CRUN_PATH}" -e -s '\''length == 1 and .[0].host.conmon.path == "/usr/local/lib/podman/conmon" and .[0].host.ociRuntime.name == "crun" and .[0].host.ociRuntime.path == $crun_path and (.[0].host.ociRuntime.version | type) == "string" and (.[0].host.ociRuntime.version | startswith("crun version 1.28\ncommit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc\n")) and (.[0].host.ociRuntime.version | contains("\nspec: 1.0.0\n")) and (.[0].host.ociRuntime.version | contains("\n+SYSTEMD ")) and .[0].host.cgroupManager == "systemd" and .[0].host.security.rootless == true and .[0].host.serviceIsRemote == false and .[0].host.arch == "arm64" and .[0].host.os == "linux"'\'' "${SYSWARDEN_PODMAN_INFO}" >/dev/null; then echo "ERROR: native ARM64 Podman resolved an unexpected local runtime configuration." >&2; exit 1; fi; exec "$@"' \
+              'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY; if [[ -z "${SYSWARDEN_HOST_UID:-}" || ! "${SYSWARDEN_HOST_UID}" =~ ^[1-9][0-9]*$ || -z "${SYSWARDEN_HOST_OWNER:-}" || ! "${SYSWARDEN_HOST_OWNER}" =~ ^[1-9][0-9]*:[0-9]+$ || "${SYSWARDEN_HOST_OWNER%%:*}" != "${SYSWARDEN_HOST_UID}" ]]; then echo "ERROR: native ARM64 delegated host owner identity is incomplete." >&2; exit 1; fi; delegated_uid="$(id -u)"; if [[ "${delegated_uid}" != "${SYSWARDEN_HOST_UID}" ]]; then printf "ERROR: native ARM64 delegated UID differs from the exported host UID (expected=%s observed=%s).\n" "${SYSWARDEN_HOST_UID}" "${delegated_uid}" >&2; exit 1; fi; if [[ -z "${CONTAINERS_CONF:-}" || -n "${CONTAINERS_CONF_OVERRIDE:-}" || ! -f "${CONTAINERS_CONF}" || -L "${CONTAINERS_CONF}" || "$(stat -c "%u:%g:%a" "${CONTAINERS_CONF}")" != "${SYSWARDEN_HOST_OWNER}:600" ]]; then echo "ERROR: native ARM64 Podman configuration isolation is incomplete." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_LOCAL:-}" || ! -f "${SYSWARDEN_PODMAN_LOCAL}" || -L "${SYSWARDEN_PODMAN_LOCAL}" || ! -x "${SYSWARDEN_PODMAN_LOCAL}" || "$(stat -c "%u:%g:%a" "${SYSWARDEN_PODMAN_LOCAL}")" != "${SYSWARDEN_HOST_OWNER}:700" ]]; then echo "ERROR: native ARM64 local-only Podman launcher is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_PODMAN_INFO:-}" || -z "${SYSWARDEN_PODMAN_INFO_INODE:-}" || ! "${SYSWARDEN_PODMAN_INFO_INODE}" =~ ^[0-9]+:[0-9]+$ || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info target is unavailable." >&2; exit 1; fi; if [[ -z "${SYSWARDEN_CRUN_PATH:-}" || "${SYSWARDEN_CRUN_SHA256:-}" != "cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342" || ! "${SYSWARDEN_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$ || ! "${SYSWARDEN_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$ ]]; then echo "ERROR: native ARM64 crun delegated identity is incomplete." >&2; exit 1; fi; crun_parent="${SYSWARDEN_CRUN_PATH%/*}"; if [[ ! -d "${crun_parent}" || -L "${crun_parent}" ]]; then echo "ERROR: native ARM64 crun parent is not a real delegated directory." >&2; exit 1; fi; if ! crun_parent_identity="$(stat -c "%u:%g:%a:%d:%i" "${crun_parent}")"; then echo "ERROR: native ARM64 crun parent identity is unavailable inside the delegated session." >&2; exit 1; fi; expected_crun_parent_identity="${SYSWARDEN_HOST_OWNER}:700:${SYSWARDEN_CRUN_DIRECTORY_INODE}"; if [[ "${crun_parent_identity}" != "${expected_crun_parent_identity}" ]]; then printf "ERROR: native ARM64 crun parent identity changed inside the delegated session (expected=%s observed=%s).\n" "${expected_crun_parent_identity}" "${crun_parent_identity}" >&2; exit 1; fi; if [[ ! -f "${SYSWARDEN_CRUN_PATH}" || -L "${SYSWARDEN_CRUN_PATH}" || ! -x "${SYSWARDEN_CRUN_PATH}" ]]; then echo "ERROR: native ARM64 crun is not a real delegated executable." >&2; exit 1; fi; if ! crun_identity="$(stat -c "%u:%g:%a:%s:%d:%i" "${SYSWARDEN_CRUN_PATH}")"; then echo "ERROR: native ARM64 crun identity is unavailable inside the delegated session." >&2; exit 1; fi; expected_crun_identity="${SYSWARDEN_HOST_OWNER}:700:3298128:${SYSWARDEN_CRUN_INODE}"; if [[ "${crun_identity}" != "${expected_crun_identity}" ]]; then printf "ERROR: native ARM64 crun identity changed inside the delegated session (expected=%s observed=%s).\n" "${expected_crun_identity}" "${crun_identity}" >&2; exit 1; fi; if ! printf "%s  %s\n" "${SYSWARDEN_CRUN_SHA256}" "${SYSWARDEN_CRUN_PATH}" | sha256sum --check --strict >/dev/null; then echo "ERROR: native ARM64 crun changed bytes inside the delegated session." >&2; exit 1; fi; if ! crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --root "${crun_parent}" --version)"; then echo "ERROR: native ARM64 crun is not executable inside the delegated session." >&2; exit 1; fi; mapfile -t crun_version_lines <<< "${crun_version_output}"; if [[ "${#crun_version_lines[@]}" -ne 5 || "${crun_version_lines[0]:-}" != "crun version 1.28" || "${crun_version_lines[1]:-}" != "commit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc" || "${crun_version_lines[2]:-}" != "rundir: ${crun_parent}" || "${crun_version_lines[3]:-}" != "spec: 1.0.0" || ! "${crun_version_lines[4]:-}" =~ (^|[[:space:]])\+SYSTEMD($|[[:space:]]) ]]; then echo "ERROR: native ARM64 crun lacks the exact delegated version or systemd capability." >&2; exit 1; fi; if ! /usr/local/lib/podman/conmon --version >/dev/null; then echo "ERROR: native ARM64 conmon is not executable inside the delegated session." >&2; exit 1; fi; if ! "${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" info --format json; then echo "ERROR: native ARM64 Podman could not attest its isolated runtime configuration." >&2; exit 1; fi; if [[ ! -s "${SYSWARDEN_PODMAN_INFO}" || ! -f "${SYSWARDEN_PODMAN_INFO}" || -L "${SYSWARDEN_PODMAN_INFO}" ]]; then echo "ERROR: native ARM64 Podman info evidence is not a real non-empty file." >&2; exit 1; fi; if ! podman_info_identity="$(stat -c "%u:%g:%a:%d:%i" "${SYSWARDEN_PODMAN_INFO}")"; then echo "ERROR: native ARM64 Podman info evidence identity is unavailable." >&2; exit 1; fi; expected_podman_info_identity="${SYSWARDEN_HOST_OWNER}:600:${SYSWARDEN_PODMAN_INFO_INODE}"; if [[ "${podman_info_identity}" != "${expected_podman_info_identity}" ]]; then printf "ERROR: native ARM64 Podman info evidence changed identity or permissions (expected=%s observed=%s).\n" "${expected_podman_info_identity}" "${podman_info_identity}" >&2; exit 1; fi; if ! jq --arg crun_path "${SYSWARDEN_CRUN_PATH}" -e -s '\''length == 1 and .[0].host.conmon.path == "/usr/local/lib/podman/conmon" and .[0].host.ociRuntime.name == "crun" and .[0].host.ociRuntime.path == $crun_path and (.[0].host.ociRuntime.version | type) == "string" and (.[0].host.ociRuntime.version | startswith("crun version 1.28\ncommit: 54f16ffbefcd022bf032af768b5c5ce075c18bfc\n")) and (.[0].host.ociRuntime.version | contains("\nspec: 1.0.0\n")) and (.[0].host.ociRuntime.version | contains("\n+SYSTEMD ")) and .[0].host.cgroupManager == "systemd" and .[0].host.security.rootless == true and .[0].host.serviceIsRemote == false and .[0].host.arch == "arm64" and .[0].host.os == "linux"'\'' "${SYSWARDEN_PODMAN_INFO}" >/dev/null; then echo "ERROR: native ARM64 Podman resolved an unexpected local runtime configuration." >&2; exit 1; fi; exec "$@"' \
               syswarden-arm64-lifecycle \
               /usr/bin/python3 "${GITHUB_WORKSPACE}/scripts/ci/package_lifecycle_lab.py" \
               --packages-dir "${ARM_CANDIDATE_PACKAGES_DIR}" \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1439,13 +1439,13 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                16,
+                17,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 15)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 16)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 16)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 17)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 28,
-                "scripts/ci/release_gate_test.py": 28,
+                ".github/workflows/release-manager.yml": 30,
+                "scripts/ci/release_gate_test.py": 30,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -1482,6 +1482,10 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         pinned_contracts = (
+            (
+                'if [[ "${v4032_delegated_owner_parent_sha}" != '
+                '"5d20d2c4cbd1b249fc36b25025db280f25f7eb32" ]]; then'
+            ),
             (
                 'if [[ "${v4032_arm64_attestation_parent_sha}" != '
                 '"8e3ef2a0f50e4833f3078a7a09c2d07bf984f6ef" ]]; then'
@@ -1553,6 +1557,10 @@ class ReleaseGateTests(unittest.TestCase):
         )
         for contract in pinned_contracts:
             self.assertEqual(workflow.count(contract), 2)
+        delegated_owner_subject_contract = (
+            "v4032_delegated_owner_expected_subject='Qualification : preserve "
+            "ARM64 crun owner across delegation (#112)'"
+        )
         arm64_attestation_subject_contract = (
             "v4032_arm64_attestation_expected_subject='Qualification : stabilize "
             "ARM64 crun version attestation (#111)'"
@@ -1612,6 +1620,12 @@ class ReleaseGateTests(unittest.TestCase):
         repair_subject_contract = (
             "v4032_expected_subject='Qualification : repair v4.03.2 "
             "package lifecycle qualification (#95) (#95)'"
+        )
+        delegated_owner_paths = (
+            ".github/workflows/release-manager.yml",
+            ".github/workflows/release-qualification.yml",
+            "scripts/ci/release_gate_test.py",
+            "scripts/ci/release_qualification_workflow_test.py",
         )
         arm64_attestation_paths = (
             ".github/workflows/release-manager.yml",
@@ -1728,6 +1742,7 @@ class ReleaseGateTests(unittest.TestCase):
                 compliance_paths
                 + repair_paths
                 + crun_paths
+                + delegated_owner_paths
                 + arm64_attestation_paths
                 + docs_paths
                 + systemd_paths
@@ -1745,6 +1760,7 @@ class ReleaseGateTests(unittest.TestCase):
             "src/core/syswarden-core/webhook/discord.go",
         )
         for block in blocks:
+            self.assertEqual(block.count(delegated_owner_subject_contract), 1)
             self.assertEqual(block.count(arm64_attestation_subject_contract), 1)
             self.assertEqual(block.count(docs_subject_contract), 1)
             self.assertEqual(block.count(systemd_subject_contract), 1)
@@ -1763,20 +1779,96 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 block.count(
                     '[[ "${commit_subject}" != '
+                    '"${v4032_delegated_owner_expected_subject}" ]]'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_delegated_owner_parent_sha="$(git rev-parse HEAD^)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_delegated_owner_head_line <<< '
+                    '"$(git rev-list --parents -n 1 HEAD)"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count("${#v4032_delegated_owner_head_line[@]} != 2"), 1
+            )
+            delegated_owner_diff = block.split(
+                "# BEGIN exact v4.03.2 delegated ARM64 crun owner "
+                "diff contract\n",
+                1,
+            )[1].split(
+                "# END exact v4.03.2 delegated ARM64 crun owner "
+                "diff contract",
+                1,
+            )[0]
+            self.assertEqual(
+                delegated_owner_diff.count(
+                    "git diff-tree --no-commit-id --name-status -r "
+                    "--no-renames -z HEAD^ HEAD"
+                ),
+                1,
+            )
+            self.assertEqual(
+                delegated_owner_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+            )
+            self.assertEqual(
+                delegated_owner_diff.count('"${tree_mode}" != "100644"'), 1
+            )
+            self.assertEqual(
+                delegated_owner_diff.count('"${tree_type}" != "blob"'), 1
+            )
+            self.assertEqual(
+                delegated_owner_diff.count(
+                    "! \"${tree_object}\" =~ ^[0-9a-f]{40}$"
+                ),
+                1,
+            )
+            self.assertEqual(
+                delegated_owner_diff.count(
+                    "${#actual_v4032_delegated_owner_diff[@]} != "
+                    "${#expected_v4032_delegated_owner_diff[@]}"
+                ),
+                1,
+            )
+            for path in delegated_owner_paths:
+                self.assertEqual(delegated_owner_diff.count(f'"{path}"'), 2)
+                self.assertEqual(delegated_owner_diff.count(f'M "{path}"'), 1)
+            self.assertEqual(
+                block.count("v4032_arm64_attestation_ref=HEAD^\n"), 1
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_attestation_parent_sha="$(git rev-parse '
+                    '"${v4032_arm64_attestation_ref}^")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    'v4032_arm64_attestation_subject="$(git log -1 --format=%s '
+                    '"${v4032_arm64_attestation_ref}")"'
+                ),
+                1,
+            )
+            self.assertEqual(
+                block.count(
+                    '[[ "${v4032_arm64_attestation_subject}" != '
                     '"${v4032_arm64_attestation_expected_subject}" ]]'
                 ),
                 1,
             )
             self.assertEqual(
                 block.count(
-                    'v4032_arm64_attestation_parent_sha="$(git rev-parse HEAD^)"'
-                ),
-                1,
-            )
-            self.assertEqual(
-                block.count(
                     'v4032_arm64_attestation_head_line <<< '
-                    '"$(git rev-list --parents -n 1 HEAD)"'
+                    '"$(git rev-list --parents -n 1 '
+                    '"${v4032_arm64_attestation_ref}")"'
                 ),
                 1,
             )
@@ -1795,17 +1887,28 @@ class ReleaseGateTests(unittest.TestCase):
             self.assertEqual(
                 arm64_attestation_diff.count(
                     "git diff-tree --no-commit-id --name-status -r "
-                    "--no-renames -z HEAD^ HEAD"
+                    "--no-renames -z \\\n"
+                    '        "${v4032_arm64_attestation_ref}^" '
+                    '"${v4032_arm64_attestation_ref}"'
                 ),
                 1,
             )
             self.assertEqual(
-                arm64_attestation_diff.count("for tree_ref in HEAD^ HEAD; do"), 1
+                arm64_attestation_diff.count(
+                    'for tree_ref in "${v4032_arm64_attestation_ref}^" '
+                    '"${v4032_arm64_attestation_ref}"; do'
+                ),
+                1,
             )
             for path in arm64_attestation_paths:
                 self.assertEqual(arm64_attestation_diff.count(f'"{path}"'), 2)
                 self.assertEqual(arm64_attestation_diff.count(f'M "{path}"'), 1)
-            self.assertEqual(block.count("v4032_docs_ref=HEAD^\n"), 1)
+            self.assertEqual(
+                block.count(
+                    'v4032_docs_ref="${v4032_arm64_attestation_ref}^"\n'
+                ),
+                1,
+            )
             self.assertEqual(
                 block.count(
                     'v4032_docs_parent_sha="$(git rev-parse '
@@ -2949,7 +3052,7 @@ class ReleaseGateTests(unittest.TestCase):
                     "git diff-tree --no-commit-id --name-status -r "
                     "--no-renames -z \\"
                 ),
-                14,
+                15,
             )
             self.assertEqual(
                 block.count(
@@ -2968,12 +3071,12 @@ class ReleaseGateTests(unittest.TestCase):
                 block.count(
                     'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'
                 ),
-                15,
+                16,
             )
             self.assertEqual(
                 block.count('"${tree_mode}" != "${expected_mode}"'), 1
             )
-            self.assertEqual(block.count('"${tree_type}" != "blob"'), 15)
+            self.assertEqual(block.count('"${tree_type}" != "blob"'), 16)
             self.assertEqual(block.count('expected_mode="100644"'), 1)
             self.assertEqual(
                 block.count('[[ "${fix_path}" == "build_packages.sh" ]]'), 1
@@ -2990,6 +3093,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_count += 2 if path in crun_paths else 0
                 expected_count += 2 if path in compliance_paths else 0
                 expected_count += 2 if path in merge_paths else 0
+                expected_count += 2 if path in delegated_owner_paths else 0
                 expected_count += 2 if path in arm64_attestation_paths else 0
                 expected_count += 2 if path in arm64_paths else 0
                 expected_count += 2 if path in runtime_paths else 0
@@ -3007,6 +3111,7 @@ class ReleaseGateTests(unittest.TestCase):
                 expected_status_count += 1 if path in crun_paths else 0
                 expected_status_count += 1 if path in compliance_paths else 0
                 expected_status_count += 1 if path in merge_paths else 0
+                expected_status_count += 1 if path in delegated_owner_paths else 0
                 expected_status_count += (
                     1 if path in arm64_attestation_paths else 0
                 )
@@ -3150,6 +3255,30 @@ class ReleaseGateTests(unittest.TestCase):
             )[0]
             self.assertNotIn("--tag-phase", parent_validation)
 
+    def exact_v4032_delegated_owner_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        begin = (
+            "# BEGIN exact v4.03.2 delegated ARM64 crun owner diff contract\n"
+        )
+        end = "# END exact v4.03.2 delegated ARM64 crun owner diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def v4032_delegated_owner_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4032_recovery_blocks(workflow)[0]
+        start = "v4032_delegated_owner_expected_subject="
+        end = (
+            'read -r -a v4032_delegated_owner_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
     def exact_v4032_arm64_attestation_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
@@ -3163,20 +3292,33 @@ class ReleaseGateTests(unittest.TestCase):
         )
         self.assertEqual(block.count(begin), 1)
         self.assertEqual(block.count(end), 1)
-        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+        return (
+            "set -euo pipefail\nv4032_arm64_attestation_ref=HEAD\n"
+            + block.split(begin, 1)[1].split(end, 1)[0]
+        )
 
     def v4032_arm64_attestation_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_arm64_attestation_expected_subject="
+        subject_assignment = (
+            'v4032_arm64_attestation_subject="$(git log -1 --format=%s '
+            '"${v4032_arm64_attestation_ref}")"'
+        )
         end = (
             'read -r -a v4032_arm64_attestation_head_line <<< '
-            '"$(git rev-list --parents -n 1 HEAD)"'
+            '"$(git rev-list --parents -n 1 '
+            '"${v4032_arm64_attestation_ref}")"'
         )
         self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(subject_assignment), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
-        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+        fragment = fragment.replace(
+            subject_assignment,
+            'v4032_arm64_attestation_subject="${COMMIT_SUBJECT:?}"',
+        )
+        return "set -euo pipefail\n" + fragment
 
     def exact_v4032_docs_diff_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -3893,6 +4035,53 @@ class ReleaseGateTests(unittest.TestCase):
             check=True,
         )
         return repository
+
+    def test_release_manager_v4032_delegated_owner_subject_is_exact_github_squash(
+        self,
+    ) -> None:
+        self.assert_exact_subject_gate(
+            self.v4032_delegated_owner_subject_gate_script(),
+            {
+                "valid": (
+                    "Qualification : preserve ARM64 crun owner across delegation (#112)",
+                    True,
+                ),
+                "bare": (
+                    "Qualification : preserve ARM64 crun owner across delegation",
+                    False,
+                ),
+                "previous pull request": (
+                    "Qualification : preserve ARM64 crun owner across delegation (#111)",
+                    False,
+                ),
+                "wrong verb": (
+                    "Qualification : stabilize ARM64 crun owner across delegation (#112)",
+                    False,
+                ),
+                "wrong scope": (
+                    "Qualification : preserve ARM64 runc owner across delegation (#112)",
+                    False,
+                ),
+                "trailing space": (
+                    "Qualification : preserve ARM64 crun owner across delegation (#112) ",
+                    False,
+                ),
+            },
+        )
+
+    def test_release_manager_v4032_delegated_owner_diff_rejects_git_shape_mutations(
+        self,
+    ) -> None:
+        self.assert_regular_diff_gate(
+            self.exact_v4032_delegated_owner_diff_script(),
+            "v4032-delegated-owner-diff",
+            (
+                ".github/workflows/release-manager.yml",
+                ".github/workflows/release-qualification.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/ci/release_qualification_workflow_test.py",
+            ),
+        )
 
     def test_release_manager_v4032_arm64_attestation_subject_is_exact_github_squash(
         self,
@@ -4645,9 +4834,37 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "delegated owner parent resolution": workflow.replace(
+                'v4032_delegated_owner_parent_sha="$(git rev-parse HEAD^)"',
+                'v4032_delegated_owner_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact delegated owner parent": workflow.replace(
+                "5d20d2c4cbd1b249fc36b25025db280f25f7eb32",
+                "6d20d2c4cbd1b249fc36b25025db280f25f7eb32",
+            ),
+            "delegated owner canonical subject": workflow.replace(
+                "Qualification : preserve ARM64 crun owner across delegation (#112)",
+                "Qualification : stabilize ARM64 crun owner across delegation (#112)",
+            ),
+            "delegated owner subject source": workflow.replace(
+                'commit_subject="$(git log -1 --format=%s HEAD)"',
+                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+            ),
+            "delegated owner linear head": workflow.replace(
+                'v4032_delegated_owner_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4032_delegated_owner_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "ARM64 attestation reference": workflow.replace(
+                "v4032_arm64_attestation_ref=HEAD^",
+                "v4032_arm64_attestation_ref=HEAD^^",
+            ),
             "ARM64 attestation parent resolution": workflow.replace(
-                'v4032_arm64_attestation_parent_sha="$(git rev-parse HEAD^)"',
-                'v4032_arm64_attestation_parent_sha="$(git rev-parse HEAD^^)"',
+                'v4032_arm64_attestation_parent_sha="$(git rev-parse '
+                '"${v4032_arm64_attestation_ref}^")"',
+                'v4032_arm64_attestation_parent_sha="$(git rev-parse '
+                '"${v4032_arm64_attestation_ref}^^")"',
             ),
             "exact ARM64 attestation parent": workflow.replace(
                 "8e3ef2a0f50e4833f3078a7a09c2d07bf984f6ef",
@@ -4658,18 +4875,20 @@ class ReleaseGateTests(unittest.TestCase):
                 "Qualification : repair ARM64 crun version attestation (#111)",
             ),
             "ARM64 attestation subject source": workflow.replace(
-                'commit_subject="$(git log -1 --format=%s HEAD)"',
-                'commit_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_arm64_attestation_subject="$(git log -1 --format=%s '
+                '"${v4032_arm64_attestation_ref}")"',
+                'v4032_arm64_attestation_subject="$(git log -1 --format=%s HEAD)"',
             ),
             "ARM64 attestation linear head": workflow.replace(
                 'v4032_arm64_attestation_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD)"',
+                '"$(git rev-list --parents -n 1 '
+                '"${v4032_arm64_attestation_ref}")"',
                 'v4032_arm64_attestation_head_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
+                '"$(git rev-list --parents -n 1 HEAD)"',
             ),
             "documentation reference": workflow.replace(
-                "v4032_docs_ref=HEAD^",
-                "v4032_docs_ref=HEAD^^",
+                'v4032_docs_ref="${v4032_arm64_attestation_ref}^"',
+                'v4032_docs_ref="${v4032_arm64_attestation_ref}^^"',
             ),
             "documentation parent resolution": workflow.replace(
                 'v4032_docs_parent_sha="$(git rev-parse '

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -388,6 +388,99 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
                 f"{name} must be pinned to a full commit SHA",
             )
 
+    def assert_arm64_delegated_owner_contract(self, workflow: str) -> None:
+        script = workflow_step_script(
+            workflow, "Run Native ARM64 Package Lifecycle Shard"
+        )
+        required = (
+            'host_owner_identity="${user_id}:${user_group}"',
+            '! "${host_owner_identity}" =~ ^[1-9][0-9]*:[0-9]+$',
+            '"$(stat -c \'%u\' "${HOME}")" != \\\n'
+            '        "${user_id}"',
+            '"${host_owner_identity}:700:${ARM_SHARD_ROOT_INODE}"',
+            '"${host_owner_identity}:700:${ARM_CRUN_DIRECTORY_INODE}"',
+            '"${host_owner_identity}:700:3298128:${ARM_CRUN_INODE}"',
+            '"$(stat -c \'%u:%g:%a\' "${containers_conf}")" !=',
+            '"$(stat -c \'%u:%g:%a\' "${podman_local}")" !=',
+            '"$(stat -c \'%u:%g:%a\' "${podman_info}")" !=',
+            '--setenv="SYSWARDEN_HOST_OWNER=${host_owner_identity}"',
+            '--setenv="SYSWARDEN_HOST_UID=${user_id}"',
+            '! "${SYSWARDEN_HOST_UID}" =~ ^[1-9][0-9]*$',
+            '! "${SYSWARDEN_HOST_OWNER}" =~ ^[1-9][0-9]*:[0-9]+$',
+            '"${SYSWARDEN_HOST_OWNER%%:*}" != "${SYSWARDEN_HOST_UID}"',
+            'delegated_uid="$(id -u)"',
+            '"${delegated_uid}" != "${SYSWARDEN_HOST_UID}"',
+            "native ARM64 delegated UID differs from the exported host UID",
+            '"$(stat -c "%u:%g:%a" "${CONTAINERS_CONF}")" != '
+            '"${SYSWARDEN_HOST_OWNER}:600"',
+            '"$(stat -c "%u:%g:%a" "${SYSWARDEN_PODMAN_LOCAL}")" != '
+            '"${SYSWARDEN_HOST_OWNER}:700"',
+            'expected_crun_parent_identity="${SYSWARDEN_HOST_OWNER}:700:'
+            '${SYSWARDEN_CRUN_DIRECTORY_INODE}"',
+            '"${crun_parent_identity}" != "${expected_crun_parent_identity}"',
+            "native ARM64 crun parent identity changed inside the delegated session",
+            'expected_crun_identity="${SYSWARDEN_HOST_OWNER}:700:3298128:'
+            '${SYSWARDEN_CRUN_INODE}"',
+            '"${crun_identity}" != "${expected_crun_identity}"',
+            "native ARM64 crun identity changed inside the delegated session",
+            'printf "%s  %s\\n" "${SYSWARDEN_CRUN_SHA256}" '
+            '"${SYSWARDEN_CRUN_PATH}"',
+            'crun_version_output="$("${SYSWARDEN_CRUN_PATH}" --root '
+            '"${crun_parent}" --version)"',
+            '"${crun_version_lines[2]:-}" != "rundir: ${crun_parent}"',
+            r'\+SYSTEMD($|[[:space:]])',
+            'expected_podman_info_identity="${SYSWARDEN_HOST_OWNER}:600:'
+            '${SYSWARDEN_PODMAN_INFO_INODE}"',
+            '"${podman_info_identity}" != "${expected_podman_info_identity}"',
+            "native ARM64 Podman info evidence changed identity or permissions",
+            "(expected=%s observed=%s)",
+        )
+        for contract in required:
+            self.assertIn(contract, script)
+        self.assertEqual(
+            script.count('--setenv="SYSWARDEN_HOST_OWNER=${host_owner_identity}"'),
+            1,
+        )
+        self.assertEqual(
+            script.count('--setenv="SYSWARDEN_HOST_UID=${user_id}"'), 1
+        )
+        self.assertNotIn('account_owner_identity=', script)
+
+        systemd_run = script.index("sudo -n systemd-run")
+        delegated_shell = script.index(
+            "/usr/bin/bash --noprofile --norc -e -o pipefail -c", systemd_run
+        )
+        lifecycle_lab = script.index("scripts/ci/package_lifecycle_lab.py")
+        delegated_script = script[delegated_shell:lifecycle_lab]
+        self.assertNotIn("$(id -g)", delegated_script)
+        self.assertNotIn('$(id -g "${user_name}")', script)
+
+        ordered = (
+            "native ARM64 delegated host owner identity is incomplete",
+            "native ARM64 delegated UID differs from the exported host UID",
+            "native ARM64 Podman configuration isolation is incomplete",
+            "native ARM64 local-only Podman launcher is unavailable",
+            "native ARM64 Podman info target is unavailable",
+            "native ARM64 crun delegated identity is incomplete",
+            "native ARM64 crun parent is not a real delegated directory",
+            "native ARM64 crun parent identity is unavailable inside the delegated session",
+            "native ARM64 crun parent identity changed inside the delegated session",
+            "native ARM64 crun is not a real delegated executable",
+            "native ARM64 crun identity is unavailable inside the delegated session",
+            "native ARM64 crun identity changed inside the delegated session",
+            "native ARM64 crun changed bytes inside the delegated session",
+            "native ARM64 crun is not executable inside the delegated session",
+            "native ARM64 crun lacks the exact delegated version or systemd capability",
+            "native ARM64 conmon is not executable inside the delegated session",
+            "native ARM64 Podman could not attest its isolated runtime configuration",
+            "native ARM64 Podman info evidence is not a real non-empty file",
+            "native ARM64 Podman info evidence identity is unavailable",
+            "native ARM64 Podman info evidence changed identity or permissions",
+            "native ARM64 Podman resolved an unexpected local runtime configuration",
+        )
+        positions = [delegated_script.index(marker) for marker in ordered]
+        self.assertEqual(positions, sorted(positions))
+
     def test_is_manual_only_with_three_required_inputs(self) -> None:
         trigger = self.workflow.split("\nenv:", 1)[0]
         self.assertIn("  workflow_dispatch:\n", trigger)
@@ -1385,12 +1478,17 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertIn('test "$(uname -m)" = "aarch64"', self.workflow)
 
     def test_arm64_lab_uses_exact_transient_systemd_delegation(self) -> None:
+        self.assert_arm64_delegated_owner_contract(self.workflow)
         script = workflow_step_script(
             self.workflow, "Run Native ARM64 Package Lifecycle Shard"
         )
         for contract in (
+            'host_owner_identity="${user_id}:${user_group}"',
+            '! "${host_owner_identity}" =~ ^[1-9][0-9]*:[0-9]+$',
             '"${user_name}" != "runner"',
             '"${HOME}" != "/home/runner"',
+            '"$(stat -c \'%u\' "${HOME}")" != \\\n'
+            '        "${user_id}"',
             '"${self_cgroup}" == /user.slice/*',
             'delegate_drop_in="${delegate_directory}/syswarden-release-qualification.conf"',
             'delegate_drop_in_owned=false',
@@ -1416,12 +1514,12 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '! "${ARM_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$',
             '! "${ARM_SHARD_ROOT_INODE:-}" =~ ^[0-9]+:[0-9]+$',
             'attest_arm_shard_root() {',
-            '"${user_id}:${user_group}:700:${ARM_SHARD_ROOT_INODE}"',
+            '"${host_owner_identity}:700:${ARM_SHARD_ROOT_INODE}"',
             'attest_arm_crun_directory() {',
-            '"${user_id}:${user_group}:700:${ARM_CRUN_DIRECTORY_INODE}"',
+            '"${host_owner_identity}:700:${ARM_CRUN_DIRECTORY_INODE}"',
             'attest_arm_crun() {',
             '"$(stat -c \'%u:%g:%a:%s:%d:%i\' "${ARM_CRUN_PATH}")" !=',
-            '"${user_id}:${user_group}:700:3298128:${ARM_CRUN_INODE}"',
+            '"${host_owner_identity}:700:3298128:${ARM_CRUN_INODE}"',
             'printf \'%s  %s\\n\' "${ARM_CRUN_SHA256}" "${ARM_CRUN_PATH}"',
             'crun_version_output="$("${ARM_CRUN_PATH}"',
             '--root "${crun_directory}" --version)" || return 1',
@@ -1447,11 +1545,13 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"crun=[\\"${ARM_CRUN_PATH}\\"]"',
             "'[engine.platform_to_oci_runtime]'",
             "'\"linux/arm64\"=\"crun\"'",
-            '"$(stat -c \'%a\' "${containers_conf}")" != "600"',
+            '"$(stat -c \'%u:%g:%a\' "${containers_conf}")" !=',
+            '"${host_owner_identity}:600"',
             "'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY'",
             "'exec /usr/local/bin/podman --remote=false \"$@\"'",
             'chmod 0700 "${podman_local}"',
-            '"$(stat -c \'%a\' "${podman_local}")" != "700"',
+            '"$(stat -c \'%u:%g:%a\' "${podman_local}")" !=',
+            '"${host_owner_identity}:700"',
             "local-only Podman launcher is not a private runner-owned executable",
             ': > "${podman_info}"',
             'chmod 0600 "${podman_info}"',
@@ -1473,6 +1573,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '--setenv="SYSWARDEN_CRUN_INODE=${ARM_CRUN_INODE}"',
             '--setenv="SYSWARDEN_CRUN_PATH=${ARM_CRUN_PATH}"',
             '--setenv="SYSWARDEN_CRUN_SHA256=${ARM_CRUN_SHA256}"',
+            '--setenv="SYSWARDEN_HOST_OWNER=${host_owner_identity}"',
+            '--setenv="SYSWARDEN_HOST_UID=${user_id}"',
             '--setenv="SYSWARDEN_PODMAN_INFO=${podman_info}"',
             '--setenv="SYSWARDEN_PODMAN_INFO_INODE=${podman_info_inode}"',
             '--setenv="SYSWARDEN_PODMAN_LOCAL=${podman_local}"',
@@ -1490,13 +1592,34 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342"',
             '! "${SYSWARDEN_CRUN_INODE:-}" =~ ^[0-9]+:[0-9]+$',
             '! "${SYSWARDEN_CRUN_DIRECTORY_INODE:-}" =~ ^[0-9]+:[0-9]+$',
+            '-z "${SYSWARDEN_HOST_UID:-}"',
+            '! "${SYSWARDEN_HOST_UID}" =~ ^[1-9][0-9]*$',
+            '-z "${SYSWARDEN_HOST_OWNER:-}"',
+            '! "${SYSWARDEN_HOST_OWNER}" =~ ^[1-9][0-9]*:[0-9]+$',
+            '"${SYSWARDEN_HOST_OWNER%%:*}" != "${SYSWARDEN_HOST_UID}"',
+            "native ARM64 delegated host owner identity is incomplete",
+            'delegated_uid="$(id -u)"',
+            '"${delegated_uid}" != "${SYSWARDEN_HOST_UID}"',
+            "native ARM64 delegated UID differs from the exported host UID",
             "native ARM64 crun delegated identity is incomplete",
             'crun_parent="${SYSWARDEN_CRUN_PATH%/*}"',
-            '"$(stat -c "%u:%g:%a:%d:%i" "${crun_parent}")" != '
-            '"$(id -u):$(id -g):700:${SYSWARDEN_CRUN_DIRECTORY_INODE}"',
-            '"$(stat -c "%u:%g:%a:%s:%d:%i" "${SYSWARDEN_CRUN_PATH}")" != '
-            '"$(id -u):$(id -g):700:3298128:${SYSWARDEN_CRUN_INODE}"',
-            "native ARM64 crun changed identity inside the delegated session",
+            'if [[ ! -d "${crun_parent}" || -L "${crun_parent}" ]]',
+            "native ARM64 crun parent is not a real delegated directory",
+            'crun_parent_identity="$(stat -c "%u:%g:%a:%d:%i" '
+            '"${crun_parent}")"',
+            'expected_crun_parent_identity="${SYSWARDEN_HOST_OWNER}:700:'
+            '${SYSWARDEN_CRUN_DIRECTORY_INODE}"',
+            '"${crun_parent_identity}" != "${expected_crun_parent_identity}"',
+            "native ARM64 crun parent identity changed inside the delegated session",
+            'if [[ ! -f "${SYSWARDEN_CRUN_PATH}" || '
+            '-L "${SYSWARDEN_CRUN_PATH}" || ! -x "${SYSWARDEN_CRUN_PATH}" ]]',
+            "native ARM64 crun is not a real delegated executable",
+            'crun_identity="$(stat -c "%u:%g:%a:%s:%d:%i" '
+            '"${SYSWARDEN_CRUN_PATH}")"',
+            'expected_crun_identity="${SYSWARDEN_HOST_OWNER}:700:3298128:'
+            '${SYSWARDEN_CRUN_INODE}"',
+            '"${crun_identity}" != "${expected_crun_identity}"',
+            "native ARM64 crun identity changed inside the delegated session",
             'printf "%s  %s\\n" "${SYSWARDEN_CRUN_SHA256}" '
             '"${SYSWARDEN_CRUN_PATH}"',
             "native ARM64 crun changed bytes inside the delegated session",
@@ -1510,9 +1633,11 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"${SYSWARDEN_PODMAN_LOCAL}" --out "${SYSWARDEN_PODMAN_INFO}" '
             "info --format json",
             "native ARM64 Podman could not attest its isolated runtime configuration",
-            '"$(stat -c "%u:%a" "${SYSWARDEN_PODMAN_INFO}")" != "$(id -u):600"',
-            '"$(stat -c "%d:%i" "${SYSWARDEN_PODMAN_INFO}")" != '
-            '"${SYSWARDEN_PODMAN_INFO_INODE}"',
+            'podman_info_identity="$(stat -c "%u:%g:%a:%d:%i" '
+            '"${SYSWARDEN_PODMAN_INFO}")"',
+            'expected_podman_info_identity="${SYSWARDEN_HOST_OWNER}:600:'
+            '${SYSWARDEN_PODMAN_INFO_INODE}"',
+            '"${podman_info_identity}" != "${expected_podman_info_identity}"',
             "native ARM64 Podman info evidence changed identity or permissions",
             '.host.conmon.path == "/usr/local/lib/podman/conmon"',
             '.host.ociRuntime.name == "crun"',
@@ -1687,8 +1812,12 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
         info_target = script.index(': > "${podman_info}"')
         host_crun_attestation = script.index("if ! attest_arm_crun; then")
+        delegated_crun_parent_identity = script.index(
+            "native ARM64 crun parent identity changed inside the delegated session",
+            systemd_run,
+        )
         delegated_crun_identity = script.index(
-            "native ARM64 crun changed identity inside the delegated session",
+            "native ARM64 crun identity changed inside the delegated session",
             systemd_run,
         )
         delegated_crun_digest = script.index(
@@ -1730,6 +1859,8 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertLess(host_crun_attestation, systemd_run)
         self.assertLess(platform_pin, systemd_run)
         self.assertLess(systemd_run, configuration_guard)
+        self.assertLess(configuration_guard, delegated_crun_parent_identity)
+        self.assertLess(delegated_crun_parent_identity, delegated_crun_identity)
         self.assertLess(configuration_guard, delegated_crun_identity)
         self.assertLess(delegated_crun_identity, delegated_crun_digest)
         self.assertLess(delegated_crun_digest, crun_probe)
@@ -1740,6 +1871,198 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertLess(podman_probe, podman_verdict)
         self.assertLess(podman_verdict, lifecycle_lab)
         self.assertLess(podman_probe, lifecycle_lab)
+
+    def test_arm64_delegated_owner_contract_rejects_identity_mutations(self) -> None:
+        def replace_exact(source: str, old: str, new: str) -> str:
+            self.assertEqual(source.count(old), 1, old)
+            return source.replace(old, new, 1)
+
+        host_owner = 'host_owner_identity="${user_id}:${user_group}"'
+        home_owner = (
+            '"$(stat -c \'%u\' "${HOME}")" != \\\n'
+            '                  "${user_id}"'
+        )
+        owner_export = '--setenv="SYSWARDEN_HOST_OWNER=${host_owner_identity}"'
+        uid_export = '--setenv="SYSWARDEN_HOST_UID=${user_id}"'
+        delegated_uid = 'delegated_uid="$(id -u)"'
+        parent_identity = (
+            'expected_crun_parent_identity="${SYSWARDEN_HOST_OWNER}:700:'
+            '${SYSWARDEN_CRUN_DIRECTORY_INODE}"'
+        )
+        crun_identity = (
+            'expected_crun_identity="${SYSWARDEN_HOST_OWNER}:700:3298128:'
+            '${SYSWARDEN_CRUN_INODE}"'
+        )
+        podman_identity = (
+            'expected_podman_info_identity="${SYSWARDEN_HOST_OWNER}:600:'
+            '${SYSWARDEN_PODMAN_INFO_INODE}"'
+        )
+        mutations = (
+            replace_exact(
+                self.workflow,
+                host_owner,
+                'host_owner_identity="${user_id}:$(id -g "${user_name}")"',
+            ),
+            replace_exact(
+                self.workflow,
+                home_owner,
+                '"$(stat -c \'%u:%g\' "${HOME}")" != '
+                '"${host_owner_identity}"',
+            ),
+            replace_exact(self.workflow, owner_export, "# owner export removed"),
+            replace_exact(self.workflow, uid_export, "# UID export removed"),
+            replace_exact(self.workflow, delegated_uid, 'delegated_uid="$(id -g)"'),
+            replace_exact(
+                self.workflow,
+                parent_identity,
+                'expected_crun_parent_identity="$(id -u):$(id -g):700:'
+                '${SYSWARDEN_CRUN_DIRECTORY_INODE}"',
+            ),
+            replace_exact(
+                self.workflow,
+                crun_identity,
+                'expected_crun_identity="$(id -u):$(id -g):700:3298128:'
+                '${SYSWARDEN_CRUN_INODE}"',
+            ),
+            replace_exact(
+                self.workflow,
+                '"$(stat -c "%u:%g:%a" "${CONTAINERS_CONF}")" != '
+                '"${SYSWARDEN_HOST_OWNER}:600"',
+                '"$(stat -c "%u:%g:%a" "${CONTAINERS_CONF}")" != '
+                '"$(id -u):$(id -g):600"',
+            ),
+            replace_exact(
+                self.workflow,
+                podman_identity,
+                'expected_podman_info_identity="$(id -u):$(id -g):600:'
+                '${SYSWARDEN_PODMAN_INFO_INODE}"',
+            ),
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation[-160:]), self.assertRaises(
+                AssertionError
+            ):
+                self.assert_arm64_delegated_owner_contract(mutation)
+
+        first = "native ARM64 delegated UID differs from the exported host UID"
+        second = "native ARM64 Podman configuration isolation is incomplete"
+        placeholder = "ARM64_ORDER_MUTATION_PLACEHOLDER"
+        reordered = self.workflow.replace(first, placeholder, 1)
+        reordered = reordered.replace(second, first, 1).replace(placeholder, second, 1)
+        with self.assertRaises(AssertionError):
+            self.assert_arm64_delegated_owner_contract(reordered)
+
+    def test_arm64_delegated_owner_uses_host_gid_not_delegated_primary_gid(
+        self,
+    ) -> None:
+        if os.getuid() == 0:
+            self.skipTest("delegated non-root identity behavior requires a non-root test user")
+        script = workflow_step_script(
+            self.workflow, "Run Native ARM64 Package Lifecycle Shard"
+        )
+        command_line = next(
+            line.strip()
+            for line in script.splitlines()
+            if line.strip().startswith(
+                "'unset CONTAINER_HOST CONTAINER_CONNECTION CONTAINER_SSHKEY;"
+            )
+        )
+        identity_prefix, separator, _ = command_line.partition(
+            'if ! printf "%s  %s\\n" "${SYSWARDEN_CRUN_SHA256}"'
+        )
+        self.assertTrue(separator)
+        self.assertTrue(identity_prefix.startswith("'"))
+        identity_prefix = identity_prefix[1:] + "exit 0"
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            runtime = root / "runtime"
+            runtime.mkdir(mode=0o700)
+            runtime.chmod(0o700)
+            crun = runtime / "crun-1.28-linux-arm64"
+            crun.touch(mode=0o700)
+            os.truncate(crun, 3_298_128)
+            crun.chmod(0o700)
+            containers_conf = root / "containers.conf"
+            containers_conf.write_text("[engine]\n", encoding="utf-8")
+            containers_conf.chmod(0o600)
+            podman_local = root / "podman-local"
+            podman_local.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            podman_local.chmod(0o700)
+            podman_info = root / "podman-info.json"
+            podman_info.touch(mode=0o600)
+            podman_info.chmod(0o600)
+
+            binary_directory = root / "bin"
+            binary_directory.mkdir(mode=0o700)
+            delegated_id = binary_directory / "id"
+            delegated_id.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = \"-u\" ]; then\n"
+                "  printf '%s\\n' \"${FAKE_DELEGATED_UID:?}\"\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"${1:-}\" = \"-g\" ]; then\n"
+                "  echo 'delegated id -g must not be queried' >&2\n"
+                "  exit 97\n"
+                "fi\n"
+                "exec /usr/bin/id \"$@\"\n",
+                encoding="utf-8",
+            )
+            delegated_id.chmod(0o700)
+
+            def inode(path: Path) -> str:
+                identity = path.stat()
+                return f"{identity.st_dev}:{identity.st_ino}"
+
+            user_id = os.getuid()
+            user_group = os.getgid()
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "CONTAINERS_CONF": str(containers_conf),
+                    "CONTAINERS_CONF_OVERRIDE": "",
+                    "FAKE_DELEGATED_UID": str(user_id),
+                    "PATH": f"{binary_directory}{os.pathsep}{environment['PATH']}",
+                    "SYSWARDEN_CRUN_DIRECTORY_INODE": inode(runtime),
+                    "SYSWARDEN_CRUN_INODE": inode(crun),
+                    "SYSWARDEN_CRUN_PATH": str(crun),
+                    "SYSWARDEN_CRUN_SHA256": (
+                        "cc1e8ec89aef1422e0741be196f9ed099e2e09d2f48f30f27cd44a22ef1f0342"
+                    ),
+                    "SYSWARDEN_HOST_OWNER": f"{user_id}:{user_group}",
+                    "SYSWARDEN_HOST_UID": str(user_id),
+                    "SYSWARDEN_PODMAN_INFO": str(podman_info),
+                    "SYSWARDEN_PODMAN_INFO_INODE": inode(podman_info),
+                    "SYSWARDEN_PODMAN_LOCAL": str(podman_local),
+                }
+            )
+            accepted = subprocess.run(
+                ["/bin/bash", "-e", "-o", "pipefail", "-c", identity_prefix],
+                cwd=REPOSITORY,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertNotIn("delegated id -g must not be queried", accepted.stderr)
+
+            environment["FAKE_DELEGATED_UID"] = str(user_id + 1)
+            rejected = subprocess.run(
+                ["/bin/bash", "-e", "-o", "pipefail", "-c", identity_prefix],
+                cwd=REPOSITORY,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn(
+                "delegated UID differs from the exported host UID", rejected.stderr
+            )
 
     def test_premerge_package_workflow_runs_every_qualification_validator(self) -> None:
         step = workflow_step(


### PR DESCRIPTION
## Summary

- Preserve the exact host-created UID:GID ownership across the delegated systemd user-manager session.
- Pass the attested host owner and UID explicitly into systemd-run.
- Require the delegated UID to match the attested host UID without assuming the delegated primary GID.
- Keep the v4.03.2 release-manager ancestry contract synchronized with the qualification workflow.

## Root cause

The delegated systemd user manager may expose a primary GID that differs from the GID owning the host-created qualification artifacts. Comparing ownership to the delegated id -g therefore rejected unchanged, correctly owned artifacts.

## Security properties retained

- Exact UID:GID ownership for job-created configuration, launcher, crun directory, crun binary, and Podman evidence.
- Exact SHA256, device/inode, size, modes, crun version and commit.
- Rootless Podman isolation, rundir attestation, SYSTEMD feature attestation, JSON evidence, and cleanup.
- No relaxation of runtime bytes or lifecycle controls.

## Failure evidence

- Qualification run: https://github.com/duggytuxy/syswarden/actions/runs/32826433538
- Native ARM64 job: https://github.com/duggytuxy/syswarden/actions/runs/32826433538/job/97735371459

## Validation

- Release gate tests: 88/88
- Qualification workflow tests: 35/35
- Required checks tests: 20/20
- Qualification gate tests: 26/26
- Qualification adapter tests: 21/21
- Release attestation tests: 4/4
- Update manifest and versionctl Go tests passed
- Full CI discovery suite passed, including the six socket-bound package cases outside the local sandbox
- YAML parsing, Bash syntax, ShellCheck error severity, and whitespace checks passed