### PR TITLE
CI : make release inventory comparison portable

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -1879,7 +1879,7 @@ jobs:
             --repository "${GITHUB_WORKSPACE}" \
             --tag "${RELEASE_TAG}" \
             --assets existing_release_assets
-          diff --no-index \
+          cmp --silent \
             release_payload/assets/RELEASE_SHA256SUMS.txt \
             existing_release_assets/RELEASE_SHA256SUMS.txt
           bash scripts/ci/verify_release_attestations.sh \
@@ -1949,7 +1949,7 @@ jobs:
             --repository "${GITHUB_WORKSPACE}" \
             --tag "${RELEASE_TAG}" \
             --assets draft_release_assets
-          diff --no-index \
+          cmp --silent \
             release_payload/assets/RELEASE_SHA256SUMS.txt \
             draft_release_assets/RELEASE_SHA256SUMS.txt
           bash scripts/ci/verify_release_attestations.sh \
@@ -2154,7 +2154,7 @@ jobs:
             --repository "${GITHUB_WORKSPACE}" \
             --tag "${RELEASE_TAG}" \
             --assets published_release_assets
-          diff --no-index \
+          cmp --silent \
             release_payload/assets/RELEASE_SHA256SUMS.txt \
             published_release_assets/RELEASE_SHA256SUMS.txt
           bash scripts/ci/verify_release_attestations.sh \

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1367,6 +1367,34 @@ class ReleaseGateTests(unittest.TestCase):
         self.assertEqual(workflow.count("jq -j '.body'"), 2)
         self.assertNotIn("jq -r '.body'", workflow)
 
+    def test_workflow_uses_portable_byte_exact_release_inventory_comparisons(
+        self,
+    ) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        comparisons = (
+            (
+                "release_payload/assets/RELEASE_SHA256SUMS.txt",
+                "existing_release_assets/RELEASE_SHA256SUMS.txt",
+            ),
+            (
+                "release_payload/assets/RELEASE_SHA256SUMS.txt",
+                "draft_release_assets/RELEASE_SHA256SUMS.txt",
+            ),
+            (
+                "release_payload/assets/RELEASE_SHA256SUMS.txt",
+                "published_release_assets/RELEASE_SHA256SUMS.txt",
+            ),
+        )
+
+        self.assertNotIn("diff --no-index", workflow)
+        for expected, actual in comparisons:
+            comparison = (
+                "cmp --silent \\\n"
+                f"            {expected} \\\n"
+                f"            {actual}"
+            )
+            self.assertEqual(workflow.count(comparison), 1, actual)
+
     def assert_preserved_version_recovery_contract(self, workflow: str) -> None:
         scripts = workflow_step_scripts(
             workflow, "Validate Tag, Source, Changelog, and Main Ancestry"


### PR DESCRIPTION
## Summary

- Replace the three invalid plain diff --no-index invocations with byte-exact cmp --silent checks.
- Cover existing, private-draft, and published release inventories.
- Add a regression test that forbids the invalid option and requires all three portable comparisons exactly once.

## Context

Publisher run 32857272712 validated the exact v4.03.2 payload and created the private draft, then failed only because --no-index is a git diff option rather than a plain diff option. The release was recovered through the same skipped checks using cmp, including exact asset validation and OIDC provenance verification.

## Validation

- 495 Python CI tests passed with 8 expected skips.
- 62 release gate tests passed.
- YAML parsing passed.
- Python compilation passed.
- git diff --check passed.

README.md, documentation, product code, and version files are unchanged.