### PR TITLE
CI : bind one-time v4.03.3 changelog seal

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -135,7 +135,95 @@ jobs:
               --base-ref HEAD^ \
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
-            if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
+            if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then
+              # v4.03.3 was already versioned by the reviewed PR118 squash.
+              # Authorize one exact follow-up that seals the single-use
+              # changelog rewrite policy without changing release version
+              # targets or changelog.
+              v4033_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
+                exit 1
+              fi
+              v4033_base_sha="$(git rev-parse HEAD^^)"
+              if [[ "${v4033_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                exit 1
+              fi
+              v4033_parent_subject="$(git log -1 --format=%s HEAD^)"
+              v4033_expected_parent_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+              if [[ "${v4033_parent_subject}" != "${v4033_expected_parent_subject}" ]]; then
+                echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                exit 1
+              fi
+              v4033_followup_subject_pattern='^CI : bind one-time v4.03.3 changelog seal \(#[1-9][0-9]*\)$'
+              if [[ ! "${commit_subject}" =~ ${v4033_followup_subject_pattern} ]]; then
+                echo "ERROR: the v4.03.3 follow-up requires the exact reviewed CI subject." >&2
+                exit 1
+              fi
+              read -r -a v4033_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4033_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+              if (( ${#v4033_head_line[@]} != 2 || ${#v4033_parent_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.3 follow-up and reviewed PR118 squash must both be linear." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.3 changelog-seal diff contract
+              expected_v4033_followup_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/versionctl/repository.go"
+                M "scripts/versionctl/repository_test.go"
+              )
+              mapfile -d '' -t actual_v4033_followup_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4033_followup_diff[@]} != ${#expected_v4033_followup_diff[@]} )); then
+                echo "ERROR: the v4.03.3 follow-up must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4033_followup_diff[@]}; index++)); do
+                if [[ "${actual_v4033_followup_diff[index]}" != "${expected_v4033_followup_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.3 follow-up contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4033_followup_paths=(
+                ".github/workflows/release-manager.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/versionctl/repository.go"
+                "scripts/versionctl/repository_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4033_followup_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.3 follow-up path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.3 changelog-seal diff contract
+              git diff --quiet HEAD^ HEAD -- \
+                changelog.md \
+                README.md \
+                src/core/syswarden-cli/pkg/system/upgrade.go \
+                src/core/syswarden-tui/main.go \
+                src/core/syswarden-cli/cmd/install.go \
+                src/core/syswarden-cli/config/default.go \
+                src/core/syswarden-cli/pkg/integration/webhook.go \
+                src/core/syswarden-core/webhook/discord.go
+              v4033_parent_message="$(git log -1 --format=%B HEAD^)"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4033_base_sha}" \
+                --tag-phase \
+                --commit-message "${v4033_parent_message}"
+            elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind
               # the release to one exact reviewed three-commit chain. Keep this
@@ -699,7 +787,95 @@ jobs:
               --base-ref HEAD^ \
               --commit-message "${commit_message}"
             commit_subject="$(git log -1 --format=%s HEAD)"
-            if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
+            if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then
+              # v4.03.3 was already versioned by the reviewed PR118 squash.
+              # Authorize one exact follow-up that seals the single-use
+              # changelog rewrite policy without changing release version
+              # targets or changelog.
+              v4033_parent_sha="$(git rev-parse HEAD^)"
+              if [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
+                exit 1
+              fi
+              v4033_base_sha="$(git rev-parse HEAD^^)"
+              if [[ "${v4033_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                exit 1
+              fi
+              v4033_parent_subject="$(git log -1 --format=%s HEAD^)"
+              v4033_expected_parent_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+              if [[ "${v4033_parent_subject}" != "${v4033_expected_parent_subject}" ]]; then
+                echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                exit 1
+              fi
+              v4033_followup_subject_pattern='^CI : bind one-time v4.03.3 changelog seal \(#[1-9][0-9]*\)$'
+              if [[ ! "${commit_subject}" =~ ${v4033_followup_subject_pattern} ]]; then
+                echo "ERROR: the v4.03.3 follow-up requires the exact reviewed CI subject." >&2
+                exit 1
+              fi
+              read -r -a v4033_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+              read -r -a v4033_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+              if (( ${#v4033_head_line[@]} != 2 || ${#v4033_parent_line[@]} != 2 )); then
+                echo "ERROR: the v4.03.3 follow-up and reviewed PR118 squash must both be linear." >&2
+                exit 1
+              fi
+              # BEGIN exact v4.03.3 changelog-seal diff contract
+              expected_v4033_followup_diff=(
+                M ".github/workflows/release-manager.yml"
+                M "scripts/ci/release_gate_test.py"
+                M "scripts/versionctl/repository.go"
+                M "scripts/versionctl/repository_test.go"
+              )
+              mapfile -d '' -t actual_v4033_followup_diff < <(
+                git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+              )
+              if (( ${#actual_v4033_followup_diff[@]} != ${#expected_v4033_followup_diff[@]} )); then
+                echo "ERROR: the v4.03.3 follow-up must modify exactly the four reviewed files." >&2
+                exit 1
+              fi
+              for ((index = 0; index < ${#expected_v4033_followup_diff[@]}; index++)); do
+                if [[ "${actual_v4033_followup_diff[index]}" != "${expected_v4033_followup_diff[index]}" ]]; then
+                  echo "ERROR: the v4.03.3 follow-up contains an unauthorized path, status, or rename." >&2
+                  exit 1
+                fi
+              done
+              v4033_followup_paths=(
+                ".github/workflows/release-manager.yml"
+                "scripts/ci/release_gate_test.py"
+                "scripts/versionctl/repository.go"
+                "scripts/versionctl/repository_test.go"
+              )
+              for tree_ref in HEAD^ HEAD; do
+                for fix_path in "${v4033_followup_paths[@]}"; do
+                  tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                  IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                  if [[ "${tree_mode}" != "100644" || \
+                        "${tree_type}" != "blob" || \
+                        ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                        "${tree_path}" != "${fix_path}" || \
+                        -n "${tree_extra:-}" ]]; then
+                    echo "ERROR: reviewed v4.03.3 follow-up path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                    exit 1
+                  fi
+                done
+              done
+              # END exact v4.03.3 changelog-seal diff contract
+              git diff --quiet HEAD^ HEAD -- \
+                changelog.md \
+                README.md \
+                src/core/syswarden-cli/pkg/system/upgrade.go \
+                src/core/syswarden-tui/main.go \
+                src/core/syswarden-cli/cmd/install.go \
+                src/core/syswarden-cli/config/default.go \
+                src/core/syswarden-cli/pkg/integration/webhook.go \
+                src/core/syswarden-core/webhook/discord.go
+              v4033_parent_message="$(git log -1 --format=%B HEAD^)"
+              ./scripts/versioning.sh validate-commit \
+                --repo "${GITHUB_WORKSPACE}" \
+                --base-ref "${v4033_base_sha}" \
+                --tag-phase \
+                --commit-message "${v4033_parent_message}"
+            elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind
               # the release to one exact reviewed three-commit chain. Keep this

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1467,10 +1467,10 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD)"), 6
+            workflow.count("git rev-list --parents -n 1 HEAD)"), 8
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD^)"), 6
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 8
         )
         self.assertEqual(
             workflow.count(
@@ -1485,7 +1485,7 @@ class ReleaseGateTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 6)
+        self.assertEqual(workflow.count("git diff --quiet HEAD^ HEAD --"), 8)
         self.assertEqual(
             workflow.count(
                 '\n                parent_commit_message="$(git log -1 --format=%B HEAD^)"'
@@ -1510,8 +1510,8 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         for script in scripts:
-            self.assertEqual(script.count("--tag-phase"), 3)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 5)
+            self.assertEqual(script.count("--tag-phase"), 4)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 6)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -1524,22 +1524,205 @@ class ReleaseGateTests(unittest.TestCase):
                 script.count(
                     "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD"
                 ),
-                2,
+                3,
             )
-            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 2)
+            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 3)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                2,
+                3,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 2)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 2)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 3)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 3)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 4,
-                "scripts/ci/release_gate_test.py": 4,
+                ".github/workflows/release-manager.yml": 6,
+                "scripts/ci/release_gate_test.py": 6,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
                 self.assertEqual(script.count(f'"{path}"'), count)
+
+    def v4033_recovery_blocks(self, workflow: str) -> list[str]:
+        scripts = workflow_step_scripts(
+            workflow, "Validate Tag, Source, Changelog, and Main Ancestry"
+        )
+        self.assertEqual(len(scripts), 2)
+        self.assertEqual(scripts[0], scripts[1])
+        start = 'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then\n'
+        end = '\n  elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then\n'
+        blocks = []
+        for script in scripts:
+            self.assertEqual(script.count(start), 1)
+            remainder = script.split(start, 1)[1]
+            self.assertIn(end, remainder)
+            blocks.append(start + remainder.split(end, 1)[0])
+        self.assertEqual(blocks[0], blocks[1])
+        return blocks
+
+    def assert_v4033_preserved_version_recovery_contract(
+        self, workflow: str
+    ) -> None:
+        blocks = self.v4033_recovery_blocks(workflow)
+        self.assertEqual(
+            workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then'), 2
+        )
+        self.assertEqual(
+            workflow.count(
+                "v4033_followup_subject_pattern='^CI : bind one-time v4.03.3 "
+                "changelog seal \\(#[1-9][0-9]*\\)$'"
+            ),
+            2,
+        )
+        self.assertNotIn("arm" + "64", workflow.casefold())
+        self.assertNotIn("aarch" + "64", workflow.casefold())
+        for block in blocks:
+            required = (
+                "one exact follow-up that seals the single-use",
+                'v4033_parent_sha="$(git rev-parse HEAD^)"',
+                '"${v4033_parent_sha}" != '
+                '"689871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+                'v4033_base_sha="$(git rev-parse HEAD^^)"',
+                '"${v4033_base_sha}" != '
+                '"b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+                'v4033_parent_subject="$(git log -1 --format=%s HEAD^)"',
+                "v4033_expected_parent_subject="
+                "'Patch : correct webhook, firewall and OSINT handling (#118)'",
+                '"${v4033_parent_subject}" != '
+                '"${v4033_expected_parent_subject}"',
+                "v4033_followup_subject_pattern="
+                "'^CI : bind one-time v4.03.3 changelog seal "
+                "\\(#[1-9][0-9]*\\)$'",
+                '[[ ! "${commit_subject}" =~ '
+                '${v4033_followup_subject_pattern} ]]',
+                'v4033_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                "${#v4033_head_line[@]} != 2",
+                "${#v4033_parent_line[@]} != 2",
+                "# BEGIN exact v4.03.3 changelog-seal diff contract",
+                "# END exact v4.03.3 changelog-seal diff contract",
+                "expected_v4033_followup_diff=(",
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "${#actual_v4033_followup_diff[@]} != "
+                "${#expected_v4033_followup_diff[@]}",
+                'for tree_ref in HEAD^ HEAD; do',
+                'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"',
+                '"${tree_mode}" != "100644"',
+                '"${tree_type}" != "blob"',
+                "git diff --quiet HEAD^ HEAD --",
+                'v4033_parent_message="$(git log -1 --format=%B HEAD^)"',
+                '--base-ref "${v4033_base_sha}"',
+                "--tag-phase",
+                '--commit-message "${v4033_parent_message}"',
+            )
+            for contract in required:
+                self.assertEqual(block.count(contract), 1, contract)
+            expected_followup_paths = (
+                ".github/workflows/release-manager.yml",
+                "scripts/ci/release_gate_test.py",
+                "scripts/versionctl/repository.go",
+                "scripts/versionctl/repository_test.go",
+            )
+            for path in expected_followup_paths:
+                self.assertEqual(block.count(f'M "{path}"'), 1, path)
+                self.assertEqual(block.count(f'"{path}"'), 2, path)
+            protected_release_paths = (
+                "changelog.md",
+                "README.md",
+                "src/core/syswarden-cli/pkg/system/upgrade.go",
+                "src/core/syswarden-tui/main.go",
+                "src/core/syswarden-cli/cmd/install.go",
+                "src/core/syswarden-cli/config/default.go",
+                "src/core/syswarden-cli/pkg/integration/webhook.go",
+                "src/core/syswarden-core/webhook/discord.go",
+            )
+            for path in protected_release_paths:
+                self.assertEqual(block.count(path), 1, path)
+            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 1)
+            self.assertEqual(block.count("--tag-phase"), 1)
+
+    def v4033_followup_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_recovery_blocks(workflow)[0]
+        start = "v4033_followup_subject_pattern="
+        end = 'read -r -a v4033_head_line <<< "$(git rev-list --parents -n 1 HEAD)"'
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
+    def exact_v4033_followup_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_recovery_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.3 changelog-seal diff contract\n"
+        end = "# END exact v4.03.3 changelog-seal diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def make_v4033_followup_diff_repository(
+        self, name: str, mutation: str | None
+    ) -> Path:
+        repository = self.root / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        followup_paths = [
+            repository / ".github/workflows/release-manager.yml",
+            repository / "scripts/ci/release_gate_test.py",
+            repository / "scripts/versionctl/repository.go",
+            repository / "scripts/versionctl/repository_test.go",
+        ]
+        protected_paths = {
+            "changelog": repository / "changelog.md",
+            "readme": repository / "README.md",
+            "version target": repository
+            / "src/core/syswarden-cli/pkg/system/upgrade.go",
+        }
+        for path in [*followup_paths, *protected_paths.values()]:
+            self.write_file(path, b"reviewed parent\n")
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed parent"],
+            check=True,
+        )
+        for path in followup_paths:
+            if mutation != "unchanged path" or path != followup_paths[-1]:
+                path.write_bytes(b"reviewed changelog seal\n")
+        if mutation in protected_paths:
+            protected_paths[mutation].write_bytes(b"unauthorized release drift\n")
+        elif mutation == "extra file":
+            self.write_file(repository / "unauthorized.txt", b"unexpected\n")
+        elif mutation == "mode":
+            followup_paths[0].chmod(0o755)
+        elif mutation == "symlink":
+            followup_paths[1].unlink()
+            followup_paths[1].symlink_to("unauthorized-target")
+        elif mutation == "rename":
+            followup_paths[3].rename(
+                followup_paths[3].with_name("renamed_repository_test.go")
+            )
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed fix"],
+            check=True,
+        )
+        return repository
 
     def v4032_recovery_blocks(self, workflow: str) -> list[str]:
         scripts = workflow_step_scripts(
@@ -1547,7 +1730,7 @@ class ReleaseGateTests(unittest.TestCase):
         )
         self.assertEqual(len(scripts), 2)
         self.assertEqual(scripts[0], scripts[1])
-        start = 'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then\n'
+        start = 'elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then\n'
         end = "\n  else\n"
         blocks = []
         for script in scripts:
@@ -1566,7 +1749,7 @@ class ReleaseGateTests(unittest.TestCase):
             workflow.count('commit_subject="$(git log -1 --format=%s HEAD)"'), 2
         )
         self.assertEqual(
-            workflow.count('if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
+            workflow.count('elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then'), 2
         )
         self.assertNotIn("arm" + "64", workflow.casefold())
         self.assertNotIn("aarch" + "64", workflow.casefold())
@@ -1767,6 +1950,204 @@ class ReleaseGateTests(unittest.TestCase):
         )
         return repository
 
+    def test_release_manager_bounds_v4033_changelog_seal_to_exact_chain(
+        self,
+    ) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        self.assert_v4033_preserved_version_recovery_contract(workflow)
+
+    def test_release_manager_v4033_contract_rejects_mutations(self) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        mutations = {
+            "release tag": workflow.replace(
+                'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
+                'if [[ "${RELEASE_TAG}" == "v4.03.4" ]]; then',
+            ),
+            "parent resolution": workflow.replace(
+                'v4033_parent_sha="$(git rev-parse HEAD^)"',
+                'v4033_parent_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact PR118 parent": workflow.replace(
+                "689871803bdef1bc2a25d3eece0a7c35fdb5c447",
+                "789871803bdef1bc2a25d3eece0a7c35fdb5c447",
+            ),
+            "base resolution": workflow.replace(
+                'v4033_base_sha="$(git rev-parse HEAD^^)"',
+                'v4033_base_sha="$(git rev-parse HEAD^^^)"',
+            ),
+            "exact PR117 base": workflow.replace(
+                "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449",
+                "c9fbfe2ee292a53e6e19dd3e27a071f78fe2f449",
+            ),
+            "parent subject": workflow.replace(
+                "Patch : correct webhook, firewall and OSINT handling (#118)",
+                "Patch : correct webhook and firewall handling (#118)",
+            ),
+            "parent subject comparison": workflow.replace(
+                '"${v4033_parent_subject}" != '
+                '"${v4033_expected_parent_subject}"',
+                '"${v4033_parent_subject}" == '
+                '"${v4033_expected_parent_subject}"',
+            ),
+            "follow-up subject": workflow.replace(
+                "CI : bind one-time v4.03.3 changelog seal",
+                "CI : bind reusable v4.03.3 changelog seal",
+            ),
+            "follow-up subject comparison": workflow.replace(
+                '[[ ! "${commit_subject}" =~ '
+                '${v4033_followup_subject_pattern} ]]',
+                '[[ "${commit_subject}" =~ '
+                '${v4033_followup_subject_pattern} ]]',
+            ),
+            "linear head": workflow.replace(
+                'v4033_head_line <<< "$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_head_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "linear parent": workflow.replace(
+                'v4033_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"',
+                'v4033_parent_line <<< "$(git rev-list --parents -n 1 HEAD^^)"',
+            ),
+            "linearity comparison": workflow.replace(
+                "${#v4033_parent_line[@]} != 2",
+                "${#v4033_parent_line[@]} == 2",
+            ),
+            "diff rename policy": workflow.replace(
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "git diff-tree --no-commit-id --name-status -r -z HEAD^ HEAD",
+            ),
+            "diff status": workflow.replace(
+                'M "scripts/versionctl/repository.go"',
+                'A "scripts/versionctl/repository.go"',
+            ),
+            "diff path": workflow.replace(
+                'M "scripts/versionctl/repository_test.go"',
+                'M "scripts/versionctl/rewrite_test.go"',
+            ),
+            "diff count comparison": workflow.replace(
+                "${#actual_v4033_followup_diff[@]} != "
+                "${#expected_v4033_followup_diff[@]}",
+                "${#actual_v4033_followup_diff[@]} == "
+                "${#expected_v4033_followup_diff[@]}",
+            ),
+            "tree path": workflow.replace(
+                '\n                "scripts/versionctl/repository.go"\n',
+                '\n                "scripts/versionctl/rewrite.go"\n',
+            ),
+            "blob mode": workflow.replace(
+                '"${tree_mode}" != "100644"',
+                '"${tree_mode}" != "100755"',
+            ),
+            "changelog drift": workflow.replace(
+                "changelog.md \\", "CHANGELOG.md \\",
+            ),
+            "README drift": workflow.replace("README.md \\", "README.rst \\"),
+            "version target drift": workflow.replace(
+                "src/core/syswarden-cli/pkg/system/upgrade.go \\",
+                "src/core/syswarden-cli/pkg/system/update.go \\",
+            ),
+            "replay base": workflow.replace(
+                '--base-ref "${v4033_base_sha}"', '--base-ref HEAD^'
+            ),
+            "replay subject": workflow.replace(
+                'v4033_parent_message="$(git log -1 --format=%B HEAD^)"',
+                'v4033_parent_message="$(git log -1 --format=%B HEAD)"',
+            ),
+        }
+        mutations["duplicated block divergence"] = workflow.replace(
+            "689871803bdef1bc2a25d3eece0a7c35fdb5c447",
+            "789871803bdef1bc2a25d3eece0a7c35fdb5c447",
+            1,
+        )
+        for name, mutation in mutations.items():
+            with self.subTest(name=name):
+                self.assertNotEqual(mutation, workflow)
+                with self.assertRaises(AssertionError):
+                    self.assert_v4033_preserved_version_recovery_contract(mutation)
+
+    def test_release_manager_v4033_subject_is_exact_github_squash(self) -> None:
+        script = self.v4033_followup_subject_gate_script()
+        cases = {
+            "valid": ("CI : bind one-time v4.03.3 changelog seal (#119)", True),
+            "bare": ("CI : bind one-time v4.03.3 changelog seal", False),
+            "zero": ("CI : bind one-time v4.03.3 changelog seal (#0)", False),
+            "leading zero": (
+                "CI : bind one-time v4.03.3 changelog seal (#0119)",
+                False,
+            ),
+            "non-numeric": (
+                "CI : bind one-time v4.03.3 changelog seal (#PR)",
+                False,
+            ),
+            "wrong category": (
+                "Patch : bind one-time v4.03.3 changelog seal (#119)",
+                False,
+            ),
+            "wrong version": (
+                "CI : bind one-time v4.03.4 changelog seal (#119)",
+                False,
+            ),
+            "double space": (
+                "CI : bind one-time v4.03.3 changelog seal  (#119)",
+                False,
+            ),
+            "trailing space": (
+                "CI : bind one-time v4.03.3 changelog seal (#119) ",
+                False,
+            ),
+            "extra text": (
+                "CI : bind one-time v4.03.3 changelog seal (#119) extra",
+                False,
+            ),
+        }
+        for name, (subject, accepted) in cases.items():
+            with self.subTest(name=name):
+                environment = dict(os.environ)
+                environment["COMMIT_SUBJECT"] = subject
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=REPOSITORY,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_release_manager_v4033_exact_diff_rejects_git_shape_and_release_drift(
+        self,
+    ) -> None:
+        script = self.exact_v4033_followup_diff_script()
+        mutations = (
+            None,
+            "extra file",
+            "changelog",
+            "readme",
+            "version target",
+            "unchanged path",
+            "mode",
+            "symlink",
+            "rename",
+        )
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=mutation or "exact"):
+                repository = self.make_v4033_followup_diff_repository(
+                    f"v4033-followup-diff-{index}", mutation
+                )
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=repository,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if mutation is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_release_manager_bounds_v4032_to_current_amd64_candidate(
         self,
     ) -> None:
@@ -1777,8 +2158,8 @@ class ReleaseGateTests(unittest.TestCase):
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         mutations = {
             "release tag": workflow.replace(
-                'if [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
-                'if [[ "${RELEASE_TAG}" == "v4.03.3" ]]; then',
+                'elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then',
+                'elif [[ "${RELEASE_TAG}" == "v4.03.1" ]]; then',
             ),
             "binding commit resolution": workflow.replace(
                 'v4032_binding_commit_sha="$(git rev-parse HEAD^)"',

--- a/scripts/versionctl/repository.go
+++ b/scripts/versionctl/repository.go
@@ -45,6 +45,11 @@ const (
 	approvedChangelogResetTo     = "v4.03.0"
 	approvedChangelogArchiveHash = "a6ebcab7a81769c52147be710622995779cedf9523270cf08cf03e275501cde5"
 	approvedChangelogArchiveLine = "Archived pre-v4.03.0 changelog SHA-256: " + approvedChangelogArchiveHash + "\n"
+
+	approvedChangelogRewriteFrom        = "v4.03.2"
+	approvedChangelogRewriteTo          = "v4.03.3"
+	approvedChangelogRewriteBaseHash    = "f978c898c30b0d40a476c09c91fc4b6d13648bc4e9298fb117593cf6e9a4d53f"
+	approvedChangelogRewriteHistoryHash = "77189b49b1c78c745f6b8d351c9837e4d7bed1bc281daec0a87249a8e6d341fa"
 )
 
 type changelogResetPolicy struct {
@@ -59,6 +64,23 @@ var approvedChangelogReset = changelogResetPolicy{
 	To:            approvedChangelogResetTo,
 	BaseSHA256:    approvedChangelogArchiveHash,
 	ArchiveSuffix: approvedChangelogArchiveLine,
+}
+
+type changelogRewritePolicy struct {
+	From          string
+	To            string
+	BaseSHA256    string
+	HistorySHA256 string
+}
+
+// approvedChangelogRewrite is a single-use exception for the exact v4.03.2
+// post-publication history seal merged with v4.03.3. Binding both byte streams
+// prevents this exception from authorizing any other historical rewrite.
+var approvedChangelogRewrite = changelogRewritePolicy{
+	From:          approvedChangelogRewriteFrom,
+	To:            approvedChangelogRewriteTo,
+	BaseSHA256:    approvedChangelogRewriteBaseHash,
+	HistorySHA256: approvedChangelogRewriteHistoryHash,
 }
 
 type snapshot map[string][]byte
@@ -285,10 +307,19 @@ func changelogHistory(data []byte) ([]byte, error) {
 }
 
 func validateChangelogHistoryTransition(base, candidate []byte, previous, next Version) error {
-	return validateChangelogHistoryTransitionWithPolicy(base, candidate, previous, next, approvedChangelogReset)
+	return validateChangelogHistoryTransitionWithPolicies(base, candidate, previous, next, approvedChangelogReset, approvedChangelogRewrite)
 }
 
 func validateChangelogHistoryTransitionWithPolicy(base, candidate []byte, previous, next Version, policy changelogResetPolicy) error {
+	return validateChangelogHistoryTransitionWithPolicies(base, candidate, previous, next, policy, changelogRewritePolicy{})
+}
+
+func validateChangelogHistoryTransitionWithPolicies(
+	base, candidate []byte,
+	previous, next Version,
+	resetPolicy changelogResetPolicy,
+	rewritePolicy changelogRewritePolicy,
+) error {
 	history, err := changelogHistory(candidate)
 	if err != nil {
 		return err
@@ -296,14 +327,25 @@ func validateChangelogHistoryTransitionWithPolicy(base, candidate []byte, previo
 	if bytes.Equal(history, base) {
 		return nil
 	}
-	if previous.String() != policy.From || next.String() != policy.To {
+	if previous.String() == rewritePolicy.From && next.String() == rewritePolicy.To {
+		baseDigest := sha256.Sum256(base)
+		if hex.EncodeToString(baseDigest[:]) != rewritePolicy.BaseSHA256 {
+			return errors.New("approved changelog rewrite baseline digest does not match")
+		}
+		historyDigest := sha256.Sum256(history)
+		if hex.EncodeToString(historyDigest[:]) != rewritePolicy.HistorySHA256 {
+			return errors.New("approved changelog rewrite history digest does not match")
+		}
+		return nil
+	}
+	if previous.String() != resetPolicy.From || next.String() != resetPolicy.To {
 		return errors.New("candidate changelog must preserve the complete baseline changelog byte-for-byte after the new release separator")
 	}
 	digest := sha256.Sum256(base)
-	if hex.EncodeToString(digest[:]) != policy.BaseSHA256 {
+	if hex.EncodeToString(digest[:]) != resetPolicy.BaseSHA256 {
 		return errors.New("approved changelog reset baseline digest does not match")
 	}
-	if !bytes.Equal(history, []byte(policy.ArchiveSuffix)) {
+	if !bytes.Equal(history, []byte(resetPolicy.ArchiveSuffix)) {
 		return errors.New("approved changelog reset must contain only the exact archived-history digest line after the release separator")
 	}
 	return nil

--- a/scripts/versionctl/repository_test.go
+++ b/scripts/versionctl/repository_test.go
@@ -39,6 +39,61 @@ func TestChangelogHistoryResetIsSingleUseAndDigestBound(t *testing.T) {
 	}
 }
 
+func TestChangelogHistoryRewriteIsSingleUseAndDigestBound(t *testing.T) {
+	t.Parallel()
+	base := validChangelog("v4.03.2")
+	history := bytes.Replace(base, []byte("Validate the version contract"), []byte("Seal the published release status"), 1)
+	candidate := prependRelease("v4.03.3", history)
+	previous, _ := parseVersion("v4.03.2")
+	next, _ := parseVersion("v4.03.3")
+	policy := changelogRewritePolicy{
+		From:          previous.String(),
+		To:            next.String(),
+		BaseSHA256:    fmt.Sprintf("%x", sha256.Sum256(base)),
+		HistorySHA256: fmt.Sprintf("%x", sha256.Sum256(history)),
+	}
+	validate := func(base, candidate []byte, previous, next Version) error {
+		return validateChangelogHistoryTransitionWithPolicies(
+			base,
+			candidate,
+			previous,
+			next,
+			changelogResetPolicy{},
+			policy,
+		)
+	}
+	if err := validate(base, candidate, previous, next); err != nil {
+		t.Fatalf("approved rewrite rejected: %v", err)
+	}
+
+	wrongBase := append([]byte(nil), base...)
+	wrongBase[0] ^= 1
+	if err := validate(wrongBase, candidate, previous, next); err == nil {
+		t.Fatal("rewrite accepted a different baseline digest")
+	}
+
+	wrongHistory := bytes.Replace(base, []byte("Validate the version contract"), []byte("Apply a different historical rewrite"), 1)
+	wrongSuffix := prependRelease("v4.03.3", wrongHistory)
+	if err := validate(base, wrongSuffix, previous, next); err == nil {
+		t.Fatal("rewrite accepted a different historical suffix digest")
+	}
+
+	otherNext, _ := parseVersion("v4.03.4")
+	if err := validate(base, candidate, previous, otherNext); err == nil {
+		t.Fatal("rewrite policy was reusable for another transition")
+	}
+	otherPrevious, _ := parseVersion("v4.03.1")
+	if err := validate(base, candidate, otherPrevious, next); err == nil {
+		t.Fatal("rewrite policy was reusable from another baseline version")
+	}
+
+	mutatedCandidate := append([]byte(nil), candidate...)
+	mutatedCandidate[len(mutatedCandidate)-2] ^= 1
+	if err := validate(base, mutatedCandidate, previous, next); err == nil {
+		t.Fatal("rewrite accepted a one-byte historical mutation")
+	}
+}
+
 func fixtureSnapshot(version string) snapshot {
 	contents := make(snapshot, len(versionTargets))
 	for _, item := range versionTargets {


### PR DESCRIPTION
## Summary

- bind the one-time v4.03.2 to v4.03.3 changelog rewrite to exact baseline and history SHA-256 values
- add a fail-closed v4.03.3 release-manager recovery path for the exact PR118 squash and this four-file follow-up
- add positive and mutation-resistant regression coverage

## Validation

- release gate tests: 66/66
- versionctl Go tests and race tests
- Go vet and gosec
- exact Auto-Versioning replay
- git diff --check

This PR does not modify README.md, CHANGELOG.md, runtime code, or version targets.