### PR TITLE
Qualification : bind v4.03.2 unsigned evidence SHA

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -138,45 +138,59 @@ jobs:
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind
-              # the release to one exact reviewed two-commit chain. Keep this
+              # the release to one exact reviewed three-commit chain. Keep this
               # release-specific exception proportional and fail closed.
-              v4032_release_commit_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4032_release_commit_sha}" != "28b7c055ceb9cc6bd0de8d66045aec76adf49db2" ]]; then
-                echo "ERROR: the v4.03.2 candidate is not based on the reviewed PR114 squash." >&2
+              v4032_binding_commit_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_binding_commit_sha}" != "2c2568b591ee622805339394de7501489a44ff2f" ]]; then
+                echo "ERROR: the v4.03.2 candidate is not based on the reviewed PR115 squash." >&2
                 exit 1
               fi
-              v4032_release_base_sha="$(git rev-parse HEAD^^)"
+              v4032_release_commit_sha="$(git rev-parse HEAD^^)"
+              if [[ "${v4032_release_commit_sha}" != "28b7c055ceb9cc6bd0de8d66045aec76adf49db2" ]]; then
+                echo "ERROR: the reviewed PR115 squash is not based on the reviewed PR114 squash." >&2
+                exit 1
+              fi
+              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
               if [[ "${v4032_release_base_sha}" != "e121e832492e6e107822441edaf5edef569ac0ef" ]]; then
                 echo "ERROR: the reviewed PR114 squash is not based on the reviewed PR113 squash." >&2
                 exit 1
               fi
-              v4032_expected_subject='Qualification : bind v4.03.2 release tip (#115)'
+              v4032_expected_subject='Qualification : bind v4.03.2 unsigned evidence SHA (#116)'
               if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 candidate requires the exact reviewed qualification squash subject." >&2
                 exit 1
               fi
-              v4032_release_subject="$(git log -1 --format=%s HEAD^)"
+              v4032_binding_subject="$(git log -1 --format=%s HEAD^)"
+              v4032_expected_binding_subject='Qualification : bind v4.03.2 release tip (#115)'
+              if [[ "${v4032_binding_subject}" != "${v4032_expected_binding_subject}" ]]; then
+                echo "ERROR: the reviewed PR115 squash subject is not exact." >&2
+                exit 1
+              fi
+              v4032_release_subject="$(git log -1 --format=%s HEAD^^)"
               v4032_expected_release_subject='Release : support AMD64 packages only (#114)'
               if [[ "${v4032_release_subject}" != "${v4032_expected_release_subject}" ]]; then
                 echo "ERROR: the reviewed PR114 squash subject is not exact." >&2
                 exit 1
               fi
               read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_release_line[@]} != 2 )); then
-                echo "ERROR: the v4.03.2 qualification tip and reviewed release commit must be linear." >&2
+              read -r -a v4032_binding_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_binding_line[@]} != 2 || ${#v4032_release_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 qualification tip and both reviewed parent commits must be linear." >&2
                 exit 1
               fi
               # BEGIN exact v4.03.2 release-tip diff contract
               expected_v4032_fix_diff=(
                 M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
                 M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_fix_diff < <(
                 git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
               )
               if (( ${#actual_v4032_fix_diff[@]} != ${#expected_v4032_fix_diff[@]} )); then
-                echo "ERROR: the v4.03.2 qualification tip must modify exactly the two reviewed files." >&2
+                echo "ERROR: the v4.03.2 qualification tip must modify exactly the four reviewed files." >&2
                 exit 1
               fi
               for ((index = 0; index < ${#expected_v4032_fix_diff[@]}; index++)); do
@@ -187,7 +201,9 @@ jobs:
               done
               v4032_fix_paths=(
                 ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
                 "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
               )
               for tree_ref in HEAD^ HEAD; do
                 for fix_path in "${v4032_fix_paths[@]}"; do
@@ -686,45 +702,59 @@ jobs:
             if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind
-              # the release to one exact reviewed two-commit chain. Keep this
+              # the release to one exact reviewed three-commit chain. Keep this
               # release-specific exception proportional and fail closed.
-              v4032_release_commit_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4032_release_commit_sha}" != "28b7c055ceb9cc6bd0de8d66045aec76adf49db2" ]]; then
-                echo "ERROR: the v4.03.2 candidate is not based on the reviewed PR114 squash." >&2
+              v4032_binding_commit_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4032_binding_commit_sha}" != "2c2568b591ee622805339394de7501489a44ff2f" ]]; then
+                echo "ERROR: the v4.03.2 candidate is not based on the reviewed PR115 squash." >&2
                 exit 1
               fi
-              v4032_release_base_sha="$(git rev-parse HEAD^^)"
+              v4032_release_commit_sha="$(git rev-parse HEAD^^)"
+              if [[ "${v4032_release_commit_sha}" != "28b7c055ceb9cc6bd0de8d66045aec76adf49db2" ]]; then
+                echo "ERROR: the reviewed PR115 squash is not based on the reviewed PR114 squash." >&2
+                exit 1
+              fi
+              v4032_release_base_sha="$(git rev-parse HEAD^^^)"
               if [[ "${v4032_release_base_sha}" != "e121e832492e6e107822441edaf5edef569ac0ef" ]]; then
                 echo "ERROR: the reviewed PR114 squash is not based on the reviewed PR113 squash." >&2
                 exit 1
               fi
-              v4032_expected_subject='Qualification : bind v4.03.2 release tip (#115)'
+              v4032_expected_subject='Qualification : bind v4.03.2 unsigned evidence SHA (#116)'
               if [[ "${commit_subject}" != "${v4032_expected_subject}" ]]; then
                 echo "ERROR: the v4.03.2 candidate requires the exact reviewed qualification squash subject." >&2
                 exit 1
               fi
-              v4032_release_subject="$(git log -1 --format=%s HEAD^)"
+              v4032_binding_subject="$(git log -1 --format=%s HEAD^)"
+              v4032_expected_binding_subject='Qualification : bind v4.03.2 release tip (#115)'
+              if [[ "${v4032_binding_subject}" != "${v4032_expected_binding_subject}" ]]; then
+                echo "ERROR: the reviewed PR115 squash subject is not exact." >&2
+                exit 1
+              fi
+              v4032_release_subject="$(git log -1 --format=%s HEAD^^)"
               v4032_expected_release_subject='Release : support AMD64 packages only (#114)'
               if [[ "${v4032_release_subject}" != "${v4032_expected_release_subject}" ]]; then
                 echo "ERROR: the reviewed PR114 squash subject is not exact." >&2
                 exit 1
               fi
               read -r -a v4032_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
-              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^)"
-              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_release_line[@]} != 2 )); then
-                echo "ERROR: the v4.03.2 qualification tip and reviewed release commit must be linear." >&2
+              read -r -a v4032_binding_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+              read -r -a v4032_release_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+              if (( ${#v4032_head_line[@]} != 2 || ${#v4032_binding_line[@]} != 2 || ${#v4032_release_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.2 qualification tip and both reviewed parent commits must be linear." >&2
                 exit 1
               fi
               # BEGIN exact v4.03.2 release-tip diff contract
               expected_v4032_fix_diff=(
                 M ".github/workflows/release-manager.yml"
+                M ".github/workflows/release-qualification.yml"
                 M "scripts/ci/release_gate_test.py"
+                M "scripts/ci/release_qualification_workflow_test.py"
               )
               mapfile -d '' -t actual_v4032_fix_diff < <(
                 git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
               )
               if (( ${#actual_v4032_fix_diff[@]} != ${#expected_v4032_fix_diff[@]} )); then
-                echo "ERROR: the v4.03.2 qualification tip must modify exactly the two reviewed files." >&2
+                echo "ERROR: the v4.03.2 qualification tip must modify exactly the four reviewed files." >&2
                 exit 1
               fi
               for ((index = 0; index < ${#expected_v4032_fix_diff[@]}; index++)); do
@@ -735,7 +765,9 @@ jobs:
               done
               v4032_fix_paths=(
                 ".github/workflows/release-manager.yml"
+                ".github/workflows/release-qualification.yml"
                 "scripts/ci/release_gate_test.py"
+                "scripts/ci/release_qualification_workflow_test.py"
               )
               for tree_ref in HEAD^ HEAD; do
                 for fix_path in "${v4032_fix_paths[@]}"; do

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -730,6 +730,7 @@ jobs:
         shell: bash
         env:
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           SIGNED_UPDATE_REQUIRED: ${{ steps.update_contract.outputs.required }}
         run: |

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1544,31 +1544,45 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertNotIn("aarch" + "64", workflow.casefold())
         for block in blocks:
             required = (
-                'v4032_release_commit_sha="$(git rev-parse HEAD^)"',
+                "one exact reviewed three-commit chain",
+                'v4032_binding_commit_sha="$(git rev-parse HEAD^)"',
+                '"${v4032_binding_commit_sha}" != '
+                '"2c2568b591ee622805339394de7501489a44ff2f"',
+                'v4032_release_commit_sha="$(git rev-parse HEAD^^)"',
                 '"${v4032_release_commit_sha}" != '
                 '"28b7c055ceb9cc6bd0de8d66045aec76adf49db2"',
-                'v4032_release_base_sha="$(git rev-parse HEAD^^)"',
+                'v4032_release_base_sha="$(git rev-parse HEAD^^^)"',
                 '"${v4032_release_base_sha}" != '
                 '"e121e832492e6e107822441edaf5edef569ac0ef"',
                 "v4032_expected_subject="
-                "'Qualification : bind v4.03.2 release tip (#115)'",
+                "'Qualification : bind v4.03.2 unsigned evidence SHA (#116)'",
                 '"${commit_subject}" != "${v4032_expected_subject}"',
-                'v4032_release_subject="$(git log -1 --format=%s HEAD^)"',
+                'v4032_binding_subject="$(git log -1 --format=%s HEAD^)"',
+                "v4032_expected_binding_subject="
+                "'Qualification : bind v4.03.2 release tip (#115)'",
+                '"${v4032_binding_subject}" != '
+                '"${v4032_expected_binding_subject}"',
+                'v4032_release_subject="$(git log -1 --format=%s HEAD^^)"',
                 "v4032_expected_release_subject="
                 "'Release : support AMD64 packages only (#114)'",
                 '"${v4032_release_subject}" != '
                 '"${v4032_expected_release_subject}"',
                 'v4032_head_line <<< '
                 '"$(git rev-list --parents -n 1 HEAD)"',
-                'v4032_release_line <<< '
+                'v4032_binding_line <<< '
                 '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_release_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
                 "${#v4032_head_line[@]} != 2",
+                "${#v4032_binding_line[@]} != 2",
                 "${#v4032_release_line[@]} != 2",
                 "# BEGIN exact v4.03.2 release-tip diff contract",
                 "# END exact v4.03.2 release-tip diff contract",
                 "expected_v4032_fix_diff=(",
                 'M ".github/workflows/release-manager.yml"',
+                'M ".github/workflows/release-qualification.yml"',
                 'M "scripts/ci/release_gate_test.py"',
+                'M "scripts/ci/release_qualification_workflow_test.py"',
                 "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD",
                 "${#actual_v4032_fix_diff[@]} != ${#expected_v4032_fix_diff[@]}",
                 'for tree_ref in HEAD^ HEAD; do',
@@ -1585,13 +1599,21 @@ class ReleaseGateTests(unittest.TestCase):
             )
             for contract in required:
                 self.assertEqual(block.count(contract), 1, contract)
+            expected_path_counts = {
+                ".github/workflows/release-manager.yml": 2,
+                ".github/workflows/release-qualification.yml": 2,
+                "scripts/ci/release_gate_test.py": 2,
+                "scripts/ci/release_qualification_workflow_test.py": 2,
+            }
+            for path, count in expected_path_counts.items():
+                self.assertEqual(block.count(f'"{path}"'), count, path)
             self.assertNotIn("changelog.md", block)
 
     def v4032_qualification_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         block = self.v4032_recovery_blocks(workflow)[0]
         start = "v4032_expected_subject="
-        end = 'v4032_release_subject="$(git log -1 --format=%s HEAD^)"'
+        end = 'v4032_binding_subject="$(git log -1 --format=%s HEAD^)"'
         self.assertEqual(block.count(start), 1)
         self.assertEqual(block.count(end), 1)
         fragment = start + block.split(start, 1)[1].split(end, 1)[0]
@@ -1686,17 +1708,19 @@ class ReleaseGateTests(unittest.TestCase):
         )
         paths = [
             repository / ".github/workflows/release-manager.yml",
+            repository / ".github/workflows/release-qualification.yml",
             repository / "scripts/ci/release_gate_test.py",
+            repository / "scripts/ci/release_qualification_workflow_test.py",
         ]
         for path in paths:
-            self.write_file(path, b"reviewed PR114 tree\n")
+            self.write_file(path, b"reviewed PR115 tree\n")
         subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
         subprocess.run(
-            ["git", "-C", repository, "commit", "-q", "-m", "reviewed PR114"],
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed PR115"],
             check=True,
         )
         for path in paths:
-            path.write_bytes(b"reviewed v4.03.2 qualification tip\n")
+            path.write_bytes(b"reviewed v4.03.2 evidence binding\n")
         if mutation == "extra file":
             self.write_file(repository / "unauthorized.txt", b"unexpected\n")
         elif mutation == "mode":
@@ -1705,7 +1729,9 @@ class ReleaseGateTests(unittest.TestCase):
             paths[1].unlink()
             paths[1].symlink_to("unauthorized-target")
         elif mutation == "rename":
-            paths[1].rename(paths[1].with_name("renamed_release_gate_test.py"))
+            paths[3].rename(
+                paths[3].with_name("renamed_release_qualification_workflow_test.py")
+            )
         subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
         subprocess.run(
             ["git", "-C", repository, "commit", "-q", "-m", "reviewed tip"],
@@ -1726,29 +1752,47 @@ class ReleaseGateTests(unittest.TestCase):
                 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
                 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
             ),
+            "binding commit resolution": workflow.replace(
+                'v4032_binding_commit_sha="$(git rev-parse HEAD^)"',
+                'v4032_binding_commit_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact reviewed PR115": workflow.replace(
+                "2c2568b591ee622805339394de7501489a44ff2f",
+                "3c2568b591ee622805339394de7501489a44ff2f",
+            ),
             "release commit resolution": workflow.replace(
-                'v4032_release_commit_sha="$(git rev-parse HEAD^)"',
                 'v4032_release_commit_sha="$(git rev-parse HEAD^^)"',
+                'v4032_release_commit_sha="$(git rev-parse HEAD^)"',
             ),
             "exact reviewed PR114": workflow.replace(
                 "28b7c055ceb9cc6bd0de8d66045aec76adf49db2",
                 "38b7c055ceb9cc6bd0de8d66045aec76adf49db2",
             ),
             "release base resolution": workflow.replace(
+                'v4032_release_base_sha="$(git rev-parse HEAD^^^)"',
                 'v4032_release_base_sha="$(git rev-parse HEAD^^)"',
-                'v4032_release_base_sha="$(git rev-parse HEAD^)"',
             ),
             "exact reviewed PR113": workflow.replace(
                 "e121e832492e6e107822441edaf5edef569ac0ef",
                 "f121e832492e6e107822441edaf5edef569ac0ef",
             ),
             "qualification subject": workflow.replace(
-                "Qualification : bind v4.03.2 release tip (#115)",
-                "Qualification : arbitrary release tip (#115)",
+                "Qualification : bind v4.03.2 unsigned evidence SHA (#116)",
+                "Qualification : bind v4.03.2 unsigned evidence (#116)",
             ),
             "qualification subject comparison": workflow.replace(
                 '"${commit_subject}" != "${v4032_expected_subject}"',
                 '"${commit_subject}" == "${v4032_expected_subject}"',
+            ),
+            "reviewed binding subject": workflow.replace(
+                "Qualification : bind v4.03.2 release tip (#115)",
+                "Qualification : bind v4.03.2 release tree (#115)",
+            ),
+            "reviewed binding subject comparison": workflow.replace(
+                '"${v4032_binding_subject}" != '
+                '"${v4032_expected_binding_subject}"',
+                '"${v4032_binding_subject}" == '
+                '"${v4032_expected_binding_subject}"',
             ),
             "reviewed release subject": workflow.replace(
                 "Release : support AMD64 packages only (#114)",
@@ -1766,19 +1810,33 @@ class ReleaseGateTests(unittest.TestCase):
                 'v4032_head_line <<< '
                 '"$(git rev-list --parents -n 1 HEAD^)"',
             ),
+            "linear binding commit": workflow.replace(
+                'v4032_binding_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4032_binding_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
+            ),
             "linear release commit": workflow.replace(
                 'v4032_release_line <<< '
-                '"$(git rev-list --parents -n 1 HEAD^)"',
-                'v4032_release_line <<< '
                 '"$(git rev-list --parents -n 1 HEAD^^)"',
+                'v4032_release_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^^)"',
             ),
             "diff rename policy": workflow.replace(
                 "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD",
                 "git diff-tree --no-commit-id --name-status -r -z HEAD^ HEAD",
             ),
             "exact fix path": workflow.replace(
-                'M "scripts/ci/release_gate_test.py"',
-                'M "scripts/ci/release_gate.py"',
+                'M "scripts/ci/release_qualification_workflow_test.py"',
+                'M "scripts/ci/release_qualification_test.py"',
+            ),
+            "tree fix path": workflow.replace(
+                '\n                "scripts/ci/release_gate_test.py"\n',
+                '\n                "scripts/ci/release_gate.py"\n',
+            ),
+            "linearity comparison": workflow.replace(
+                "${#v4032_binding_line[@]} != 2",
+                "${#v4032_binding_line[@]} == 2",
             ),
             "blob mode": workflow.replace(
                 '"${tree_mode}" != "100644"',
@@ -1798,22 +1856,28 @@ class ReleaseGateTests(unittest.TestCase):
     def test_release_manager_v4032_subject_is_exact_github_squash(self) -> None:
         script = self.v4032_qualification_subject_gate_script()
         cases = {
-            "valid": ("Qualification : bind v4.03.2 release tip (#115)", True),
-            "bare": ("Qualification : bind v4.03.2 release tip", False),
+            "valid": (
+                "Qualification : bind v4.03.2 unsigned evidence SHA (#116)",
+                True,
+            ),
+            "bare": (
+                "Qualification : bind v4.03.2 unsigned evidence SHA",
+                False,
+            ),
             "wrong pull request": (
-                "Qualification : bind v4.03.2 release tip (#114)",
+                "Qualification : bind v4.03.2 unsigned evidence SHA (#115)",
                 False,
             ),
             "different scope": (
-                "Qualification : bind v4.03.2 publication tip (#115)",
+                "Qualification : bind v4.03.2 signed evidence SHA (#116)",
                 False,
             ),
             "wrong version": (
-                "Qualification : bind v4.03.3 release tip (#115)",
+                "Qualification : bind v4.03.3 unsigned evidence SHA (#116)",
                 False,
             ),
             "trailing space": (
-                "Qualification : bind v4.03.2 release tip (#115) ",
+                "Qualification : bind v4.03.2 unsigned evidence SHA (#116) ",
                 False,
             ),
         }

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -799,6 +799,15 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         unsigned_seal = workflow_step_script(
             self.workflow, "Seal Exact Unsigned Qualification Evidence Inventory"
         )
+        unsigned_seal_step = workflow_step(
+            self.workflow, "Seal Exact Unsigned Qualification Evidence Inventory"
+        )
+        self.assertEqual(
+            unsigned_seal_step.count(
+                "RELEASE_SHA: ${{ inputs.release_sha }}"
+            ),
+            1,
+        )
         self.assertNotIn("update/syswarden-update-manifest-v1.json", unsigned_seal)
         final_seal = workflow_step_script(
             self.workflow, "Seal Exact Qualification Evidence Inventory"


### PR DESCRIPTION
## Summary

- Bind the exact release SHA into the unsigned qualification evidence seal.
- Add a regression contract for the missing environment binding.
- Extend the v4.03.2 publication exception to the exact reviewed PR116 -> PR115 -> PR114 -> PR113 chain and the exact four-file diff.

## Root cause

Qualification run 32848512661 passed the complete AMD64 lifecycle matrix, nftables laboratory, bound envelopes and aggregate gate. The final unsigned evidence step then stopped under set -u because RELEASE_SHA was used in the artifact name but was not exposed in that step environment.

## Validation

- 494 Python CI tests passed, with 8 expected skips.
- 61 release gate tests passed.
- 28 release qualification workflow tests passed.
- YAML parsing, Python compilation and git diff checks passed.
- The commit is SSH signed and GitHub verified.