### PR TITLE
Qualification : repair v4.03.3 lifecycle qualification

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -141,10 +141,130 @@ jobs:
               # changelog rewrite policy without changing release version
               # targets or changelog.
               v4033_parent_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+              if [[ "${v4033_parent_sha}" == "19e4add763e935a29219c20c86586b3557a441c9" ]]; then
+                # Authorize exactly one linear qualification repair after the
+                # reviewed PR119 seal. The exact parent makes this exception
+                # non-replayable after any later commit, while the immutable
+                # PR118 and PR117 ancestry replays the versioning transition.
+                v4033_repair_base_sha="$(git rev-parse HEAD^^)"
+                if [[ "${v4033_repair_base_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                  echo "ERROR: the reviewed PR119 squash is not based on the reviewed PR118 squash." >&2
+                  exit 1
+                fi
+                v4033_repair_release_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${v4033_repair_release_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                  echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                  exit 1
+                fi
+                v4033_repair_parent_subject="$(git log -1 --format=%s HEAD^)"
+                v4033_expected_repair_parent_subject='CI : bind one-time v4.03.3 changelog seal (#119)'
+                if [[ "${v4033_repair_parent_subject}" != "${v4033_expected_repair_parent_subject}" ]]; then
+                  echo "ERROR: the reviewed PR119 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_base_subject="$(git log -1 --format=%s HEAD^^)"
+                v4033_expected_repair_base_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+                if [[ "${v4033_repair_base_subject}" != "${v4033_expected_repair_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_release_base_subject="$(git log -1 --format=%s HEAD^^^)"
+                v4033_expected_repair_release_base_subject='CI : make release inventory comparison portable (#117)'
+                if [[ "${v4033_repair_release_base_subject}" != "${v4033_expected_repair_release_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR117 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_subject_pattern='^Qualification : repair v4.03.3 lifecycle qualification \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${v4033_repair_subject_pattern} ]]; then
+                  echo "ERROR: the v4.03.3 lifecycle repair requires the exact reviewed Qualification subject." >&2
+                  exit 1
+                fi
+                read -r -a v4033_repair_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a v4033_repair_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                read -r -a v4033_repair_base_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+                read -r -a v4033_repair_release_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^)"
+                if (( ${#v4033_repair_head_line[@]} != 2 ||
+                      ${#v4033_repair_parent_line[@]} != 2 ||
+                      ${#v4033_repair_base_line[@]} != 2 ||
+                      ${#v4033_repair_release_base_line[@]} != 2 )); then
+                  echo "ERROR: the v4.03.3 lifecycle repair and reviewed PR119/PR118/PR117 chain must be linear." >&2
+                  exit 1
+                fi
+                # BEGIN exact v4.03.3 lifecycle-repair diff contract
+                expected_v4033_repair_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M ".github/workflows/release-qualification.yml"
+                  M "scripts/ci/package_lifecycle_lab.py"
+                  M "scripts/ci/package_lifecycle_lab_test.py"
+                  M "scripts/ci/release_gate_test.py"
+                  M "scripts/ci/release_qualification_adapter_test.py"
+                  M "scripts/ci/release_qualification_workflow_test.py"
+                  M "src/core/syswarden-cli/cmd/install.go"
+                  M "src/core/syswarden-cli/cmd/reload.go"
+                  M "src/core/syswarden-cli/cmd/reload_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/removal_linux.go"
+                  M "src/core/syswarden-cli/pkg/integration/removal_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/siem_linux.go"
+                  M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                )
+                mapfile -d '' -t actual_v4033_repair_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_v4033_repair_diff[@]} != ${#expected_v4033_repair_diff[@]} )); then
+                  echo "ERROR: the v4.03.3 lifecycle repair must modify exactly the sixteen reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_v4033_repair_diff[@]}; index++)); do
+                  if [[ "${actual_v4033_repair_diff[index]}" != "${expected_v4033_repair_diff[index]}" ]]; then
+                    echo "ERROR: the v4.03.3 lifecycle repair contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                v4033_repair_paths=(
+                  ".github/workflows/release-manager.yml"
+                  ".github/workflows/release-qualification.yml"
+                  "scripts/ci/package_lifecycle_lab.py"
+                  "scripts/ci/package_lifecycle_lab_test.py"
+                  "scripts/ci/release_gate_test.py"
+                  "scripts/ci/release_qualification_adapter_test.py"
+                  "scripts/ci/release_qualification_workflow_test.py"
+                  "src/core/syswarden-cli/cmd/install.go"
+                  "src/core/syswarden-cli/cmd/reload.go"
+                  "src/core/syswarden-cli/cmd/reload_test.go"
+                  "src/core/syswarden-cli/pkg/integration/removal_linux.go"
+                  "src/core/syswarden-cli/pkg/integration/removal_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/siem_linux.go"
+                  "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${v4033_repair_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed v4.03.3 lifecycle-repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact v4.03.3 lifecycle-repair diff contract
+                v4033_repair_versioning_message="$(git log -1 --format=%B HEAD^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${v4033_repair_release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${v4033_repair_versioning_message}"
+              elif [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
                 echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
                 exit 1
-              fi
+              else
               v4033_base_sha="$(git rev-parse HEAD^^)"
               if [[ "${v4033_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
                 echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
@@ -223,6 +343,7 @@ jobs:
                 --base-ref "${v4033_base_sha}" \
                 --tag-phase \
                 --commit-message "${v4033_parent_message}"
+              fi
             elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind
@@ -793,10 +914,130 @@ jobs:
               # changelog rewrite policy without changing release version
               # targets or changelog.
               v4033_parent_sha="$(git rev-parse HEAD^)"
-              if [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+              if [[ "${v4033_parent_sha}" == "19e4add763e935a29219c20c86586b3557a441c9" ]]; then
+                # Authorize exactly one linear qualification repair after the
+                # reviewed PR119 seal. The exact parent makes this exception
+                # non-replayable after any later commit, while the immutable
+                # PR118 and PR117 ancestry replays the versioning transition.
+                v4033_repair_base_sha="$(git rev-parse HEAD^^)"
+                if [[ "${v4033_repair_base_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                  echo "ERROR: the reviewed PR119 squash is not based on the reviewed PR118 squash." >&2
+                  exit 1
+                fi
+                v4033_repair_release_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${v4033_repair_release_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                  echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                  exit 1
+                fi
+                v4033_repair_parent_subject="$(git log -1 --format=%s HEAD^)"
+                v4033_expected_repair_parent_subject='CI : bind one-time v4.03.3 changelog seal (#119)'
+                if [[ "${v4033_repair_parent_subject}" != "${v4033_expected_repair_parent_subject}" ]]; then
+                  echo "ERROR: the reviewed PR119 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_base_subject="$(git log -1 --format=%s HEAD^^)"
+                v4033_expected_repair_base_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+                if [[ "${v4033_repair_base_subject}" != "${v4033_expected_repair_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_release_base_subject="$(git log -1 --format=%s HEAD^^^)"
+                v4033_expected_repair_release_base_subject='CI : make release inventory comparison portable (#117)'
+                if [[ "${v4033_repair_release_base_subject}" != "${v4033_expected_repair_release_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR117 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_repair_subject_pattern='^Qualification : repair v4.03.3 lifecycle qualification \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${v4033_repair_subject_pattern} ]]; then
+                  echo "ERROR: the v4.03.3 lifecycle repair requires the exact reviewed Qualification subject." >&2
+                  exit 1
+                fi
+                read -r -a v4033_repair_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a v4033_repair_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                read -r -a v4033_repair_base_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+                read -r -a v4033_repair_release_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^)"
+                if (( ${#v4033_repair_head_line[@]} != 2 ||
+                      ${#v4033_repair_parent_line[@]} != 2 ||
+                      ${#v4033_repair_base_line[@]} != 2 ||
+                      ${#v4033_repair_release_base_line[@]} != 2 )); then
+                  echo "ERROR: the v4.03.3 lifecycle repair and reviewed PR119/PR118/PR117 chain must be linear." >&2
+                  exit 1
+                fi
+                # BEGIN exact v4.03.3 lifecycle-repair diff contract
+                expected_v4033_repair_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M ".github/workflows/release-qualification.yml"
+                  M "scripts/ci/package_lifecycle_lab.py"
+                  M "scripts/ci/package_lifecycle_lab_test.py"
+                  M "scripts/ci/release_gate_test.py"
+                  M "scripts/ci/release_qualification_adapter_test.py"
+                  M "scripts/ci/release_qualification_workflow_test.py"
+                  M "src/core/syswarden-cli/cmd/install.go"
+                  M "src/core/syswarden-cli/cmd/reload.go"
+                  M "src/core/syswarden-cli/cmd/reload_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/removal_linux.go"
+                  M "src/core/syswarden-cli/pkg/integration/removal_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go"
+                  M "src/core/syswarden-cli/pkg/integration/siem_linux.go"
+                  M "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                )
+                mapfile -d '' -t actual_v4033_repair_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_v4033_repair_diff[@]} != ${#expected_v4033_repair_diff[@]} )); then
+                  echo "ERROR: the v4.03.3 lifecycle repair must modify exactly the sixteen reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_v4033_repair_diff[@]}; index++)); do
+                  if [[ "${actual_v4033_repair_diff[index]}" != "${expected_v4033_repair_diff[index]}" ]]; then
+                    echo "ERROR: the v4.03.3 lifecycle repair contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                v4033_repair_paths=(
+                  ".github/workflows/release-manager.yml"
+                  ".github/workflows/release-qualification.yml"
+                  "scripts/ci/package_lifecycle_lab.py"
+                  "scripts/ci/package_lifecycle_lab_test.py"
+                  "scripts/ci/release_gate_test.py"
+                  "scripts/ci/release_qualification_adapter_test.py"
+                  "scripts/ci/release_qualification_workflow_test.py"
+                  "src/core/syswarden-cli/cmd/install.go"
+                  "src/core/syswarden-cli/cmd/reload.go"
+                  "src/core/syswarden-cli/cmd/reload_test.go"
+                  "src/core/syswarden-cli/pkg/integration/removal_linux.go"
+                  "src/core/syswarden-cli/pkg/integration/removal_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go"
+                  "src/core/syswarden-cli/pkg/integration/siem_linux.go"
+                  "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${v4033_repair_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed v4.03.3 lifecycle-repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact v4.03.3 lifecycle-repair diff contract
+                v4033_repair_versioning_message="$(git log -1 --format=%B HEAD^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${v4033_repair_release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${v4033_repair_versioning_message}"
+              elif [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
                 echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
                 exit 1
-              fi
+              else
               v4033_base_sha="$(git rev-parse HEAD^^)"
               if [[ "${v4033_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
                 echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
@@ -875,6 +1116,7 @@ jobs:
                 --base-ref "${v4033_base_sha}" \
                 --tag-phase \
                 --commit-message "${v4033_parent_message}"
+              fi
             elif [[ "${RELEASE_TAG}" == "v4.03.2" ]]; then
               # The protected qualification, package byte comparison, signed
               # update manifest, tag resolution and origin/main ancestry bind

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -283,6 +283,7 @@ jobs:
           aggregate_dir="${artifact_root}/aggregate"
           status_dir="${qualification_root}/status-internal"
           nftables_tmp_dir="${qualification_root}/nftables-tmp"
+          package_tmp_dir="${qualification_root}/package-tmp"
           transition_dir="${qualification_root}/historical-transition"
           install -d -m 0700 \
             "${artifact_root}" \
@@ -294,6 +295,7 @@ jobs:
             "${artifact_root}/status" \
             "${status_dir}" \
             "${nftables_tmp_dir}" \
+            "${package_tmp_dir}" \
             "${transition_dir}"
           test -d "${nftables_tmp_dir}"
           test ! -L "${nftables_tmp_dir}"
@@ -305,6 +307,16 @@ jobs:
           test ! -L "${nftables_tmp_probe}"
           rm -f -- "${nftables_tmp_probe}"
           test ! -e "${nftables_tmp_probe}"
+          test -d "${package_tmp_dir}"
+          test ! -L "${package_tmp_dir}"
+          [[ -O "${package_tmp_dir}" ]]
+          test "$(stat -c '%a' "${package_tmp_dir}")" = "700"
+          package_tmp_probe="$(mktemp \
+            "${package_tmp_dir}/.write-probe.XXXXXX")"
+          test -f "${package_tmp_probe}"
+          test ! -L "${package_tmp_probe}"
+          rm -f -- "${package_tmp_probe}"
+          test ! -e "${package_tmp_probe}"
 
           {
             printf 'QUALIFICATION_ROOT=%s\n' "${qualification_root}"
@@ -316,6 +328,7 @@ jobs:
             printf 'AGGREGATE_DIR=%s\n' "${aggregate_dir}"
             printf 'STATUS_DIR=%s\n' "${status_dir}"
             printf 'NFTABLES_TMP_DIR=%s\n' "${nftables_tmp_dir}"
+            printf 'PACKAGE_TMP_DIR=%s\n' "${package_tmp_dir}"
             printf 'TRANSITION_DIR=%s\n' "${transition_dir}"
           } >> "${GITHUB_ENV}"
           {
@@ -573,6 +586,23 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+          umask 077
+          test -n "${PACKAGE_TMP_DIR:-}"
+          test "${PACKAGE_TMP_DIR}" = "${QUALIFICATION_ROOT}/package-tmp"
+          test -d "${QUALIFICATION_ROOT}"
+          test ! -L "${QUALIFICATION_ROOT}"
+          [[ -O "${QUALIFICATION_ROOT}" ]]
+          test "$(stat -c '%a' "${QUALIFICATION_ROOT}")" = "700"
+          test -d "${PACKAGE_TMP_DIR}"
+          test ! -L "${PACKAGE_TMP_DIR}"
+          [[ -O "${PACKAGE_TMP_DIR}" ]]
+          test "$(stat -c '%a' "${PACKAGE_TMP_DIR}")" = "700"
+          package_tmp_probe="$(mktemp \
+            "${PACKAGE_TMP_DIR}/.write-probe.XXXXXX")"
+          test -f "${package_tmp_probe}"
+          test ! -L "${package_tmp_probe}"
+          rm -f -- "${package_tmp_probe}"
+          test ! -e "${package_tmp_probe}"
           common_binding_arguments=(
             --qualification-repository "${GITHUB_REPOSITORY}"
             --qualification-release-sha "${RELEASE_SHA}"
@@ -586,15 +616,24 @@ jobs:
             --qualification-previous-release-id "${PREVIOUS_RELEASE_ID}"
           )
           set +e
+          TMPDIR="${PACKAGE_TMP_DIR}" \
+          TMP="${PACKAGE_TMP_DIR}" \
+          TEMP="${PACKAGE_TMP_DIR}" \
+          GOTMPDIR="${PACKAGE_TMP_DIR}" \
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
             --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
+            --package-tmp-dir "${PACKAGE_TMP_DIR}" \
             --architecture-shard amd64 \
             "${common_binding_arguments[@]}" \
             --pull-policy never \
             --output "${RAW_DIR}/package-lifecycle-amd64.json" \
             --pretty
           amd64_rc=$?
+          TMPDIR="${PACKAGE_TMP_DIR}" \
+          TMP="${PACKAGE_TMP_DIR}" \
+          TEMP="${PACKAGE_TMP_DIR}" \
+          GOTMPDIR="${PACKAGE_TMP_DIR}" \
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
             --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
@@ -872,6 +911,26 @@ jobs:
             rmdir -- "${NFTABLES_TMP_DIR}"
             test ! -e "${NFTABLES_TMP_DIR}"
             test ! -L "${NFTABLES_TMP_DIR}"
+          fi
+          if [[ -n "${PACKAGE_TMP_DIR:-}" ]]; then
+            if [[ -z "${QUALIFICATION_ROOT:-}" || \
+                  "${QUALIFICATION_ROOT}" != "${RUNNER_TEMP%/}"/syswarden-release-qualification.* || \
+                  "${PACKAGE_TMP_DIR}" != "${QUALIFICATION_ROOT}/package-tmp" ]]; then
+              echo "ERROR: refusing unsafe package temporary-directory cleanup." >&2
+              exit 1
+            fi
+            test -d "${QUALIFICATION_ROOT}"
+            test ! -L "${QUALIFICATION_ROOT}"
+            [[ -O "${QUALIFICATION_ROOT}" ]]
+            test "$(stat -c '%a' "${QUALIFICATION_ROOT}")" = "700"
+            test -d "${PACKAGE_TMP_DIR}"
+            test ! -L "${PACKAGE_TMP_DIR}"
+            [[ -O "${PACKAGE_TMP_DIR}" ]]
+            test "$(stat -c '%a' "${PACKAGE_TMP_DIR}")" = "700"
+            find -P "${PACKAGE_TMP_DIR}" -xdev -mindepth 1 -delete
+            rmdir -- "${PACKAGE_TMP_DIR}"
+            test ! -e "${PACKAGE_TMP_DIR}"
+            test ! -L "${PACKAGE_TMP_DIR}"
           fi
           if [[ -n "${TRANSITION_DIR:-}" ]]; then
             if [[ -z "${QUALIFICATION_ROOT:-}" || \

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -144,6 +144,24 @@ RPM_BOOTSTRAP = (
     "policycoreutils-python-utils dnf-automatic procps-ng e2fsprogs socat binutils "
     "cpio diffutils file util-linux && dnf clean all"
 )
+RPM_COMMON_IMAGE_DEPENDENCY_GUARD = (
+    "RUN ! rpm -q qrencode >/dev/null 2>&1 && "
+    "! rpm -q epel-release >/dev/null 2>&1\n"
+)
+HISTORICAL_RPM_TRANSITION_VERSION = "4.03.2"
+HISTORICAL_RPM_TRANSITION_BOOTSTRAPS = {
+    "fedora": (
+        "dnf -y install qrencode && "
+        "rpm -q qrencode >/dev/null && "
+        "! rpm -q epel-release >/dev/null 2>&1 && dnf clean all"
+    ),
+    "almalinux": (
+        "dnf -y install epel-release && "
+        "dnf -y install qrencode && "
+        "rpm -q epel-release >/dev/null && "
+        "rpm -q qrencode >/dev/null && dnf clean all"
+    ),
+}
 APK_BOOTSTRAP = (
     "apk add --no-cache openrc openrc-init && "
     "apk add --no-cache iproute2 nftables cronie cronie-openrc curl wget rsyslog rsyslog-uxsock "
@@ -743,9 +761,14 @@ def expected_event_checks(family: str, scenario: str) -> tuple[str, ...]:
 
     checks = list(_preparation_event_checks(scenario))
 
-    def installed(command: str, label: str) -> None:
+    def installed(
+        command: str,
+        label: str,
+        before_phase_checks: tuple[str, ...] = (),
+    ) -> None:
         checks.append(f"{scenario}.{command}")
         checks.append(f"{scenario}.{command}.maintainer_script")
+        checks.extend(before_phase_checks)
         checks.extend(_installed_phase_event_checks(scenario, label))
         checks.extend(_state_event_checks(scenario, label))
 
@@ -782,7 +805,12 @@ def expected_event_checks(family: str, scenario: str) -> tuple[str, ...]:
         )
 
     if scenario == "upgrade-rollback":
-        installed("install.previous", "previous")
+        checks.append(f"{scenario}.preinstall.networkless_config")
+        installed(
+            "install.previous",
+            "previous",
+            (f"{scenario}.previous.networkless_config_preserved",),
+        )
         installed("upgrade.candidate", "candidate")
         installed("reinstall.candidate", "reinstall")
         checks.extend(_installed_phase_event_checks(scenario, "restart-one"))
@@ -1118,6 +1146,26 @@ def require_real_directory(path: Path, label: str) -> Path:
     return absolute
 
 
+def require_private_directory(path: Path, label: str) -> Path:
+    absolute = require_real_directory(path, label)
+    try:
+        resolved = absolute.resolve(strict=True)
+        metadata = absolute.lstat()
+    except OSError as exc:
+        raise LifecycleLabError(f"cannot resolve {label} {absolute}: {exc}") from exc
+    if resolved != absolute:
+        raise LifecycleLabError(
+            f"{label} must not contain symlinked path components: {absolute}"
+        )
+    if metadata.st_uid != os.geteuid():
+        raise LifecycleLabError(
+            f"{label} must be owned by effective uid {os.geteuid()}: {absolute}"
+        )
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise LifecycleLabError(f"{label} must have mode 0700: {absolute}")
+    return absolute
+
+
 def read_checksum(checksum_file: Path, package_name: str) -> str:
     try:
         metadata = checksum_file.lstat()
@@ -1414,6 +1462,21 @@ def validate_inputs(
     return candidate_root, previous_root, pairs
 
 
+def historical_transition_bootstrap(
+    spec: PlatformSpec, previous_version: str
+) -> str:
+    parse_syswarden_version(previous_version)
+    if spec.family != "rpm" or previous_version != HISTORICAL_RPM_TRANSITION_VERSION:
+        return ""
+    command = HISTORICAL_RPM_TRANSITION_BOOTSTRAPS.get(spec.distribution)
+    if command is None:
+        raise LifecycleLabError(
+            "unsupported RPM distribution for the exact v4.03.2 transition "
+            f"bootstrap: {spec.distribution!r}"
+        )
+    return f"RUN {command}\n"
+
+
 def build_containerfile(spec: PlatformSpec) -> str:
     validate_image_reference(spec.image)
     helper_encoded = base64.b64encode(LAB_NETWORK_HELPER.encode("utf-8")).decode(
@@ -1532,8 +1595,27 @@ def build_containerfile(spec: PlatformSpec) -> str:
         f"FROM {spec.image}\n"
         "ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 container=podman\n"
         f"RUN {spec.bootstrap_command}\n"
+        + (RPM_COMMON_IMAGE_DEPENDENCY_GUARD if spec.family == "rpm" else "")
         + init_contract
     )
+
+
+def build_historical_transition_containerfile(
+    spec: PlatformSpec,
+    previous_version: str,
+    common_image: str,
+) -> str | None:
+    if re.fullmatch(
+        r"localhost/syswarden-lifecycle-[a-z0-9-]+-[0-9a-f]{32}",
+        common_image,
+    ) is None:
+        raise LifecycleLabError(
+            f"unsafe common lifecycle image reference: {common_image!r}"
+        )
+    transition_bootstrap = historical_transition_bootstrap(spec, previous_version)
+    if not transition_bootstrap:
+        return None
+    return f"FROM {common_image}\n{transition_bootstrap}"
 
 
 LIFECYCLE_SCRIPT = r'''#!/bin/sh
@@ -2298,6 +2380,45 @@ legacy_webtui_runtime_absent() {
     done
 }
 
+v4032_to_v4033_upgrade_selected() {
+    v4032_to_v4033_transition_selected && \
+        [ "$(installed_version 2>/dev/null || true)" = 4.03.2 ]
+}
+
+attest_v4032_previous_webtui_retirement() {
+    previous_webtui_root="${1:-/}"
+    previous_webtui_root="${previous_webtui_root%/}"
+    previous_webtui_proc_root="${2:-${previous_webtui_root}/proc}"
+    previous_webtui_executable="${previous_webtui_root}/opt/syswarden/bin/syswarden-cli"
+
+    v4032_to_v4033_upgrade_selected || return 1
+    legacy_webtui_runtime_absent "${previous_webtui_root}" || return 1
+    syswarden_verify_no_exact_webtui_process \
+        "${previous_webtui_root}" "${previous_webtui_proc_root}" \
+        "${previous_webtui_executable}" || return 1
+    previous_webtui_ss_stderr="$(
+        mktemp /tmp/syswarden-previous-webtui-ss.XXXXXX
+    )" || return 1
+    for previous_webtui_port in 62027 62028; do
+        : > "${previous_webtui_ss_stderr}" || {
+            rm -f "${previous_webtui_ss_stderr}"
+            return 1
+        }
+        previous_webtui_ss_output="$(
+            ss -H -ltn "sport = :${previous_webtui_port}" \
+                2>"${previous_webtui_ss_stderr}"
+        )"
+        previous_webtui_ss_status=$?
+        if [ "${previous_webtui_ss_status}" -ne 0 ] || \
+           [ -s "${previous_webtui_ss_stderr}" ] || \
+           [ -n "${previous_webtui_ss_output}" ]; then
+            rm -f "${previous_webtui_ss_stderr}"
+            return 1
+        fi
+    done
+    rm -f "${previous_webtui_ss_stderr}" || return 1
+}
+
 alpine_apk_owner_version() {
     syswarden_owner_path="$1"
     syswarden_owner_package="$2"
@@ -2630,13 +2751,31 @@ prepare_package_transition() {
     esac
 }
 
+v4028_to_v4032_transition_selected() {
+    [ "${SCENARIO}" = upgrade-rollback ] && \
+        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.02.8 ] && \
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.2 ]
+}
+
+v4032_to_v4033_transition_selected() {
+    [ "${SCENARIO}" = upgrade-rollback ] && \
+        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.2 ] && \
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.3 ]
+}
+
 expected_systemd_enablement_prefix() {
     label="$1"
     case "${SCENARIO}:${label}" in
         upgrade-rollback:previous|upgrade-rollback:candidate|upgrade-rollback:reinstall|\
         upgrade-rollback:restart-one|upgrade-rollback:restart-two|upgrade-rollback:rollback|\
         upgrade-rollback:recovery)
-            printf '%s\n' /etc/systemd/system
+            if v4028_to_v4032_transition_selected; then
+                printf '%s\n' /etc/systemd/system
+            elif v4032_to_v4033_transition_selected; then
+                printf '%s\n' ..
+            else
+                return 1
+            fi
             ;;
         remove:fresh|remove:reinstall-after-remove|purge:fresh)
             printf '%s\n' ..
@@ -3029,17 +3168,22 @@ probe_postinstall_contract() {
         fi
         probe_seeded_operator_listener_preservation "${label}" || mark_postinstall_failure operator-listener
     elif [ "${actual_version}" = "${EXPECTED_PREVIOUS_VERSION}" ]; then
-        case "${PACKAGE_FAMILY}" in
-            deb|rpm)
-                [ -f /etc/systemd/system/syswarden-webtui.service ] && \
-                    grep -Fq '/opt/syswarden/bin/syswarden-cli web-tui' \
-                        /etc/systemd/system/syswarden-webtui.service || mark_postinstall_failure previous-webtui
-                ;;
-            apk)
-                [ -f /etc/init.d/syswarden-webtui ] && \
-                    grep -Fq 'command_args="web-tui"' /etc/init.d/syswarden-webtui || mark_postinstall_failure previous-webtui
-                ;;
-        esac
+        if v4032_to_v4033_upgrade_selected; then
+            attest_v4032_previous_webtui_retirement || \
+                mark_postinstall_failure previous-webtui-retirement
+        else
+            case "${PACKAGE_FAMILY}" in
+                deb|rpm)
+                    [ -f /etc/systemd/system/syswarden-webtui.service ] && \
+                        grep -Fq '/opt/syswarden/bin/syswarden-cli web-tui' \
+                            /etc/systemd/system/syswarden-webtui.service || mark_postinstall_failure previous-webtui
+                    ;;
+                apk)
+                    [ -f /etc/init.d/syswarden-webtui ] && \
+                        grep -Fq 'command_args="web-tui"' /etc/init.d/syswarden-webtui || mark_postinstall_failure previous-webtui
+                    ;;
+            esac
+        fi
     else
         mark_postinstall_failure installed-version
     fi
@@ -3145,6 +3289,108 @@ probe_payload() {
         record fail "${PREFIX}.${label}.elf_contract" "payload binaries violate the exact package-family ELF contract"
     fi
     probe_postinstall_contract "${label}"
+}
+
+write_preinstall_networkless_config() {
+    preinstall_networkless_config="$1"
+    printf '%s\n' \
+        '# Lifecycle-only network-isolation override; production defaults remain list_choice = "1".' \
+        '[network.blocklists]' \
+        'list_choice = "4"' \
+        'custom_url = ""' \
+        'custom_url_ipv6 = ""' \
+        'custom_hash = ""' \
+        'custom_hash_ipv6 = ""' \
+        'use_spamhaus = false' \
+        '' > "${preinstall_networkless_config}"
+}
+
+seed_and_attest_preinstall_networkless_config() {
+    preinstall_networkless_path=/etc/syswarden/config/modules/99-user.toml
+    for preinstall_networkless_directory in \
+        /etc/syswarden \
+        /etc/syswarden/config \
+        /etc/syswarden/config/modules; do
+        if [ -e "${preinstall_networkless_directory}" ] || \
+           [ -L "${preinstall_networkless_directory}" ]; then
+            if [ ! -d "${preinstall_networkless_directory}" ] || \
+               [ -L "${preinstall_networkless_directory}" ] || \
+               [ "$(stat -c '%u:%g' \
+                   "${preinstall_networkless_directory}" 2>/dev/null || true)" != 0:0 ]; then
+                record fail "${PREFIX}.preinstall.networkless_config" \
+                    "refusing a non-directory, symlinked, or non-root-owned configuration ancestor"
+                return 1
+            fi
+        fi
+    done
+    if [ -e "${preinstall_networkless_path}" ] || \
+       [ -L "${preinstall_networkless_path}" ]; then
+        record fail "${PREFIX}.preinstall.networkless_config" \
+            "refusing to replace a pre-existing networkless configuration path"
+        return 1
+    fi
+    mkdir -p /etc/syswarden/config/modules || return 1
+    for preinstall_networkless_directory in \
+        /etc/syswarden \
+        /etc/syswarden/config \
+        /etc/syswarden/config/modules; do
+        if [ ! -d "${preinstall_networkless_directory}" ] || \
+           [ -L "${preinstall_networkless_directory}" ] || \
+           [ "$(stat -c '%u:%g' \
+               "${preinstall_networkless_directory}" 2>/dev/null || true)" != 0:0 ]; then
+            record fail "${PREFIX}.preinstall.networkless_config" \
+                "configuration ancestors failed their real root-owned directory attestation"
+            return 1
+        fi
+    done
+    if [ -e "${preinstall_networkless_path}" ] || \
+       [ -L "${preinstall_networkless_path}" ]; then
+        record fail "${PREFIX}.preinstall.networkless_config" \
+            "networkless configuration path appeared before publication"
+        return 1
+    fi
+    write_preinstall_networkless_config "${preinstall_networkless_path}" || return 1
+    chmod 0640 "${preinstall_networkless_path}" || return 1
+    preinstall_networkless_identity="$(
+        stat -c '%u:%g:%a:%h' "${preinstall_networkless_path}" 2>/dev/null || true
+    )"
+    preinstall_networkless_hash="$(
+        hash_file "${preinstall_networkless_path}" 2>/dev/null || true
+    )"
+    if [ -f "${preinstall_networkless_path}" ] && \
+       [ ! -L "${preinstall_networkless_path}" ] && \
+       [ "${preinstall_networkless_identity}" = 0:0:640:1 ] && \
+       [ "${preinstall_networkless_hash}" = \
+         e0a6d764d1786c3661c6f25fa7b688bd8c8922d8fd0a00135925ae982f274d68 ]; then
+        record pass "${PREFIX}.preinstall.networkless_config" \
+            "exact option-4 networkless configuration is installed before the previous package"
+        return 0
+    fi
+    record fail "${PREFIX}.preinstall.networkless_config" \
+        "option-4 networkless configuration failed its exact pre-install attestation"
+    return 1
+}
+
+attest_preinstall_networkless_config_after_previous() {
+    preinstall_networkless_path=/etc/syswarden/config/modules/99-user.toml
+    preinstall_networkless_identity="$(
+        stat -c '%u:%g:%a:%h' "${preinstall_networkless_path}" 2>/dev/null || true
+    )"
+    preinstall_networkless_hash="$(
+        hash_file "${preinstall_networkless_path}" 2>/dev/null || true
+    )"
+    if [ -f "${preinstall_networkless_path}" ] && \
+       [ ! -L "${preinstall_networkless_path}" ] && \
+       [ "${preinstall_networkless_identity}" = 0:0:640:1 ] && \
+       [ "${preinstall_networkless_hash}" = \
+         e0a6d764d1786c3661c6f25fa7b688bd8c8922d8fd0a00135925ae982f274d68 ]; then
+        record pass "${PREFIX}.previous.networkless_config_preserved" \
+            "the previous package preserved the exact option-4 networkless configuration"
+        return 0
+    fi
+    record fail "${PREFIX}.previous.networkless_config_preserved" \
+        "the previous package changed the exact option-4 networkless configuration"
+    return 1
 }
 
 write_seeded_operator_token() {
@@ -3286,6 +3532,10 @@ write_exclusive_root_pidfile() {
 
 quiesce_previous_webtui_runtime() {
     prepare_service_runtime_fixture || return 1
+    if v4032_to_v4033_upgrade_selected; then
+        attest_v4032_previous_webtui_retirement || return 1
+        return 0
+    fi
     case "${PACKAGE_FAMILY}" in
         deb|rpm)
             previous_webtui_unit=/etc/systemd/system/syswarden-webtui.service
@@ -3641,6 +3891,9 @@ seed_live_legacy_webtui_process() {
         deb|rpm) ;;
         *) return 0 ;;
     esac
+    if v4032_to_v4033_upgrade_selected; then
+        return 0
+    fi
     /opt/syswarden/bin/syswarden-cli web-tui \
         --bind=127.0.0.1:62028 --token=lot0-lifecycle-live-retired-token \
         >/tmp/syswarden-legacy-webtui-process.log 2>&1 &
@@ -3983,12 +4236,49 @@ assert_historical_rollback_token() {
     rm -f "${sanitized}" "${secret_file}"
 }
 
+expected_upgrade_rollback_token_contract() {
+    label="$1"
+    [ "${SCENARIO}:${label}" = upgrade-rollback:rollback ] || return 1
+    case "${PACKAGE_FAMILY}" in
+        deb|rpm) ;;
+        *) return 1 ;;
+    esac
+    if v4028_to_v4032_transition_selected; then
+        printf '%s\n' historical-webtui-credential
+    elif v4032_to_v4033_transition_selected; then
+        printf '%s\n' byte-exact
+    else
+        return 1
+    fi
+}
+
+record_unsupported_rollback_token_contract() {
+    label="$1"
+    check_equal "${label}.state.token.type" regular unsupported-transition
+    check_equal "${label}.state.token.hash" "${STATE_TOKEN_HASH}" unsupported-transition
+    check_equal "${label}.state.token.mode" 640 unsupported-transition
+    check_equal "${label}.state.token.owner" 0:0 unsupported-transition
+}
+
 assert_all_state_preserved() {
     label="$1"
     assert_preserved "${label}" config /etc/syswarden/config/lifecycle-operator.conf "${STATE_CONFIG_HASH}" 640
     if [ "${SCENARIO}:${label}:${PACKAGE_FAMILY}" = upgrade-rollback:rollback:deb ] || \
        [ "${SCENARIO}:${label}:${PACKAGE_FAMILY}" = upgrade-rollback:rollback:rpm ]; then
-        assert_historical_rollback_token "${label}"
+        rollback_token_contract="$(
+            expected_upgrade_rollback_token_contract "${label}" 2>/dev/null || true
+        )"
+        case "${rollback_token_contract}" in
+            historical-webtui-credential)
+                assert_historical_rollback_token "${label}"
+                ;;
+            byte-exact)
+                assert_preserved "${label}" token /etc/syswarden/config/modules/99-user.toml "${STATE_TOKEN_HASH}" 640
+                ;;
+            *)
+                record_unsupported_rollback_token_contract "${label}"
+                ;;
+        esac
     else
         assert_preserved "${label}" token /etc/syswarden/config/modules/99-user.toml "${STATE_TOKEN_HASH}" 640
     fi
@@ -4136,6 +4426,21 @@ rsyslog_reactivation_mode() {
     return 1
 }
 
+attest_owned_cron_seed_state() {
+    syswarden_owned_cron_path="$1"
+    syswarden_owned_cron_evidence_label="$2"
+    case "${PACKAGE_FAMILY}:${SCENARIO}:${syswarden_owned_cron_evidence_label}" in
+        deb:remove:remove-before-purge)
+            [ ! -e "${syswarden_owned_cron_path}" ] && \
+                [ ! -L "${syswarden_owned_cron_path}" ] || return 1
+            ;;
+        *)
+            [ -f "${syswarden_owned_cron_path}" ] && \
+                [ ! -L "${syswarden_owned_cron_path}" ] || return 1
+            ;;
+    esac
+}
+
 seed_generated_runtime_artifacts() {
     rsyslog_contract="${1:-ambiguous-rsyslog}"
     evidence_label="${2:-}"
@@ -4151,15 +4456,35 @@ seed_generated_runtime_artifacts() {
                 [ -f "${path}" ] && [ ! -L "${path}" ] || return 1
                 [ "$(stat -c '%u:%g:%a:%h' "${path}" 2>/dev/null || true)" = 0:0:600:1 ] || return 1
             done
-            grep -F -x -q '*.* @127.0.0.1:5514' \
-                /etc/rsyslog.d/99-syswarden-siem.conf || return 1
-            for fragment in \
+            [ "$(grep -F -x -c '*.* @127.0.0.1:5514' \
+                /etc/rsyslog.d/99-syswarden-siem.conf || true)" = 1 ] || return 1
+            for forbidden_fragment in \
+                'imfile' \
+                '/var/log/syswarden/waf.json' \
+                'syswarden-waf-json' \
+                'Facility="local7"'; do
+                ! grep -F -q "${forbidden_fragment}" \
+                    /etc/rsyslog.d/99-syswarden-siem.conf || return 1
+            done
+            [ "$(grep -F -x -c 'module(load="imfile")' \
+                /etc/rsyslog.d/99-syswarden-waf-bridge.conf || true)" = 1 ] || return 1
+            [ "$(grep -F -x -c 'input(type="imfile"' \
+                /etc/rsyslog.d/99-syswarden-waf-bridge.conf || true)" = 1 ] || return 1
+            waf_telemetry_input_block="$(
+                sed -n \
+                    '/^input(type="imfile"$/,/^[[:space:]]*Facility="local7")[[:space:]]*$/p' \
+                    /etc/rsyslog.d/99-syswarden-waf-bridge.conf
+            )" || return 1
+            [ -n "${waf_telemetry_input_block}" ] || return 1
+            for telemetry_fragment in \
                 'File="/var/log/syswarden/waf.json"' \
                 'Tag="syswarden-waf-json"' \
                 'Facility="local7"'; do
-                grep -F -q "${fragment}" \
-                    /etc/rsyslog.d/99-syswarden-siem.conf || return 1
+                [ "$(printf '%s\n' "${waf_telemetry_input_block}" | \
+                    grep -F -c "${telemetry_fragment}" || true)" = 1 ] || return 1
             done
+            ! printf '%s\n' "${waf_telemetry_input_block}" | \
+                grep -F -q 'ruleset="waf_bridge"' || return 1
             for fragment in \
                 'module(load="omuxsock")' \
                 '$OMUxSockSocket /var/run/syswarden.sock' \
@@ -4282,7 +4607,8 @@ seed_generated_runtime_artifacts() {
     fi
     LC_ALL=C crontab -l > /tmp/syswarden-root-cron-confirmed 2>/tmp/syswarden-root-cron-confirmed.error || return 1
     cmp -s /tmp/syswarden-root-cron-before /tmp/syswarden-root-cron-confirmed || return 1
-    [ -f /etc/cron.d/syswarden ] && [ ! -L /etc/cron.d/syswarden ] || return 1
+    attest_owned_cron_seed_state \
+        /etc/cron.d/syswarden "${evidence_label}" || return 1
     printf '%s' '# Managed by' > /etc/cron.d/.syswarden.pending-v1 || return 1
     chmod 0600 /etc/cron.d/.syswarden.pending-v1 || return 1
 }
@@ -4460,10 +4786,12 @@ probe_execution_architecture() {
 
 scenario_upgrade_rollback_initial() {
     prepare_expected_payloads || return
+    seed_and_attest_preinstall_networkless_config || return
     prepare_package_transition || return
     prepare_alma_v4028_rpm_rsyslog_fixture \
         /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     run_install_step install.previous "${PREVIOUS_PACKAGE}" || return
+    attest_preinstall_networkless_config_after_previous || return
     attest_alma_v4028_rpm_rsyslog_after_previous \
         /proc /etc/systemd/system 0:0 /usr/sbin/rsyslogd || return
     if [ "${FORWARD_ONLY_APK_TRANSITION}" = "1" ]; then
@@ -7437,11 +7765,33 @@ def run_platform(
         "scenarios": [],
     }
     image_tag = f"localhost/syswarden-lifecycle-{slug}-{uuid.uuid4().hex}"
+    historical_image_tag = f"{image_tag}-historical-upgrade"
     context = workspace / f"build-{slug}"
     context.mkdir(mode=0o700)
     containerfile = context / "Containerfile"
     containerfile.write_text(build_containerfile(spec), encoding="utf-8")
     containerfile.chmod(0o600)
+    historical_containerfile_text = (
+        build_historical_transition_containerfile(
+            spec,
+            pair.previous.version,
+            image_tag,
+        )
+        if "upgrade-rollback" in spec.scenarios
+        else None
+    )
+    historical_context: Path | None = None
+    historical_containerfile: Path | None = None
+    image_tags = [image_tag]
+    if historical_containerfile_text is not None:
+        historical_context = workspace / f"build-{slug}-historical-upgrade"
+        historical_context.mkdir(mode=0o700)
+        historical_containerfile = historical_context / "Containerfile"
+        historical_containerfile.write_text(
+            historical_containerfile_text, encoding="utf-8"
+        )
+        historical_containerfile.chmod(0o600)
+        image_tags.append(historical_image_tag)
     image_cleanup_failed = False
 
     try:
@@ -7474,6 +7824,27 @@ def run_platform(
             timeout=900,
         )
         require_success(build, f"bootstrap {spec.name} lifecycle image")
+        if historical_containerfile is not None and historical_context is not None:
+            historical_build = runner.run(
+                (
+                    podman,
+                    "build",
+                    "--pull=never",
+                    "--layers=false",
+                    "--platform",
+                    spec.podman_platform,
+                    "--tag",
+                    historical_image_tag,
+                    "--file",
+                    str(historical_containerfile),
+                    str(historical_context),
+                ),
+                timeout=900,
+            )
+            require_success(
+                historical_build,
+                f"bootstrap {spec.name} historical upgrade lifecycle image",
+            )
 
         script_path = workspace / "package-lifecycle.sh"
         for scenario in spec.scenarios:
@@ -7484,7 +7855,12 @@ def run_platform(
             )
             run_args = container_run_arguments(
                 podman,
-                image_tag,
+                (
+                    historical_image_tag
+                    if scenario == "upgrade-rollback"
+                    and historical_containerfile is not None
+                    else image_tag
+                ),
                 container_name,
                 candidate_root,
                 previous_root,
@@ -7735,22 +8111,37 @@ def run_platform(
         platform_result["error"] = str(exc)
         return platform_result
     finally:
-        image_cleanup = runner.run(
-            (podman, "image", "rm", "--force", image_tag), timeout=120
+        cleanup_results: list[tuple[int, int]] = []
+        for cleanup_tag in reversed(image_tags):
+            image_cleanup = runner.run(
+                (podman, "image", "rm", "--force", cleanup_tag), timeout=120
+            )
+            image_exists = runner.run(
+                (podman, "image", "exists", cleanup_tag), timeout=30
+            )
+            cleanup_results.append(
+                (image_cleanup.returncode, image_exists.returncode)
+            )
+        cleanup_remove_exit = next(
+            (remove for remove, _ in cleanup_results if remove != 0), 0
         )
-        image_exists = runner.run(
-            (podman, "image", "exists", image_tag), timeout=30
+        cleanup_exists_exit = next(
+            (exists for _, exists in cleanup_results if exists != 1), 1
+        )
+        cleanup_absent = all(
+            remove == 0 and exists == 1
+            for remove, exists in cleanup_results
         )
         platform_result["bootstrap_image_cleanup"] = {
-            "remove_exit_code": image_cleanup.returncode,
-            "exists_probe_exit_code": image_exists.returncode,
-            "absent_after_cleanup": image_exists.returncode == 1,
+            "remove_exit_code": cleanup_remove_exit,
+            "exists_probe_exit_code": cleanup_exists_exit,
+            "absent_after_cleanup": cleanup_absent,
         }
-        if image_cleanup.returncode != 0 or image_exists.returncode != 1:
+        if not cleanup_absent:
             image_cleanup_failed = True
             cleanup_error = (
                 "bootstrap image cleanup did not attest exact object absence: "
-                f"rm={image_cleanup.returncode}, exists={image_exists.returncode}"
+                f"rm={cleanup_remove_exit}, exists={cleanup_exists_exit}"
             )
             existing_error = platform_result.get("error")
             platform_result["error"] = (
@@ -9435,6 +9826,12 @@ def run_lab(
     candidate_root, previous_root, pairs = validate_inputs(
         args.packages_dir, args.previous_packages_dir, platforms
     )
+    package_tmp_dir = getattr(args, "package_tmp_dir", None)
+    if package_tmp_dir is None:
+        raise LifecycleLabError("--package-tmp-dir is required outside aggregate mode")
+    package_tmp_root = require_private_directory(
+        package_tmp_dir, "package lifecycle temporary directory"
+    )
     actual_host_architecture = host_architecture or platform.machine()
     normalized_host = normalize_host_architecture(actual_host_architecture)
     if architecture_shard is not None and normalized_host != architecture_shard:
@@ -9446,7 +9843,9 @@ def run_lab(
         active_runner, args.podman, actual_host_architecture
     )
 
-    with tempfile.TemporaryDirectory(prefix="syswarden-package-lifecycle-") as raw:
+    with tempfile.TemporaryDirectory(
+        prefix="syswarden-package-lifecycle-", dir=package_tmp_root
+    ) as raw:
         workspace = Path(raw)
         script_path = workspace / "package-lifecycle.sh"
         script_path.write_text(LIFECYCLE_SCRIPT, encoding="utf-8")
@@ -10230,6 +10629,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--podman", default="podman")
     parser.add_argument("--architecture-shard", choices=("amd64",))
     parser.add_argument("--aggregate-amd64-report", type=Path)
+    parser.add_argument("--package-tmp-dir", type=Path)
     parser.add_argument("--qualification-repository")
     parser.add_argument("--qualification-release-sha")
     parser.add_argument("--qualification-release-tag")

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -308,11 +308,11 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
         self.inspect_memory = inspect_memory
         self.inspect_pids_limit = inspect_pids_limit
         self.uid_map = uid_map if uid_map is not None else [
-            {"container_id": 0, "host_id": 1000, "size": 1},
+            {"container_id": 0, "host_id": os.geteuid(), "size": 1},
             {"container_id": 1, "host_id": 524288, "size": 65536},
         ]
         self.gid_map = gid_map if gid_map is not None else [
-            {"container_id": 0, "host_id": 1000, "size": 1},
+            {"container_id": 0, "host_id": os.getegid(), "size": 1},
             {"container_id": 1, "host_id": 524288, "size": 65536},
         ]
         self.containers: dict[str, dict[str, object]] = {}
@@ -792,19 +792,15 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
 
 class PackageLifecycleLabTests(unittest.TestCase):
     def setUp(self) -> None:
-        effective_uid = mock.patch.object(os, "geteuid", return_value=1000)
-        effective_gid = mock.patch.object(os, "getegid", return_value=1000)
-        effective_uid.start()
-        effective_gid.start()
-        self.addCleanup(effective_gid.stop)
-        self.addCleanup(effective_uid.stop)
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary_directory.cleanup)
         self.root = Path(self.temporary_directory.name)
         self.candidate = self.root / "candidate"
         self.previous = self.root / "previous"
+        self.package_tmp = self.root / "package-tmp"
         self.candidate.mkdir()
         self.previous.mkdir()
+        self.package_tmp.mkdir(mode=0o700)
         self.create_package_set(self.candidate, b"candidate", "4.02.8")
         self.create_package_set(self.previous, b"previous", "4.02.7")
 
@@ -832,6 +828,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
             "podman": "podman",
             "pull_policy": "never",
             "scenario_timeout": 60,
+            "package_tmp_dir": self.package_tmp,
         }
         values.update(overrides)
         return argparse.Namespace(**values)
@@ -1270,6 +1267,91 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 self.previous,
                 package_lifecycle_lab.DEFAULT_PLATFORMS,
             )
+
+    def test_package_temporary_directory_is_private_real_and_owner_bound(self) -> None:
+        self.assertEqual(
+            package_lifecycle_lab.require_private_directory(
+                self.package_tmp, "package temporary directory"
+            ),
+            self.package_tmp.absolute(),
+        )
+
+        self.package_tmp.chmod(0o755)
+        try:
+            with self.assertRaisesRegex(
+                package_lifecycle_lab.LifecycleLabError, "mode 0700"
+            ):
+                package_lifecycle_lab.require_private_directory(
+                    self.package_tmp, "package temporary directory"
+                )
+        finally:
+            self.package_tmp.chmod(0o700)
+
+        direct_link = self.root / "package-tmp-link"
+        direct_link.symlink_to(self.package_tmp, target_is_directory=True)
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError, "real directory"
+        ):
+            package_lifecycle_lab.require_private_directory(
+                direct_link, "package temporary directory"
+            )
+
+        ancestor_link = self.root / "root-link"
+        ancestor_link.symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError, "symlinked path components"
+        ):
+            package_lifecycle_lab.require_private_directory(
+                ancestor_link / self.package_tmp.name,
+                "package temporary directory",
+            )
+
+        with mock.patch.object(
+            os, "geteuid", return_value=os.geteuid() + 1
+        ), self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError, "owned by effective uid"
+        ):
+            package_lifecycle_lab.require_private_directory(
+                self.package_tmp, "package temporary directory"
+            )
+
+    def test_unsafe_package_temporary_directory_fails_before_podman(self) -> None:
+        unsafe = self.root / "unsafe-package-tmp"
+        unsafe.mkdir(mode=0o755)
+        unsafe.chmod(0o755)
+        runner = FakePodmanRunner()
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError, "mode 0700"
+        ):
+            package_lifecycle_lab.run_lab(
+                self.args(package_tmp_dir=unsafe), runner=runner
+            )
+        self.assertEqual(runner.calls, [])
+
+        missing_runner = FakePodmanRunner()
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "--package-tmp-dir is required",
+        ):
+            package_lifecycle_lab.run_lab(
+                self.args(package_tmp_dir=None), runner=missing_runner
+            )
+        self.assertEqual(missing_runner.calls, [])
+
+    def test_workspace_is_created_beneath_explicit_package_temporary_directory(
+        self,
+    ) -> None:
+        runner = FakePodmanRunner()
+        report = package_lifecycle_lab.run_lab(self.args(), runner=runner)
+        self.assertEqual(report["status"], "pass")
+        build_calls = [call for call in runner.calls if call[1] == "build"]
+        self.assertEqual(len(build_calls), len(package_lifecycle_lab.DEFAULT_PLATFORMS))
+        for call in build_calls:
+            with self.subTest(call=call):
+                self.assertTrue(
+                    Path(call[-1]).is_relative_to(self.package_tmp),
+                    call[-1],
+                )
 
     def test_containerfile_uses_exact_base_and_bootstrap_only(self) -> None:
         spec = package_lifecycle_lab.DEFAULT_PLATFORMS[0]
@@ -3472,15 +3554,24 @@ probe
         self.assertIn("'[network]' 'interfaces = \"lo\"'", token_writer)
         self.assertNotIn('interfaces = "eth0"', token_writer)
 
-    def test_previous_package_is_installed_and_probed_before_operator_seed(self) -> None:
+    def test_networkless_preconfiguration_precedes_previous_install_and_full_seed_follows_probe(
+        self,
+    ) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         initial = source[
             source.index("scenario_upgrade_rollback_initial() {") : source.index(
                 "\nscenario_upgrade_rollback_restart_one() {"
             )
         ]
+        networkless = initial.index(
+            "seed_and_attest_preinstall_networkless_config || return"
+        )
+        prepare = initial.index("prepare_package_transition || return")
         install = initial.index(
             'run_install_step install.previous "${PREVIOUS_PACKAGE}"'
+        )
+        postinstall_attestation = initial.index(
+            "attest_preinstall_networkless_config_after_previous || return"
         )
         probes = (
             initial.index("probe_forward_only_apk_payload previous"),
@@ -3491,7 +3582,12 @@ probe
         candidate = initial.index(
             'run_install_step upgrade.candidate "${CANDIDATE_PACKAGE}"'
         )
-        self.assertTrue(all(install < probe < seed for probe in probes))
+        self.assertLess(networkless, prepare)
+        self.assertLess(prepare, install)
+        self.assertLess(install, postinstall_attestation)
+        self.assertTrue(
+            all(postinstall_attestation < probe < seed for probe in probes)
+        )
         self.assertLess(seed, preserved)
         self.assertLess(preserved, candidate)
 
@@ -3625,6 +3721,8 @@ probe
             'EXPECTED_CANDIDATE_VERSION="4.03.2"\n'
             'FORWARD_ONLY_APK_TRANSITION="1"\n'
             "prepare_expected_payloads() { return 0; }\n"
+            "seed_and_attest_preinstall_networkless_config() { :; }\n"
+            "attest_preinstall_networkless_config_after_previous() { :; }\n"
             "seed_state() { :; }\n"
             "seed_legacy_webtui_upgrade_state() { :; }\n"
             "seed_live_legacy_webtui_process() { :; }\n"
@@ -3685,6 +3783,8 @@ probe
             "FAILURES=0\n"
             "probe_execution_architecture() { return 0; }\n"
             "prepare_package_transition() { return 0; }\n"
+            "seed_and_attest_preinstall_networkless_config() { return 0; }\n"
+            "attest_preinstall_networkless_config_after_previous() { return 0; }\n"
             "prepare_alma_v4028_rpm_rsyslog_fixture() { return 0; }\n"
             "attest_alma_v4028_rpm_rsyslog_fixture() { return 0; }\n"
             "attest_alma_v4028_rpm_rsyslog_after_previous() { return 0; }\n"
@@ -4860,6 +4960,7 @@ probe
         baseline = package_lifecycle_lab.run_lab(
             self.args(), runner=FakePodmanRunner()
         )
+        different_uid = os.geteuid() + 1
 
         def isolation(item: dict[str, object]) -> dict[str, object]:
             return item["platforms"][0]["scenarios"][0]["isolation"]
@@ -4870,8 +4971,8 @@ probe
             ]
 
         def engine_valid_but_different(item: dict[str, object]) -> None:
-            item["engine"]["effective_uid"] = 1001
-            item["engine"]["uid_map"][0]["outside_id"] = 1001
+            item["engine"]["effective_uid"] = different_uid
+            item["engine"]["uid_map"][0]["outside_id"] = different_uid
 
         def engine_overlapping_map(item: dict[str, object]) -> None:
             item["engine"]["effective_uid"] = 524289
@@ -4910,7 +5011,7 @@ probe
                 userns_mode="private-explicit"
             ),
             "engine_effective_uid_only": lambda item: item["engine"].update(
-                effective_uid=1001
+                effective_uid=different_uid
             ),
             "engine_only_valid_map": engine_valid_but_different,
             "engine_host_root_map": lambda item: item["engine"]["uid_map"][0].update(
@@ -4925,7 +5026,7 @@ probe
                 extra=1
             ),
             "scenario_only_map": lambda item: snapshot(item)["pid1_uid_map"][0].update(
-                outside_id=1001
+                outside_id=different_uid
             ),
             "scenario_map_host_root": lambda item: snapshot(item)[
                 "pid1_gid_map"
@@ -4967,6 +5068,7 @@ probe
             self.args(), runner=FakePodmanRunner()
         )
         platform_result = baseline["platforms"][0]
+        different_uid = os.geteuid() + 1
 
         def scenario_copy() -> tuple[dict[str, object], dict[str, object]]:
             platform = json.loads(json.dumps(platform_result))
@@ -4978,7 +5080,7 @@ probe
             del platform
             scenario["boots"][0]["post_exec"]["pid1_uid_map"][0][
                 "outside_id"
-            ] = 1001
+            ] = different_uid
 
         cases["pre_post_map"] = post_map
 
@@ -5013,7 +5115,7 @@ probe
             for phase in ("pre_exec", "post_exec"):
                 scenario["boots"][1][phase]["pid1_uid_map"][0][
                     "outside_id"
-                ] = 1001
+                ] = different_uid
 
         cases["inter_boot_map"] = inter_boot
 
@@ -5042,8 +5144,9 @@ probe
 
         def shard_only_map(item: dict[str, object]) -> None:
             record = item["native_shards"]["reports"][0]
-            record["effective_uid"] = 1001
-            record["uid_map"][0]["outside_id"] = 1001
+            different_uid = int(record["effective_uid"]) + 1
+            record["effective_uid"] = different_uid
+            record["uid_map"][0]["outside_id"] = different_uid
 
         mutations = {
             "shard_only_map": shard_only_map,
@@ -5494,6 +5597,151 @@ probe
         for key in ("opt_root", "config_root", "data_root", "log_root"):
             self.assertIn(f"purge.purge.state.{key}", direct_purge)
 
+    def test_owned_cron_seed_state_exception_is_exact_and_fail_closed(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("attest_owned_cron_seed_state() {")
+        end = source.index("\n}\n\nseed_generated_runtime_artifacts() {", start)
+        function = source[start : end + 2]
+        self.assertIn("deb:remove:remove-before-purge)", function)
+        self.assertEqual(function.count("deb:remove:remove-before-purge)"), 1)
+        self.assertIn('[ ! -e "${syswarden_owned_cron_path}" ]', function)
+        self.assertIn('[ ! -L "${syswarden_owned_cron_path}" ]', function)
+        self.assertIn('[ -f "${syswarden_owned_cron_path}" ]', function)
+
+        harness = (
+            function
+            + '\nattest_owned_cron_seed_state "${TEST_CRON_PATH}" "${TEST_LABEL}"\n'
+        )
+        cases = (
+            ("first-regular", "deb", "remove", "remove", "regular", 0),
+            ("first-absent", "deb", "remove", "remove", "absent", 1),
+            ("first-directory", "deb", "remove", "remove", "directory", 1),
+            ("first-symlink", "deb", "remove", "remove", "symlink", 1),
+            (
+                "second-absent",
+                "deb",
+                "remove",
+                "remove-before-purge",
+                "absent",
+                0,
+            ),
+            (
+                "second-regular",
+                "deb",
+                "remove",
+                "remove-before-purge",
+                "regular",
+                1,
+            ),
+            (
+                "second-directory",
+                "deb",
+                "remove",
+                "remove-before-purge",
+                "directory",
+                1,
+            ),
+            (
+                "second-symlink",
+                "deb",
+                "remove",
+                "remove-before-purge",
+                "symlink",
+                1,
+            ),
+            (
+                "second-broken-symlink",
+                "deb",
+                "remove",
+                "remove-before-purge",
+                "broken-symlink",
+                1,
+            ),
+            (
+                "wrong-family",
+                "rpm",
+                "remove",
+                "remove-before-purge",
+                "absent",
+                1,
+            ),
+            (
+                "wrong-scenario",
+                "deb",
+                "purge",
+                "remove-before-purge",
+                "absent",
+                1,
+            ),
+            (
+                "wrong-label",
+                "deb",
+                "remove",
+                "other",
+                "absent",
+                1,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "syswarden"
+            symlink_target = root / "operator-cron"
+            symlink_target.write_text("operator\n", encoding="ascii")
+            for label, family, scenario, evidence, path_kind, expected in cases:
+                with self.subTest(case=label):
+                    if target.is_symlink() or target.is_file():
+                        target.unlink()
+                    elif target.is_dir():
+                        target.rmdir()
+                    if path_kind == "regular":
+                        target.write_text("managed\n", encoding="ascii")
+                    elif path_kind == "directory":
+                        target.mkdir()
+                    elif path_kind == "symlink":
+                        target.symlink_to(symlink_target)
+                    elif path_kind == "broken-symlink":
+                        target.symlink_to(root / "missing-operator-cron")
+                    elif path_kind != "absent":
+                        self.fail(f"unsupported path fixture: {path_kind}")
+                    environment = os.environ.copy()
+                    environment.update(
+                        {
+                            "PACKAGE_FAMILY": family,
+                            "SCENARIO": scenario,
+                            "TEST_CRON_PATH": str(target),
+                            "TEST_LABEL": evidence,
+                        }
+                    )
+                    result = subprocess.run(
+                        ["/bin/sh", "-eu", "-c", harness],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+                    self.assertEqual(result.returncode, expected, result.stderr)
+
+        seed_start = source.index("seed_generated_runtime_artifacts() {")
+        seed_end = source.index(
+            "\n}\n\nassert_generated_runtime_artifact_contract() {", seed_start
+        )
+        seed = source[seed_start:seed_end]
+        self.assertEqual(seed.count("attest_owned_cron_seed_state \\"), 1)
+        self.assertIn('/etc/cron.d/syswarden "${evidence_label}"', seed)
+        pending = "printf '%s' '# Managed by' > /etc/cron.d/.syswarden.pending-v1"
+        root_crontab_attestation = (
+            "cmp -s /tmp/syswarden-root-cron-before "
+            "/tmp/syswarden-root-cron-confirmed"
+        )
+        cron_seed_attestation = "attest_owned_cron_seed_state \\"
+        self.assertIn(pending, seed)
+        self.assertIn(root_crontab_attestation, seed)
+        self.assertLess(
+            seed.index(root_crontab_attestation),
+            seed.index(cron_seed_attestation),
+        )
+        self.assertLess(seed.index(cron_seed_attestation), seed.index(pending))
+
     def test_rpm_and_apk_final_removal_require_dedicated_roots_absent(self) -> None:
         for family, scenario, label in (
             ("rpm", "remove", "final-removal"),
@@ -5562,9 +5810,53 @@ probe
         self.assertIn(".syswarden-rsyslog-provenance-v1", exact)
         self.assertIn("syswarden-rsyslog-provenance-v1", exact)
         self.assertIn("*.* @127.0.0.1:5514", exact)
-        self.assertIn('File="/var/log/syswarden/waf.json"', exact)
-        self.assertIn('Tag="syswarden-waf-json"', exact)
-        self.assertIn('Facility="local7"', exact)
+        forbidden_start = exact.index("for forbidden_fragment in")
+        forbidden_end = exact.index("\n            done", forbidden_start)
+        forbidden = exact[forbidden_start:forbidden_end]
+        for fragment in (
+            "'imfile'",
+            "'/var/log/syswarden/waf.json'",
+            "'syswarden-waf-json'",
+            "'Facility=\"local7\"'",
+        ):
+            self.assertIn(fragment, forbidden)
+        self.assertIn("99-syswarden-siem.conf", forbidden)
+        self.assertNotIn("99-syswarden-waf-bridge.conf", forbidden)
+        self.assertIn("waf_telemetry_input_block", exact)
+        telemetry_start = exact.index("for telemetry_fragment in")
+        telemetry_end = exact.index("\n            done", telemetry_start)
+        telemetry = exact[telemetry_start:telemetry_end]
+        self.assertIn("waf_telemetry_input_block", telemetry)
+        for fragment in (
+            'File="/var/log/syswarden/waf.json"',
+            'Tag="syswarden-waf-json"',
+            'Facility="local7"',
+        ):
+            self.assertIn(fragment, telemetry)
+        module_count_start = exact.index(
+            "grep -F -x -c 'module(load=\"imfile\")'"
+        )
+        module_count_end = exact.index("|| return 1", module_count_start)
+        self.assertIn(
+            "99-syswarden-waf-bridge.conf",
+            exact[module_count_start:module_count_end],
+        )
+        telemetry_input_start = exact.index(
+            "grep -F -x -c 'input(type=\"imfile\"'"
+        )
+        telemetry_input_end = exact.index("|| return 1", telemetry_input_start)
+        self.assertIn(
+            "99-syswarden-waf-bridge.conf",
+            exact[telemetry_input_start:telemetry_input_end],
+        )
+        ruleset_guard_start = exact.index(
+            "! printf '%s\\n' \"${waf_telemetry_input_block}\""
+        )
+        ruleset_guard_end = exact.index("|| return 1", ruleset_guard_start)
+        self.assertIn(
+            'ruleset="waf_bridge"',
+            exact[ruleset_guard_start:ruleset_guard_end],
+        )
         self.assertIn('module(load="omuxsock")', exact)
         self.assertIn("$OMUxSockSocket /var/run/syswarden.sock", exact)
         self.assertIn('/var/log/nginx/*.log', exact)
@@ -6014,36 +6306,59 @@ probe
 
     def test_systemd_enablement_target_depends_on_scenario_provenance(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
-        start = source.index("expected_systemd_enablement_prefix() {")
+        start = source.index("v4028_to_v4032_transition_selected() {")
         end = source.index("\nprobe_postinstall_contract() {", start)
-        function = source[start:end]
-        cases = {
-            **{
-                ("upgrade-rollback", label): "/etc/systemd/system"
-                for label in (
-                    "previous",
-                    "candidate",
-                    "reinstall",
-                    "restart-one",
-                    "restart-two",
-                    "rollback",
-                    "recovery",
-                )
-            },
-            ("remove", "fresh"): "..",
-            ("remove", "reinstall-after-remove"): "..",
-            ("purge", "fresh"): "..",
-        }
-        for (scenario, label), expected in cases.items():
-            with self.subTest(scenario=scenario, label=label):
+        functions = source[start:end]
+        command = (
+            functions
+            + '\nSCENARIO="$1"; EXPECTED_PREVIOUS_VERSION="$2"; '
+            'EXPECTED_CANDIDATE_VERSION="$3"; '
+            'expected_systemd_enablement_prefix "$4"'
+        )
+        upgrade_labels = (
+            "previous",
+            "candidate",
+            "reinstall",
+            "restart-one",
+            "restart-two",
+            "rollback",
+            "recovery",
+        )
+        cases = [
+            *(
+                ("upgrade-rollback", "4.02.8", "4.03.2", label, "/etc/systemd/system")
+                for label in upgrade_labels
+            ),
+            *(
+                ("upgrade-rollback", "4.03.2", "4.03.3", label, "..")
+                for label in upgrade_labels
+            ),
+            ("remove", "4.03.2", "4.03.3", "fresh", ".."),
+            (
+                "remove",
+                "4.03.2",
+                "4.03.3",
+                "reinstall-after-remove",
+                "..",
+            ),
+            ("purge", "4.03.2", "4.03.3", "fresh", ".."),
+        ]
+        for scenario, previous, candidate, label, expected in cases:
+            with self.subTest(
+                scenario=scenario,
+                previous=previous,
+                candidate=candidate,
+                label=label,
+            ):
                 result = subprocess.run(
                     [
                         "/bin/sh",
                         "-c",
-                        function
-                        + '\nSCENARIO="$1"; expected_systemd_enablement_prefix "$2"',
+                        command,
                         "probe",
                         scenario,
+                        previous,
+                        candidate,
                         label,
                     ],
                     check=False,
@@ -6053,21 +6368,36 @@ probe
                 self.assertEqual(result.returncode, 0, result)
                 self.assertEqual(result.stdout.strip(), expected)
 
-        rejected = subprocess.run(
-            [
-                "/bin/sh",
-                "-c",
-                function
-                + '\nSCENARIO="$1"; expected_systemd_enablement_prefix "$2"',
-                "probe",
-                "remove",
-                "candidate",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
+        rejected = (
+            ("upgrade-rollback", "4.03.1", "4.03.3", "previous"),
+            ("upgrade-rollback", "4.03.2", "4.03.4", "candidate"),
+            ("upgrade-rollback", "4.02.8", "4.03.3", "rollback"),
+            ("upgrade-rollback", "4.03.2", "4.03.3", "unknown"),
+            ("remove", "4.03.2", "4.03.3", "candidate"),
         )
-        self.assertNotEqual(rejected.returncode, 0, rejected)
+        for scenario, previous, candidate, label in rejected:
+            with self.subTest(
+                rejected_scenario=scenario,
+                previous=previous,
+                candidate=candidate,
+                label=label,
+            ):
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        command,
+                        "probe",
+                        scenario,
+                        previous,
+                        candidate,
+                        label,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(result.returncode, 0, result)
 
     def test_cleanup_shell_events_match_declared_contract_exactly(self) -> None:
         script = package_lifecycle_lab.LIFECYCLE_SCRIPT
@@ -6969,6 +7299,96 @@ prepare_package_transition
                 )
                 self.assertEqual(result.returncode, expected, result.stderr)
 
+    def test_preinstall_networkless_configuration_is_minimal_exact_and_attested(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        writer_start = source.index("write_preinstall_networkless_config() {")
+        writer_end = source.index(
+            "\nseed_and_attest_preinstall_networkless_config() {", writer_start
+        )
+        writer = source[writer_start:writer_end]
+        destination = self.root / "preinstall-networkless.toml"
+        expected = (
+            b'# Lifecycle-only network-isolation override; production defaults remain list_choice = "1".\n'
+            b'[network.blocklists]\n'
+            b'list_choice = "4"\n'
+            b'custom_url = ""\n'
+            b'custom_url_ipv6 = ""\n'
+            b'custom_hash = ""\n'
+            b'custom_hash_ipv6 = ""\n'
+            b'use_spamhaus = false\n\n'
+        )
+        rendered = subprocess.run(
+            [
+                "/bin/sh",
+                "-c",
+                writer + '\nwrite_preinstall_networkless_config "$1"',
+                "preinstall",
+                str(destination),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(rendered.returncode, 0, rendered.stderr)
+        self.assertEqual(destination.read_bytes(), expected)
+        self.assertEqual(
+            hashlib.sha256(expected).hexdigest(),
+            "e0a6d764d1786c3661c6f25fa7b688bd8c8922d8fd0a00135925ae982f274d68",
+        )
+        self.assertNotIn("[network.saas]", writer)
+        self.assertNotIn("[user]", writer)
+        attester = source[
+            writer_end : source.index("\nwrite_seeded_operator_token() {", writer_end)
+        ]
+        for contract in (
+            "stat -c '%u:%g:%a:%h'",
+            "0:0:640:1",
+            "[ ! -L",
+            "${PREFIX}.preinstall.networkless_config",
+            "e0a6d764d1786c3661c6f25fa7b688bd8c8922d8fd0a00135925ae982f274d68",
+        ):
+            self.assertIn(contract, attester)
+        seed_attester = source[
+            source.index("seed_and_attest_preinstall_networkless_config() {") : source.index(
+                "\nattest_preinstall_networkless_config_after_previous() {"
+            )
+        ]
+        publication = seed_attester.index(
+            'write_preinstall_networkless_config "${preinstall_networkless_path}"'
+        )
+        self.assertLess(
+            seed_attester.index('[ -e "${preinstall_networkless_path}" ]'),
+            publication,
+        )
+        self.assertLess(
+            seed_attester.index('[ -L "${preinstall_networkless_path}" ]'),
+            publication,
+        )
+        for directory in (
+            "/etc/syswarden",
+            "/etc/syswarden/config",
+            "/etc/syswarden/config/modules",
+        ):
+            self.assertIn(directory, seed_attester)
+        self.assertGreaterEqual(seed_attester.count("!= 0:0"), 2)
+        checks = package_lifecycle_lab.expected_event_checks(
+            "deb", "upgrade-rollback"
+        )
+        self.assertLess(
+            checks.index("upgrade-rollback.preinstall.networkless_config"),
+            checks.index("upgrade-rollback.install.previous"),
+        )
+        self.assertLess(
+            checks.index("upgrade-rollback.install.previous.maintainer_script"),
+            checks.index("upgrade-rollback.previous.networkless_config_preserved"),
+        )
+        self.assertLess(
+            checks.index("upgrade-rollback.previous.networkless_config_preserved"),
+            checks.index("upgrade-rollback.previous.version"),
+        )
+
     def test_seed_scopes_legacy_saas_and_exact_networkless_feed_override(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         writer_start = source.index("write_seeded_operator_token() {")
@@ -7345,13 +7765,254 @@ prepare_package_transition
         self.assertIn('length(secret) != 32', contract)
         self.assertIn('credentials != 1', contract)
         self.assertIn('! grep -Fq "${rollback_secret}" "${COMMAND_LOG}"', contract)
-        self.assertIn('upgrade-rollback:rollback:deb', contract)
-        self.assertIn('upgrade-rollback:rollback:rpm', contract)
+        self.assertIn("if v4028_to_v4032_transition_selected; then", contract)
+        self.assertIn("elif v4032_to_v4033_transition_selected; then", contract)
+        self.assertIn("historical-webtui-credential", contract)
+        self.assertIn("byte-exact", contract)
+        self.assertIn(
+            'record_unsupported_rollback_token_contract "${label}"', contract
+        )
         self.assertIn(
             'assert_preserved "${label}" token /etc/syswarden/config/modules/99-user.toml',
             contract,
         )
         self.assertIn('[REDACTED]', source)
+
+    def test_upgrade_rollback_token_contract_is_exactly_version_bound(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        predicates_start = source.index("v4028_to_v4032_transition_selected() {")
+        predicates_end = source.index(
+            "\nexpected_systemd_enablement_prefix() {", predicates_start
+        )
+        contract_start = source.index(
+            "expected_upgrade_rollback_token_contract() {"
+        )
+        contract_end = source.index(
+            "\nrecord_unsupported_rollback_token_contract() {", contract_start
+        )
+        functions = (
+            source[predicates_start:predicates_end]
+            + "\n"
+            + source[contract_start:contract_end]
+        )
+        command = (
+            functions
+            + '\nSCENARIO="$1"; EXPECTED_PREVIOUS_VERSION="$2"; '
+            'EXPECTED_CANDIDATE_VERSION="$3"; PACKAGE_FAMILY="$4"; '
+            'expected_upgrade_rollback_token_contract "$5"'
+        )
+        accepted = (
+            (
+                "upgrade-rollback",
+                "4.02.8",
+                "4.03.2",
+                family,
+                "rollback",
+                "historical-webtui-credential",
+            )
+            for family in ("deb", "rpm")
+        )
+        current = (
+            (
+                "upgrade-rollback",
+                "4.03.2",
+                "4.03.3",
+                family,
+                "rollback",
+                "byte-exact",
+            )
+            for family in ("deb", "rpm")
+        )
+        for scenario, previous, candidate, family, label, expected in (
+            *accepted,
+            *current,
+        ):
+            with self.subTest(
+                scenario=scenario,
+                previous=previous,
+                candidate=candidate,
+                family=family,
+                label=label,
+            ):
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        command,
+                        "token-contract",
+                        scenario,
+                        previous,
+                        candidate,
+                        family,
+                        label,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result)
+                self.assertEqual(result.stdout.strip(), expected)
+
+        rejected = (
+            ("upgrade-rollback", "4.03.1", "4.03.3", "deb", "rollback"),
+            ("upgrade-rollback", "4.03.2", "4.03.4", "rpm", "rollback"),
+            ("upgrade-rollback", "4.02.8", "4.03.3", "deb", "rollback"),
+            ("upgrade-rollback", "4.03.2", "4.03.3", "apk", "rollback"),
+            ("upgrade-rollback", "4.03.2", "4.03.3", "deb", "recovery"),
+            ("remove", "4.03.2", "4.03.3", "deb", "rollback"),
+        )
+        for scenario, previous, candidate, family, label in rejected:
+            with self.subTest(
+                rejected_scenario=scenario,
+                previous=previous,
+                candidate=candidate,
+                family=family,
+                label=label,
+            ):
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        command,
+                        "token-contract",
+                        scenario,
+                        previous,
+                        candidate,
+                        family,
+                        label,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(result.returncode, 0, result)
+
+    def test_v4032_rollback_token_state_is_byte_exact_and_fail_closed(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("assert_preserved() {")
+        end = source.index("\nlive_telemetry_schema_valid() {", start)
+        function = source[start:end]
+        fixture = (
+            b'[network]\ninterfaces = "lo"\n\n'
+            b'[network.saas]\nallow_monitors = true\n\n'
+            b'# Lifecycle-only network-isolation override; production defaults remain list_choice = "1".\n'
+            b'[network.blocklists]\n'
+            b'list_choice = "4"\n'
+            b'custom_url = ""\n'
+            b'custom_url_ipv6 = ""\n'
+            b'custom_hash = ""\n'
+            b'custom_hash_ipv6 = ""\n'
+            b'use_spamhaus = false\n\n'
+            b'[user]\nprofile_name = "lifecycle-operator"\n'
+        )
+        expected_hash = hashlib.sha256(fixture).hexdigest()
+        self.assertEqual(
+            expected_hash,
+            "75ba724333aa74769db97901ad0efc8c2724364cfbb860a7ac2ae02538892a69",
+        )
+        harness = (
+            function
+            + r'''
+hash_file() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+file_mode() {
+    /usr/bin/stat -c '%a' "$1"
+}
+stat() {
+    if [ "$1" = -c ] && [ "$2" = '%u:%g' ]; then
+        printf '%s\n' "${TEST_OWNER}"
+    else
+        command stat "$@"
+    fi
+}
+check_equal() {
+    if [ "$2" = "$3" ]; then
+        status=pass
+    else
+        status=fail
+    fi
+    printf '%s\t%s\n' "${status}" "$1"
+}
+PREFIX=upgrade-rollback
+assert_preserved rollback token "$1" "$2" 640
+'''
+        )
+
+        def run_state(
+            kind: str,
+            *,
+            content: bytes = fixture,
+            mode: int = 0o640,
+            owner: str = "0:0",
+        ) -> dict[str, str]:
+            with tempfile.TemporaryDirectory(dir=self.root) as temporary:
+                root = Path(temporary)
+                token = root / "99-user.toml"
+                if kind == "regular":
+                    token.write_bytes(content)
+                    token.chmod(mode)
+                elif kind == "symlink":
+                    target = root / "operator-token.toml"
+                    target.write_bytes(content)
+                    target.chmod(mode)
+                    token.symlink_to(target)
+                elif kind == "directory":
+                    token.mkdir()
+                elif kind != "missing":
+                    self.fail(f"unknown token state {kind}")
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        harness,
+                        "token-state",
+                        str(token),
+                        expected_hash,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env={**os.environ, "TEST_OWNER": owner},
+                )
+                self.assertEqual(result.returncode, 0, result)
+                return {
+                    check: status
+                    for status, check in (
+                        line.split("\t", 1)
+                        for line in result.stdout.splitlines()
+                    )
+                }
+
+        exact = run_state("regular")
+        self.assertEqual(set(exact.values()), {"pass"})
+
+        retired_hex_value = b"01234567" * 4
+        adversarial = (
+            ("changed-bytes", "regular", fixture + b"# drift\n", 0o640, "0:0", "rollback.state.token.hash"),
+            (
+                "retired-credential",
+                "regular",
+                fixture + b'webtui_password = "' + retired_hex_value + b'"\n',
+                0o640,
+                "0:0",
+                "rollback.state.token.hash",
+            ),
+            ("wrong-mode", "regular", fixture, 0o600, "0:0", "rollback.state.token.mode"),
+            ("wrong-owner", "regular", fixture, 0o640, "1:1", "rollback.state.token.owner"),
+            ("symlink", "symlink", fixture, 0o640, "0:0", "rollback.state.token.type"),
+            ("directory", "directory", fixture, 0o640, "0:0", "rollback.state.token.type"),
+            ("missing", "missing", fixture, 0o640, "0:0", "rollback.state.token.type"),
+        )
+        for name, kind, content, mode, owner, failed_check in adversarial:
+            with self.subTest(state=name):
+                statuses = run_state(
+                    kind,
+                    content=content,
+                    mode=mode,
+                    owner=owner,
+                )
+                self.assertEqual(statuses[failed_check], "fail")
 
     def test_historical_rollback_token_sanitizer_restores_exact_seed_bytes(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
@@ -7423,6 +8084,202 @@ prepare_package_transition
                     text=True,
                 )
                 self.assertNotEqual(result.returncode, 0)
+
+    def test_v4032_to_v4033_previous_webtui_retirement_is_exact_and_fail_closed(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        functions_start = source.index("legacy_webtui_runtime_absent() {")
+        functions_end = source.index(
+            "\n\nalpine_apk_owner_version() {", functions_start
+        )
+        transitions_start = source.index(
+            "v4028_to_v4032_transition_selected() {"
+        )
+        transitions_end = source.index(
+            "\nexpected_systemd_enablement_prefix() {", transitions_start
+        )
+        transitions = source[transitions_start:transitions_end]
+        functions = transitions + "\n" + source[functions_start:functions_end]
+        quiesce_start = source.index("quiesce_previous_webtui_runtime() {")
+        quiesce_end = source.index(
+            "\n}\n\nlifecycle_seed_hex_prefix() {", quiesce_start
+        )
+        quiesce = source[quiesce_start:quiesce_end]
+        probe_start = source.index("probe_postinstall_contract() {")
+        probe_end = source.index("\n}\n\nverify_installed_inventory() {", probe_start)
+        probe = source[probe_start:probe_end]
+
+        exact_transition = (
+            '[ "${SCENARIO}" = upgrade-rollback ] && \\\n'
+            '        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.2 ] && \\\n'
+            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.3 ]'
+        )
+        self.assertIn(exact_transition, transitions)
+        self.assertIn(
+            "v4032_to_v4033_upgrade_selected() {\n"
+            "    v4032_to_v4033_transition_selected && \\\n"
+            '        [ "$(installed_version 2>/dev/null || true)" = 4.03.2 ]\n'
+            "}",
+            functions,
+        )
+        self.assertIn(
+            'legacy_webtui_runtime_absent "${previous_webtui_root}" || return 1',
+            functions,
+        )
+        self.assertIn("syswarden_verify_no_exact_webtui_process \\", functions)
+        self.assertIn("for previous_webtui_port in 62027 62028", functions)
+        self.assertIn(
+            "if v4032_to_v4033_upgrade_selected; then\n"
+            "        attest_v4032_previous_webtui_retirement || return 1\n"
+            "        return 0\n"
+            "    fi",
+            quiesce,
+        )
+        self.assertIn(
+            "if v4032_to_v4033_upgrade_selected; then\n"
+            "            attest_v4032_previous_webtui_retirement || \\\n"
+            "                mark_postinstall_failure previous-webtui-retirement\n"
+            "        else",
+            probe,
+        )
+        for legacy_fragment in (
+            "/etc/systemd/system/syswarden-webtui.service",
+            "/etc/init.d/syswarden-webtui",
+            "syswarden_read_exact_webtui_unit",
+        ):
+            self.assertIn(legacy_fragment, quiesce)
+
+        harness = (
+            "#!/bin/sh\nset -u\n"
+            + functions
+            + r'''
+installed_version() {
+    printf '%s\n' "${TEST_INSTALLED_VERSION:-4.03.2}"
+}
+syswarden_verify_no_exact_webtui_process() {
+    [ "${TEST_PROCESS_STATE:-absent}" = absent ]
+}
+ss() {
+    case "${TEST_SS_FAILURE:-none}" in
+        nonzero) return 42 ;;
+        stderr)
+            printf '%s\n' 'netlink attestation unavailable' >&2
+            return 0
+            ;;
+    esac
+    case "$*" in
+        *":${TEST_LISTENER_PORT:-none}"*) printf '%s\n' listener ;;
+    esac
+}
+attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
+'''
+        )
+
+        def run_case(
+            overrides: dict[str, str] | None = None,
+            *,
+            residual: tuple[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            temporary = tempfile.TemporaryDirectory(dir=self.root)
+            self.addCleanup(temporary.cleanup)
+            root = Path(temporary.name)
+            (root / "proc").mkdir()
+            if residual is not None:
+                relative, kind = residual
+                path = root / relative.lstrip("/")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                if kind == "directory":
+                    path.mkdir()
+                elif kind == "symlink":
+                    path.symlink_to(root / "missing-operator-target")
+                else:
+                    path.write_text("operator-residual\n", encoding="ascii")
+            environment = {
+                **os.environ,
+                "SCENARIO": "upgrade-rollback",
+                "EXPECTED_PREVIOUS_VERSION": "4.03.2",
+                "EXPECTED_CANDIDATE_VERSION": "4.03.3",
+                "TEST_INSTALLED_VERSION": "4.03.2",
+                "TEST_ROOT": str(root),
+            }
+            environment.update(overrides or {})
+            return subprocess.run(
+                [shutil.which("dash") or "/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+        accepted = run_case()
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        bounds = (
+            ("scenario", {"SCENARIO": "remove"}),
+            ("previous", {"EXPECTED_PREVIOUS_VERSION": "4.03.1"}),
+            ("candidate", {"EXPECTED_CANDIDATE_VERSION": "4.03.4"}),
+            ("installed", {"TEST_INSTALLED_VERSION": "4.03.1"}),
+        )
+        for label, overrides in bounds:
+            with self.subTest(bound=label):
+                self.assertNotEqual(run_case(overrides).returncode, 0)
+
+        residuals = (
+            ("systemd-unit", "/etc/systemd/system/syswarden-webtui.service", "file"),
+            (
+                "systemd-retiring",
+                "/etc/systemd/system/syswarden-webtui.service.syswarden-retiring",
+                "file",
+            ),
+            (
+                "systemd-dropin",
+                "/etc/systemd/system/syswarden-webtui.service.d",
+                "directory",
+            ),
+            (
+                "systemd-enablement",
+                "/etc/systemd/system/multi-user.target.wants/syswarden-webtui.service",
+                "symlink",
+            ),
+            ("runtime-unit", "/run/systemd/system/syswarden-webtui.service", "file"),
+            (
+                "runtime-dropin",
+                "/run/systemd/system/syswarden-webtui.service.d",
+                "directory",
+            ),
+            ("openrc-unit", "/etc/init.d/syswarden-webtui", "file"),
+            ("openrc-config", "/etc/conf.d/syswarden-webtui", "file"),
+            (
+                "openrc-enablement",
+                "/etc/runlevels/default/syswarden-webtui",
+                "symlink",
+            ),
+            ("pidfile", "/run/syswarden-webtui.pid", "file"),
+        )
+        for label, relative, kind in residuals:
+            with self.subTest(residual=label):
+                self.assertNotEqual(
+                    run_case(residual=(relative, kind)).returncode,
+                    0,
+                )
+
+        self.assertNotEqual(
+            run_case({"TEST_PROCESS_STATE": "present"}).returncode,
+            0,
+        )
+        for port in ("62027", "62028"):
+            with self.subTest(listener=port):
+                self.assertNotEqual(
+                    run_case({"TEST_LISTENER_PORT": port}).returncode,
+                    0,
+                )
+        for failure in ("nonzero", "stderr"):
+            with self.subTest(ss_failure=failure):
+                self.assertNotEqual(
+                    run_case({"TEST_SS_FAILURE": failure}).returncode,
+                    0,
+                )
 
     def test_upgrade_seeds_and_proves_exact_browser_retirement_with_port_isolation(self) -> None:
         script = package_lifecycle_lab.LIFECYCLE_SCRIPT
@@ -7533,6 +8390,7 @@ prepare_package_transition
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             script,
         )
+
         probe = script[
             script.index("operator_listener_preservation_required() {") : script.index(
                 "\nverify_installed_inventory() {"
@@ -7588,6 +8446,144 @@ prepare_package_transition
             package_lifecycle_lab.APK_BOOTSTRAP,
         ):
             self.assertRegex(bootstrap, r"(?:^|\s)socat(?:\s|$)")
+
+    def test_v4032_to_v4033_skips_only_the_impossible_live_webtui_seed(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        guard_start = source.index("v4032_to_v4033_upgrade_selected() {")
+        guard_end = source.index(
+            "\n}\n\nattest_v4032_previous_webtui_retirement() {", guard_start
+        ) + 2
+        guard = source[guard_start:guard_end]
+        transition_start = source.index(
+            "v4032_to_v4033_transition_selected() {"
+        )
+        transition_end = source.index(
+            "\n}\n\nexpected_systemd_enablement_prefix() {", transition_start
+        ) + 2
+        transition = source[transition_start:transition_end]
+        seed_start = source.index("seed_live_legacy_webtui_process() {")
+        seed_end = source.index("\n}\n\nload_state_contract() {", seed_start) + 2
+        seed = source[seed_start:seed_end]
+        scenario_start = source.index("scenario_upgrade_rollback_initial() {")
+        scenario_end = source.index(
+            "\n}\n\nscenario_upgrade_rollback_restart_one() {", scenario_start
+        ) + 2
+        scenario = source[scenario_start:scenario_end]
+
+        exact_skip = (
+            "if v4032_to_v4033_upgrade_selected; then\n"
+            "        return 0\n"
+            "    fi"
+        )
+        self.assertEqual(seed.count(exact_skip), 1)
+        self.assertLess(
+            seed.index(exact_skip),
+            seed.index("/opt/syswarden/bin/syswarden-cli web-tui"),
+        )
+        self.assertLess(
+            scenario.index("seed_legacy_webtui_upgrade_state || return"),
+            scenario.index("seed_live_legacy_webtui_process || return"),
+        )
+        self.assertLess(
+            scenario.index("seed_live_legacy_webtui_process || return"),
+            scenario.index('run_install_step upgrade.candidate "${CANDIDATE_PACKAGE}"'),
+        )
+
+        command = "/opt/syswarden/bin/syswarden-cli web-tui"
+        self.assertEqual(seed.count(command), 1)
+        fake_command = self.root / "legacy-webtui-command"
+        fake_command.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$*\" > \"${TEST_LIVE_SEED_MARKER}\"\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        fake_command.chmod(0o700)
+        fake_bin = self.root / "live-seed-bin"
+        fake_bin.mkdir()
+        fake_curl = fake_bin / "curl"
+        fake_curl.write_text("#!/bin/sh\nprintf '%s' 000\n", encoding="utf-8")
+        fake_curl.chmod(0o700)
+        seed_log = self.root / "legacy-webtui-process.log"
+        seed = seed.replace(command, f"{shlex.quote(str(fake_command))} web-tui")
+        seed = seed.replace(
+            "/tmp/syswarden-legacy-webtui-process.log", str(seed_log)
+        )
+        persist = self.root / "live-seed-persist"
+        persist.mkdir()
+        marker = self.root / "live-seed-invoked"
+        harness = (
+            "#!/bin/sh\nset -u\n"
+            + transition
+            + "\n"
+            + guard
+            + "\n"
+            + seed
+            + r'''
+installed_version() {
+    printf '%s\n' "${TEST_INSTALLED_VERSION}"
+}
+record_lifecycle_seed_failure() {
+    :
+}
+stop_lifecycle_seed_process() {
+    wait "$1" 2>/dev/null || true
+}
+seed_live_legacy_webtui_process
+'''
+        )
+
+        def run_case(
+            *,
+            family: str = "deb",
+            scenario_name: str = "upgrade-rollback",
+            previous: str = "4.03.2",
+            candidate: str = "4.03.3",
+            installed: str = "4.03.2",
+        ) -> subprocess.CompletedProcess[str]:
+            marker.unlink(missing_ok=True)
+            environment = {
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "PACKAGE_FAMILY": family,
+                "SCENARIO": scenario_name,
+                "EXPECTED_PREVIOUS_VERSION": previous,
+                "EXPECTED_CANDIDATE_VERSION": candidate,
+                "TEST_INSTALLED_VERSION": installed,
+                "TEST_LIVE_SEED_MARKER": str(marker),
+                "PERSIST_ROOT": str(persist),
+            }
+            return subprocess.run(
+                [shutil.which("dash") or "/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+        for family in ("deb", "rpm"):
+            with self.subTest(exact_family=family):
+                exact = run_case(family=family)
+                self.assertEqual(exact.returncode, 0, exact.stderr)
+                self.assertFalse(marker.exists())
+
+        bounds = (
+            ("scenario", {"scenario_name": "remove"}),
+            ("previous", {"previous": "4.03.1"}),
+            ("candidate", {"candidate": "4.03.4"}),
+            ("installed", {"installed": "4.03.1"}),
+        )
+        for label, overrides in bounds:
+            with self.subTest(bound=label):
+                rejected = run_case(**overrides)
+                self.assertNotEqual(rejected.returncode, 0, rejected.stderr)
+                self.assertTrue(marker.is_file())
+
+        apk = run_case(family="apk", previous="4.02.8")
+        self.assertEqual(apk.returncode, 0, apk.stderr)
+        self.assertFalse(marker.exists())
 
     def test_lifecycle_seed_failure_diagnostic_is_bounded_hex_and_fail_closed(
         self,
@@ -7871,6 +8867,149 @@ prepare_package_transition
             package_lifecycle_lab.APK_BOOTSTRAP,
         )
         self.assertIn("test -x /usr/bin/gpasswd", package_lifecycle_lab.APK_BOOTSTRAP)
+
+    def test_v4032_rpm_transition_restores_only_historical_lab_dependencies(
+        self,
+    ) -> None:
+        fedora = next(
+            spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if spec.distribution == "fedora"
+        )
+        alma = next(
+            spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if spec.distribution == "almalinux"
+        )
+        common_images = {
+            spec.distribution: (
+                f"localhost/syswarden-lifecycle-{package_lifecycle_lab.platform_slug(spec)}-"
+                + "a" * 32
+            )
+            for spec in (fedora, alma)
+        }
+        fedora_common = package_lifecycle_lab.build_containerfile(fedora)
+        alma_common = package_lifecycle_lab.build_containerfile(alma)
+        for common in (fedora_common, alma_common):
+            self.assertNotIn("dnf -y install qrencode", common)
+            self.assertNotIn("dnf -y install epel-release", common)
+            self.assertIn(
+                "! rpm -q qrencode >/dev/null 2>&1 && "
+                "! rpm -q epel-release >/dev/null 2>&1",
+                common,
+            )
+
+        fedora_v4032 = package_lifecycle_lab.build_historical_transition_containerfile(
+            fedora, "4.03.2", common_images["fedora"]
+        )
+        alma_v4032 = package_lifecycle_lab.build_historical_transition_containerfile(
+            alma, "4.03.2", common_images["almalinux"]
+        )
+        self.assertIsInstance(fedora_v4032, str)
+        self.assertIsInstance(alma_v4032, str)
+        assert fedora_v4032 is not None
+        assert alma_v4032 is not None
+        self.assertTrue(fedora_v4032.startswith(f"FROM {common_images['fedora']}\n"))
+        self.assertTrue(alma_v4032.startswith(f"FROM {common_images['almalinux']}\n"))
+        self.assertIn(
+            "RUN dnf -y install qrencode && rpm -q qrencode >/dev/null && "
+            "! rpm -q epel-release >/dev/null 2>&1 && dnf clean all\n",
+            fedora_v4032,
+        )
+        self.assertIn(
+            "RUN dnf -y install epel-release && dnf -y install qrencode && "
+            "rpm -q epel-release >/dev/null && rpm -q qrencode >/dev/null && "
+            "dnf clean all\n",
+            alma_v4032,
+        )
+
+        for spec in (fedora, alma):
+            with self.subTest(distribution=spec.distribution, previous="4.03.3"):
+                self.assertIsNone(
+                    package_lifecycle_lab.build_historical_transition_containerfile(
+                        spec, "4.03.3", common_images[spec.distribution]
+                    )
+                )
+        for spec in package_lifecycle_lab.DEFAULT_PLATFORMS:
+            if spec.family == "rpm":
+                continue
+            with self.subTest(distribution=spec.distribution):
+                self.assertEqual(
+                    package_lifecycle_lab.historical_transition_bootstrap(
+                        spec, "4.03.2"
+                    ),
+                    "",
+                )
+
+        unsupported = replace(fedora, distribution="unsupported-rpm")
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "unsupported RPM distribution",
+        ):
+            package_lifecycle_lab.historical_transition_bootstrap(
+                unsupported, "4.03.2"
+            )
+
+        for spec in (fedora, alma):
+            with self.subTest(distribution=spec.distribution, routing=True):
+                runner = FakePodmanRunner()
+                transition = package_lifecycle_lab.historical_transition_bootstrap(
+                    spec, "4.03.2"
+                )
+                with mock.patch.object(
+                    package_lifecycle_lab,
+                    "historical_transition_bootstrap",
+                    return_value=transition,
+                ):
+                    report = package_lifecycle_lab.run_lab(
+                        self.args(),
+                        runner=runner,
+                        platforms=(spec,),
+                        host_architecture="x86_64",
+                    )
+                self.assertEqual(
+                    report["platforms"][0]["status"],
+                    "pass",
+                    report["platforms"][0],
+                )
+                builds = [call for call in runner.calls if call[1] == "build"]
+                self.assertEqual(len(builds), 2)
+                common_tag = builds[0][builds[0].index("--tag") + 1]
+                historical_tag = builds[1][builds[1].index("--tag") + 1]
+                self.assertNotEqual(common_tag, historical_tag)
+                self.assertTrue(historical_tag.endswith("-historical-upgrade"))
+                creates = [
+                    call
+                    for call in runner.calls
+                    if call[1] == "create"
+                    and any(value.endswith(":/results:rw") for value in call)
+                ]
+                scenario_images = {
+                    next(
+                        value.removeprefix("SCENARIO=")
+                        for index, value in enumerate(call)
+                        if call[index - 1] == "--env"
+                        and value.startswith("SCENARIO=")
+                    ): call[-1]
+                    for call in creates
+                }
+                self.assertEqual(
+                    scenario_images,
+                    {
+                        "upgrade-rollback": historical_tag,
+                        "remove": common_tag,
+                    },
+                )
+                removed_tags = [
+                    call[-1]
+                    for call in runner.calls
+                    if call[1:3] == ("image", "rm")
+                ]
+                self.assertEqual(removed_tags, [historical_tag, common_tag])
+                for tag in (common_tag, historical_tag):
+                    self.assertIn(
+                        ("podman", "image", "exists", tag), runner.calls
+                    )
 
     def test_failed_event_fails_platform_and_overall_report(self) -> None:
         runner = FakePodmanRunner(event_status="fail")

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -26,6 +26,24 @@ RELEASE_MANAGER_WORKFLOW = (
 )
 RETIRED_PLATFORM = "free" + "bsd"
 RETIRED_PACKAGE_SUFFIX = "." + "txz"
+V4033_LIFECYCLE_REPAIR_PATHS = (
+    ".github/workflows/release-manager.yml",
+    ".github/workflows/release-qualification.yml",
+    "scripts/ci/package_lifecycle_lab.py",
+    "scripts/ci/package_lifecycle_lab_test.py",
+    "scripts/ci/release_gate_test.py",
+    "scripts/ci/release_qualification_adapter_test.py",
+    "scripts/ci/release_qualification_workflow_test.py",
+    "src/core/syswarden-cli/cmd/install.go",
+    "src/core/syswarden-cli/cmd/reload.go",
+    "src/core/syswarden-cli/cmd/reload_test.go",
+    "src/core/syswarden-cli/pkg/integration/removal_linux.go",
+    "src/core/syswarden-cli/pkg/integration/removal_linux_test.go",
+    "src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go",
+    "src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go",
+    "src/core/syswarden-cli/pkg/integration/siem_linux.go",
+    "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
+)
 
 
 def workflow_step_script(workflow: str, step_name: str) -> str:
@@ -1467,10 +1485,10 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD)"), 8
+            workflow.count("git rev-list --parents -n 1 HEAD)"), 10
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD^)"), 8
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 10
         )
         self.assertEqual(
             workflow.count(
@@ -1510,8 +1528,8 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         for script in scripts:
-            self.assertEqual(script.count("--tag-phase"), 4)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 6)
+            self.assertEqual(script.count("--tag-phase"), 5)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 7)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -1524,18 +1542,18 @@ class ReleaseGateTests(unittest.TestCase):
                 script.count(
                     "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD"
                 ),
-                3,
+                4,
             )
-            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 3)
+            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 4)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                3,
+                4,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 3)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 3)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 4)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 4)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 6,
-                "scripts/ci/release_gate_test.py": 6,
+                ".github/workflows/release-manager.yml": 8,
+                "scripts/ci/release_gate_test.py": 8,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -1616,17 +1634,29 @@ class ReleaseGateTests(unittest.TestCase):
                 "--tag-phase",
                 '--commit-message "${v4033_parent_message}"',
             )
+            shared_with_lifecycle_repair = {
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                'for tree_ref in HEAD^ HEAD; do',
+                'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"',
+                '"${tree_mode}" != "100644"',
+                '"${tree_type}" != "blob"',
+                "--tag-phase",
+            }
             for contract in required:
-                self.assertEqual(block.count(contract), 1, contract)
-            expected_followup_paths = (
-                ".github/workflows/release-manager.yml",
-                "scripts/ci/release_gate_test.py",
-                "scripts/versionctl/repository.go",
-                "scripts/versionctl/repository_test.go",
-            )
-            for path in expected_followup_paths:
-                self.assertEqual(block.count(f'M "{path}"'), 1, path)
-                self.assertEqual(block.count(f'"{path}"'), 2, path)
+                expected_count = 2 if contract in shared_with_lifecycle_repair else 1
+                self.assertEqual(block.count(contract), expected_count, contract)
+            expected_followup_path_counts = {
+                ".github/workflows/release-manager.yml": (2, 4),
+                "scripts/ci/release_gate_test.py": (2, 4),
+                "scripts/versionctl/repository.go": (1, 2),
+                "scripts/versionctl/repository_test.go": (1, 2),
+            }
+            for path, (status_count, quoted_count) in (
+                expected_followup_path_counts.items()
+            ):
+                self.assertEqual(block.count(f'M "{path}"'), status_count, path)
+                self.assertEqual(block.count(f'"{path}"'), quoted_count, path)
             protected_release_paths = (
                 "changelog.md",
                 "README.md",
@@ -1638,9 +1668,14 @@ class ReleaseGateTests(unittest.TestCase):
                 "src/core/syswarden-core/webhook/discord.go",
             )
             for path in protected_release_paths:
-                self.assertEqual(block.count(path), 1, path)
-            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 1)
-            self.assertEqual(block.count("--tag-phase"), 1)
+                expected_count = (
+                    3
+                    if path == "src/core/syswarden-cli/cmd/install.go"
+                    else 1
+                )
+                self.assertEqual(block.count(path), expected_count, path)
+            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 2)
+            self.assertEqual(block.count("--tag-phase"), 2)
 
     def v4033_followup_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1720,6 +1755,180 @@ class ReleaseGateTests(unittest.TestCase):
         subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
         subprocess.run(
             ["git", "-C", repository, "commit", "-q", "-m", "reviewed fix"],
+            check=True,
+        )
+        return repository
+
+    def v4033_lifecycle_repair_blocks(self, workflow: str) -> list[str]:
+        recovery_blocks = self.v4033_recovery_blocks(workflow)
+        start = (
+            'if [[ "${v4033_parent_sha}" == '
+            '"19e4add763e935a29219c20c86586b3557a441c9" ]]; then\n'
+        )
+        end = (
+            '\n    elif [[ "${v4033_parent_sha}" != '
+            '"689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then\n'
+        )
+        blocks = []
+        for recovery_block in recovery_blocks:
+            self.assertEqual(recovery_block.count(start), 1)
+            remainder = recovery_block.split(start, 1)[1]
+            self.assertIn(end, remainder)
+            blocks.append(start + remainder.split(end, 1)[0])
+        self.assertEqual(blocks[0], blocks[1])
+        return blocks
+
+    def assert_v4033_lifecycle_repair_contract(self, workflow: str) -> None:
+        repair_blocks = self.v4033_lifecycle_repair_blocks(workflow)
+        for block in repair_blocks:
+            required = (
+                '"19e4add763e935a29219c20c86586b3557a441c9"',
+                'v4033_repair_base_sha="$(git rev-parse HEAD^^)"',
+                '"${v4033_repair_base_sha}" != '
+                '"689871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+                'v4033_repair_release_base_sha="$(git rev-parse HEAD^^^)"',
+                '"${v4033_repair_release_base_sha}" != '
+                '"b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+                'v4033_repair_parent_subject="$(git log -1 --format=%s HEAD^)"',
+                "v4033_expected_repair_parent_subject="
+                "'CI : bind one-time v4.03.3 changelog seal (#119)'",
+                '"${v4033_repair_parent_subject}" != '
+                '"${v4033_expected_repair_parent_subject}"',
+                'v4033_repair_base_subject="$(git log -1 --format=%s HEAD^^)"',
+                "v4033_expected_repair_base_subject="
+                "'Patch : correct webhook, firewall and OSINT handling (#118)'",
+                '"${v4033_repair_base_subject}" != '
+                '"${v4033_expected_repair_base_subject}"',
+                'v4033_repair_release_base_subject="$(git log -1 --format=%s HEAD^^^)"',
+                "v4033_expected_repair_release_base_subject="
+                "'CI : make release inventory comparison portable (#117)'",
+                '"${v4033_repair_release_base_subject}" != '
+                '"${v4033_expected_repair_release_base_subject}"',
+                "v4033_repair_subject_pattern="
+                "'^Qualification : repair v4.03.3 lifecycle qualification "
+                "\\(#[1-9][0-9]*\\)$'",
+                '[[ ! "${commit_subject}" =~ ${v4033_repair_subject_pattern} ]]',
+                'v4033_repair_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_repair_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4033_repair_base_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
+                'v4033_repair_release_base_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^^)"',
+                "${#v4033_repair_head_line[@]} != 2",
+                "${#v4033_repair_parent_line[@]} != 2",
+                "${#v4033_repair_base_line[@]} != 2",
+                "${#v4033_repair_release_base_line[@]} != 2",
+                "# BEGIN exact v4.03.3 lifecycle-repair diff contract",
+                "# END exact v4.03.3 lifecycle-repair diff contract",
+                "expected_v4033_repair_diff=(",
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "${#actual_v4033_repair_diff[@]} != "
+                "${#expected_v4033_repair_diff[@]}",
+                'for tree_ref in HEAD^ HEAD; do',
+                'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"',
+                '"${tree_mode}" != "100644"',
+                '"${tree_type}" != "blob"',
+                'v4033_repair_versioning_message="$(git log -1 --format=%B HEAD^^)"',
+                '--base-ref "${v4033_repair_release_base_sha}"',
+                "--tag-phase",
+                '--commit-message "${v4033_repair_versioning_message}"',
+            )
+            for contract in required:
+                self.assertEqual(block.count(contract), 1, contract)
+            self.assertEqual(len(V4033_LIFECYCLE_REPAIR_PATHS), 16)
+            for path in V4033_LIFECYCLE_REPAIR_PATHS:
+                self.assertEqual(block.count(f'M "{path}"'), 1, path)
+                self.assertEqual(block.count(f'"{path}"'), 2, path)
+            for protected_path in (
+                "changelog.md",
+                "README.md",
+                "docs/",
+                "scripts/versionctl/repository.go",
+                "scripts/versionctl/repository_test.go",
+            ):
+                self.assertNotIn(protected_path, block)
+            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 1)
+
+    def v4033_lifecycle_repair_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_lifecycle_repair_blocks(workflow)[0]
+        start = "v4033_repair_subject_pattern="
+        end = (
+            'read -r -a v4033_repair_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
+    def exact_v4033_lifecycle_repair_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_lifecycle_repair_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.3 lifecycle-repair diff contract\n"
+        end = "# END exact v4.03.3 lifecycle-repair diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def make_v4033_lifecycle_repair_diff_repository(
+        self, name: str, mutation: str | None
+    ) -> Path:
+        repository = self.root / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        repair_paths = [repository / path for path in V4033_LIFECYCLE_REPAIR_PATHS]
+        protected_paths = {
+            "changelog": repository / "changelog.md",
+            "readme": repository / "README.md",
+            "documentation": repository / "docs/maintainers/release.md",
+            "version target": repository
+            / "src/core/syswarden-cli/pkg/system/upgrade.go",
+        }
+        for path in [*repair_paths, *protected_paths.values()]:
+            self.write_file(path, b"reviewed PR119 parent\n")
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed PR119"],
+            check=True,
+        )
+        for path in repair_paths:
+            if mutation != "unchanged path" or path != repair_paths[-1]:
+                path.write_bytes(b"reviewed v4.03.3 lifecycle repair\n")
+        if mutation in protected_paths:
+            protected_paths[mutation].write_bytes(b"unauthorized release drift\n")
+        elif mutation == "extra file":
+            self.write_file(repository / "unauthorized.txt", b"unexpected\n")
+        elif mutation == "mode":
+            repair_paths[0].chmod(0o755)
+        elif mutation == "symlink":
+            repair_paths[4].unlink()
+            repair_paths[4].symlink_to("unauthorized-target")
+        elif mutation == "rename":
+            repair_paths[-1].rename(
+                repair_paths[-1].with_name("renamed_waf_logs_linux.go")
+            )
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed repair"],
             check=True,
         )
         return repository
@@ -1955,6 +2164,7 @@ class ReleaseGateTests(unittest.TestCase):
     ) -> None:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         self.assert_v4033_preserved_version_recovery_contract(workflow)
+        self.assert_v4033_lifecycle_repair_contract(workflow)
 
     def test_release_manager_v4033_contract_rejects_mutations(self) -> None:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -2147,6 +2357,271 @@ class ReleaseGateTests(unittest.TestCase):
                     self.assertEqual(result.returncode, 0, result.stderr)
                 else:
                     self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_release_manager_v4033_lifecycle_repair_contract_rejects_mutations(
+        self,
+    ) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        mutations = {
+            "exact PR119 parent": workflow.replace(
+                "19e4add763e935a29219c20c86586b3557a441c9",
+                "29e4add763e935a29219c20c86586b3557a441c9",
+            ),
+            "PR118 resolution": workflow.replace(
+                'v4033_repair_base_sha="$(git rev-parse HEAD^^)"',
+                'v4033_repair_base_sha="$(git rev-parse HEAD^^^)"',
+            ),
+            "exact PR118": workflow.replace(
+                '"${v4033_repair_base_sha}" != '
+                '"689871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+                '"${v4033_repair_base_sha}" != '
+                '"789871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+            ),
+            "PR117 resolution": workflow.replace(
+                'v4033_repair_release_base_sha="$(git rev-parse HEAD^^^)"',
+                'v4033_repair_release_base_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact PR117": workflow.replace(
+                '"${v4033_repair_release_base_sha}" != '
+                '"b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+                '"${v4033_repair_release_base_sha}" != '
+                '"c9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+            ),
+            "PR119 subject": workflow.replace(
+                "CI : bind one-time v4.03.3 changelog seal (#119)",
+                "CI : bind reusable v4.03.3 changelog seal (#119)",
+            ),
+            "PR118 subject": workflow.replace(
+                "Patch : correct webhook, firewall and OSINT handling (#118)",
+                "Patch : correct webhook and firewall handling (#118)",
+            ),
+            "PR117 subject": workflow.replace(
+                "CI : make release inventory comparison portable (#117)",
+                "CI : make release inventory comparison broad (#117)",
+            ),
+            "repair subject": workflow.replace(
+                "Qualification : repair v4.03.3 lifecycle qualification",
+                "Qualification : repair reusable lifecycle qualification",
+            ),
+            "repair subject comparison": workflow.replace(
+                '[[ ! "${commit_subject}" =~ ${v4033_repair_subject_pattern} ]]',
+                '[[ "${commit_subject}" =~ ${v4033_repair_subject_pattern} ]]',
+            ),
+            "linear head": workflow.replace(
+                'v4033_repair_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_repair_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "linear PR119": workflow.replace(
+                'v4033_repair_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4033_repair_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
+            ),
+            "linear comparison": workflow.replace(
+                "${#v4033_repair_release_base_line[@]} != 2",
+                "${#v4033_repair_release_base_line[@]} == 2",
+            ),
+            "diff rename policy": workflow.replace(
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "git diff-tree --no-commit-id --name-status -r -z HEAD^ HEAD",
+            ),
+            "diff status": workflow.replace(
+                'M "scripts/ci/package_lifecycle_lab.py"',
+                'A "scripts/ci/package_lifecycle_lab.py"',
+            ),
+            "diff path": workflow.replace(
+                'M "scripts/ci/release_qualification_workflow_test.py"',
+                'M "scripts/ci/release_workflow_test.py"',
+            ),
+            "diff count comparison": workflow.replace(
+                "${#actual_v4033_repair_diff[@]} != "
+                "${#expected_v4033_repair_diff[@]}",
+                "${#actual_v4033_repair_diff[@]} == "
+                "${#expected_v4033_repair_diff[@]}",
+            ),
+            "blob mode": workflow.replace(
+                '"${tree_mode}" != "100644"',
+                '"${tree_mode}" != "100755"',
+            ),
+            "replay base": workflow.replace(
+                '--base-ref "${v4033_repair_release_base_sha}"',
+                '--base-ref HEAD^',
+            ),
+            "replay subject": workflow.replace(
+                'v4033_repair_versioning_message="$(git log -1 --format=%B HEAD^^)"',
+                'v4033_repair_versioning_message="$(git log -1 --format=%B HEAD^)"',
+            ),
+        }
+        mutations["duplicated block divergence"] = workflow.replace(
+            "19e4add763e935a29219c20c86586b3557a441c9",
+            "29e4add763e935a29219c20c86586b3557a441c9",
+            1,
+        )
+        for name, mutation in mutations.items():
+            with self.subTest(name=name):
+                self.assertNotEqual(mutation, workflow)
+                with self.assertRaises(AssertionError):
+                    self.assert_v4033_lifecycle_repair_contract(mutation)
+
+    def test_release_manager_v4033_lifecycle_repair_subject_is_exact(self) -> None:
+        script = self.v4033_lifecycle_repair_subject_gate_script()
+        cases = {
+            "valid": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#120)",
+                True,
+            ),
+            "bare": (
+                "Qualification : repair v4.03.3 lifecycle qualification",
+                False,
+            ),
+            "zero": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#0)",
+                False,
+            ),
+            "leading zero": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#0120)",
+                False,
+            ),
+            "non-numeric": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#PR)",
+                False,
+            ),
+            "wrong category": (
+                "CI : repair v4.03.3 lifecycle qualification (#120)",
+                False,
+            ),
+            "wrong version": (
+                "Qualification : repair v4.03.4 lifecycle qualification (#120)",
+                False,
+            ),
+            "double space": (
+                "Qualification : repair v4.03.3 lifecycle qualification  (#120)",
+                False,
+            ),
+            "trailing space": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#120) ",
+                False,
+            ),
+            "extra text": (
+                "Qualification : repair v4.03.3 lifecycle qualification (#120) extra",
+                False,
+            ),
+        }
+        for name, (subject, accepted) in cases.items():
+            with self.subTest(name=name):
+                environment = dict(os.environ)
+                environment["COMMIT_SUBJECT"] = subject
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=REPOSITORY,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_release_manager_v4033_lifecycle_repair_diff_is_exact(self) -> None:
+        script = self.exact_v4033_lifecycle_repair_diff_script()
+        mutations = (
+            None,
+            "extra file",
+            "changelog",
+            "readme",
+            "documentation",
+            "version target",
+            "unchanged path",
+            "mode",
+            "symlink",
+            "rename",
+        )
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=mutation or "exact"):
+                repository = self.make_v4033_lifecycle_repair_diff_repository(
+                    f"v4033-lifecycle-repair-diff-{index}", mutation
+                )
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=repository,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if mutation is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_v4033_lifecycle_repair_subject_preserves_version_contract(self) -> None:
+        repository = self.root / "v4033-version-contract"
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        version_paths = (
+            "src/core/syswarden-cli/pkg/system/upgrade.go",
+            "src/core/syswarden-tui/main.go",
+            "src/core/syswarden-cli/cmd/install.go",
+            "src/core/syswarden-cli/config/default.go",
+            "src/core/syswarden-cli/pkg/integration/webhook.go",
+            "src/core/syswarden-core/webhook/discord.go",
+            "README.md",
+            "changelog.md",
+        )
+        for relative in version_paths:
+            self.write_file(repository / relative, (REPOSITORY / relative).read_bytes())
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "v4.03.3 baseline"],
+            check=True,
+        )
+        go_cache = self.root / "go-cache"
+        go_tmp = self.root / "go-tmp"
+        go_cache.mkdir(mode=0o700)
+        go_tmp.mkdir(mode=0o700)
+        environment = dict(os.environ)
+        environment.update({"GOCACHE": str(go_cache), "GOTMPDIR": str(go_tmp)})
+        result = subprocess.run(
+            [
+                str(REPOSITORY / "scripts/versioning.sh"),
+                "validate-commit",
+                "--repo",
+                str(repository),
+                "--base-ref",
+                "HEAD",
+                "--commit-message",
+                "Qualification : repair v4.03.3 lifecycle qualification (#120)",
+            ],
+            cwd=REPOSITORY,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "Commit validation passed: non-versioning commit preserves v4.03.3",
+            result.stdout,
+        )
 
     def test_release_manager_bounds_v4032_to_current_amd64_candidate(
         self,

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -75,16 +75,19 @@ class AdapterFixture:
         self.evidence = root / "evidence"
         self.candidate = self.evidence / "packages" / "candidate"
         self.previous = self.evidence / "packages" / "previous"
+        self.package_tmp = self.evidence / "package-tmp"
         self.raw = self.evidence / "raw"
         self.bound = self.evidence / "bound"
         for directory in (
             self.repo,
             self.candidate,
             self.previous,
+            self.package_tmp,
             self.raw,
             self.bound,
         ):
             directory.mkdir(parents=True, exist_ok=True)
+        self.package_tmp.chmod(0o700)
         self.now = datetime.now(UTC).replace(microsecond=0)
         self._make_repository()
         self.commit = self._git("rev-parse", "HEAD")
@@ -201,6 +204,7 @@ class AdapterFixture:
             "podman": "podman",
             "pull_policy": "never",
             "scenario_timeout": 60,
+            "package_tmp_dir": self.package_tmp,
             "qualification_repository": self.repository,
             "qualification_release_sha": self.commit,
             "qualification_release_tag": self.version,

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -1099,6 +1099,81 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         self.assertIn("nftables-lab.rc", verdict)
         self.assertIn("all(.[]; . == 0)", verdict)
 
+    def test_package_lifecycle_uses_private_explicit_tmpdir_and_safe_cleanup(
+        self,
+    ) -> None:
+        def assert_contract(workflow: str) -> None:
+            workspace = workflow_step_script(
+                workflow, "Create Isolated Qualification Workspace"
+            )
+            lifecycle = workflow_step_script(
+                workflow, "Run and Aggregate Native AMD64 Package Lifecycle Shard"
+            )
+            cleanup = workflow_step_script(
+                workflow, "Remove Ephemeral Qualification Material"
+            )
+            for contract in (
+                'package_tmp_dir="${qualification_root}/package-tmp"',
+                'test ! -L "${package_tmp_dir}"',
+                '[[ -O "${package_tmp_dir}" ]]',
+                'test "$(stat -c \'%a\' "${package_tmp_dir}")" = "700"',
+                "printf 'PACKAGE_TMP_DIR=%s\\n' \"${package_tmp_dir}\"",
+            ):
+                self.assertIn(contract, workspace)
+            self.assertEqual(lifecycle.count('--package-tmp-dir "${PACKAGE_TMP_DIR}"'), 1)
+            for variable in ("TMPDIR", "TMP", "TEMP", "GOTMPDIR"):
+                self.assertEqual(
+                    len(
+                        re.findall(
+                            rf'(?m)^{variable}="\$\{{PACKAGE_TMP_DIR\}}" \\$',
+                            lifecycle,
+                        )
+                    ),
+                    2,
+                    variable,
+                )
+            for contract in (
+                'test "${PACKAGE_TMP_DIR}" = "${QUALIFICATION_ROOT}/package-tmp"',
+                'test ! -L "${PACKAGE_TMP_DIR}"',
+                '[[ -O "${PACKAGE_TMP_DIR}" ]]',
+                'test "$(stat -c \'%a\' "${PACKAGE_TMP_DIR}")" = "700"',
+                '"${PACKAGE_TMP_DIR}/.write-probe.XXXXXX"',
+            ):
+                self.assertIn(contract, lifecycle)
+            for contract in (
+                '"${PACKAGE_TMP_DIR}" != "${QUALIFICATION_ROOT}/package-tmp"',
+                'test ! -L "${PACKAGE_TMP_DIR}"',
+                '[[ -O "${PACKAGE_TMP_DIR}" ]]',
+                'test "$(stat -c \'%a\' "${PACKAGE_TMP_DIR}")" = "700"',
+                'find -P "${PACKAGE_TMP_DIR}" -xdev -mindepth 1 -delete',
+                'rmdir -- "${PACKAGE_TMP_DIR}"',
+                'test ! -e "${PACKAGE_TMP_DIR}"',
+            ):
+                self.assertIn(contract, cleanup)
+            self.assertNotIn('PACKAGE_TMP_DIR="/tmp', workflow)
+
+        assert_contract(self.workflow)
+        for old, new in (
+            (
+                'package_tmp_dir="${qualification_root}/package-tmp"',
+                'package_tmp_dir="/tmp/syswarden-package-tmp"',
+            ),
+            ('--package-tmp-dir "${PACKAGE_TMP_DIR}"', ""),
+            ('TMPDIR="${PACKAGE_TMP_DIR}"', 'TMPDIR="/tmp"'),
+            ('[[ -O "${PACKAGE_TMP_DIR}" ]]', ":"),
+            (
+                'test "$(stat -c \'%a\' "${PACKAGE_TMP_DIR}")" = "700"',
+                ":",
+            ),
+            ('test ! -L "${PACKAGE_TMP_DIR}"', ":"),
+            (
+                'find -P "${PACKAGE_TMP_DIR}" -xdev -mindepth 1 -delete',
+                'find -P /tmp -mindepth 1 -delete',
+            ),
+        ):
+            with self.subTest(mutation=old), self.assertRaises(AssertionError):
+                assert_contract(self.workflow.replace(old, new, 1))
+
     def test_unsigned_failure_evidence_uploads_before_x64_verdict(self) -> None:
         x64 = workflow_job(self.workflow, "qualify-release")
         upload = x64.index("Upload Exact Unsigned Qualification Evidence")

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -113,14 +113,11 @@ var installCmd = &cobra.Command{
 
 		// Phase 3: External Integrations & Log Bridges
 		fmt.Println("[SYSWARDEN] Starting Integrations & Log Bridges...")
-		if err := integration.SetupWAFLogForwarder(); err != nil {
-			return installStageError("WAF log bridge failed", err)
+		if err := setupRsyslogIntegrationsForInstall(); err != nil {
+			return err
 		}
 		if err := integration.SetupWebhooks(); err != nil {
 			return installStageError("webhook configuration failed", err)
-		}
-		if err := integration.SetupSIEM(); err != nil {
-			return installStageError("SIEM configuration failed", err)
 		}
 		if err := integration.SetupWazuh(); err != nil {
 			return installStageError("Wazuh configuration failed", err)
@@ -165,12 +162,24 @@ var installConfigPreflight = prepareInstallConfiguration
 var removeExactLegacyCompletionAfterInstall = integration.RemoveExactLegacyBashCompletion
 var quarantineLegacyDynamicBanIntervals = firewall.QuarantineLegacyDynamicBanIntervals
 var restartCoreServiceForInstall = restartCoreService
+var setupSIEMForInstall = integration.SetupSIEM
+var setupWAFForInstall = integration.SetupWAFLogForwarder
 var hostFirewallBackendPreflight = system.PreflightHostFirewallBackend
 var inspectInstallFirewallCompatibility = config.InspectHistoricalDefaultFirewallCompatibility
 var applyInstallFirewallCompatibility = config.ApplyHistoricalDefaultFirewallCompatibility
 var hostCronSchedulingPreflight = func(haEnabled bool) error {
 	_, err := system.PreflightRuntimeCronScheduling(haEnabled)
 	return err
+}
+
+func setupRsyslogIntegrationsForInstall() error {
+	if err := setupSIEMForInstall(); err != nil {
+		return installStageError("SIEM configuration failed", err)
+	}
+	if err := setupWAFForInstall(); err != nil {
+		return installStageError("WAF log bridge failed", err)
+	}
+	return nil
 }
 
 func preflightConfiguredCronScheduling() error {

--- a/src/core/syswarden-cli/cmd/reload.go
+++ b/src/core/syswarden-cli/cmd/reload.go
@@ -47,7 +47,7 @@ var reloadCmd = &cobra.Command{
 			fmt.Println("[WARN] WireGuard reload skipped because the authoritative firewall transaction failed.")
 		}
 
-		// Reconcile the WAF bridge first, then the optional SIEM forwarder.
+		// Reconcile the optional SIEM forwarder before its WAF-owned imfile input.
 		failures = append(failures, reloadRsyslogIntegrations()...)
 
 		// Re-apply AbuseIPDB / Telemetry configuration
@@ -86,13 +86,13 @@ var reloadCmd = &cobra.Command{
 
 func reloadRsyslogIntegrations() []error {
 	var failures []error
-	if err := setupWAFForReload(); err != nil {
-		fmt.Printf("[ERROR] WAF Log Bridge reload failed: %v\n", err)
-		failures = append(failures, fmt.Errorf("WAF log bridge reload: %w", err))
-	}
 	if err := setupSIEMForReload(); err != nil {
 		fmt.Printf("[ERROR] SIEM integration reload failed: %v\n", err)
 		failures = append(failures, fmt.Errorf("SIEM integration reload: %w", err))
+	}
+	if err := setupWAFForReload(); err != nil {
+		fmt.Printf("[ERROR] WAF Log Bridge reload failed: %v\n", err)
+		failures = append(failures, fmt.Errorf("WAF log bridge reload: %w", err))
 	}
 	return failures
 }

--- a/src/core/syswarden-cli/cmd/reload_test.go
+++ b/src/core/syswarden-cli/cmd/reload_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestReloadReconcilesWAFBeforeSIEMAndReportsBothFailures_SW2_PKG_001(t *testing.T) {
+func TestReloadReconcilesSIEMBeforeWAFAndReportsBothFailures_SW2_PKG_001(t *testing.T) {
 	previousWAF := setupWAFForReload
 	previousSIEM := setupSIEMForReload
 	t.Cleanup(func() {
@@ -23,14 +23,38 @@ func TestReloadReconcilesWAFBeforeSIEMAndReportsBothFailures_SW2_PKG_001(t *test
 		return errors.New("synthetic SIEM failure")
 	}
 	failures := reloadRsyslogIntegrations()
-	if !reflect.DeepEqual(calls, []string{"waf", "siem"}) {
+	if !reflect.DeepEqual(calls, []string{"siem", "waf"}) {
 		t.Fatalf("rsyslog reload order = %v", calls)
 	}
 	if len(failures) != 2 {
 		t.Fatalf("rsyslog reload failures = %v", failures)
 	}
-	if failures[0].Error() != "WAF log bridge reload: synthetic WAF failure" ||
-		failures[1].Error() != "SIEM integration reload: synthetic SIEM failure" {
+	if failures[0].Error() != "SIEM integration reload: synthetic SIEM failure" ||
+		failures[1].Error() != "WAF log bridge reload: synthetic WAF failure" {
 		t.Fatalf("rsyslog reload failures = %v", failures)
+	}
+}
+
+func TestInstallReconcilesSIEMBeforeWAF_SW2_PKG_001(t *testing.T) {
+	previousSIEM := setupSIEMForInstall
+	previousWAF := setupWAFForInstall
+	t.Cleanup(func() {
+		setupSIEMForInstall = previousSIEM
+		setupWAFForInstall = previousWAF
+	})
+	calls := []string{}
+	setupSIEMForInstall = func() error {
+		calls = append(calls, "siem")
+		return nil
+	}
+	setupWAFForInstall = func() error {
+		calls = append(calls, "waf")
+		return nil
+	}
+	if err := setupRsyslogIntegrationsForInstall(); err != nil {
+		t.Fatalf("install rsyslog integrations: %v", err)
+	}
+	if !reflect.DeepEqual(calls, []string{"siem", "waf"}) {
+		t.Fatalf("rsyslog install order = %v", calls)
 	}
 }

--- a/src/core/syswarden-cli/pkg/integration/removal_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/removal_linux.go
@@ -346,6 +346,44 @@ func inspectExactOwnedArtifact(
 	return inspection, nil
 }
 
+func selectExactOwnedArtifactAlternativeInDirectory(
+	directory *os.File,
+	name, label string,
+	uid, gid uint32,
+	alternatives ...[]byte,
+) (exactOwnedArtifactExpectation, bool, bool, error) {
+	if directory == nil || !validOwnedArtifactName(name) {
+		return exactOwnedArtifactExpectation{}, false, false, fmt.Errorf("invalid exact-artifact alternative selection")
+	}
+	present := false
+	inspected := false
+	for _, content := range alternatives {
+		if content == nil {
+			continue
+		}
+		inspected = true
+		expectation := exactContentExpectation(label, name, content, 0600)
+		inspection, err := inspectExactOwnedArtifact(directory, name, expectation, uid, gid)
+		if err != nil {
+			return exactOwnedArtifactExpectation{}, present, false, err
+		}
+		if !inspection.identity.exists {
+			if present {
+				return exactOwnedArtifactExpectation{}, false, false, fmt.Errorf("%s changed while selecting an exact generated variant", label)
+			}
+			return exactOwnedArtifactExpectation{}, false, false, nil
+		}
+		present = true
+		if inspection.exact {
+			return expectation, true, true, nil
+		}
+	}
+	if !inspected {
+		return exactOwnedArtifactExpectation{}, false, false, fmt.Errorf("no exact generated variants are available for %s", label)
+	}
+	return exactOwnedArtifactExpectation{}, present, false, nil
+}
+
 func exactArtifactQuarantineName(name string) string {
 	return "." + name + exactArtifactQuarantineSuffix
 }
@@ -891,25 +929,46 @@ func removeOwnedGeneratedArtifactsForPackageRemovalAtUsing(
 		return err
 	}
 
-	wafExpectation, hasWAFProvenance := exactOwnedArtifactExpectation{}, false
+	wafExpectation, hasWAFExpectation := exactOwnedArtifactExpectation{}, false
 	if record, exists := provenance.records[wafRsyslogConfigName]; exists {
 		wafExpectation = provenanceExpectation(
 			"SysWarden WAF rsyslog bridge", wafRsyslogConfigName, record,
 		)
-		hasWAFProvenance = true
+		hasWAFExpectation = true
 	}
-	if !hasWAFProvenance {
-		waf, _, renderErr := renderWAFRsyslogConfig(activeConfig.ModsecLogs)
+	if !hasWAFExpectation {
+		waf, _, renderErr := renderWAFRsyslogConfig(
+			activeConfig.ModsecLogs,
+			activeConfig.SiemEnabled,
+		)
 		if renderErr != nil {
 			options.warn(fmt.Sprintf("Preserving the WAF rsyslog bridge: cannot render expected bytes: %v", renderErr))
 		} else {
-			wafExpectation = exactContentExpectation(
-				"SysWarden WAF rsyslog bridge", wafRsyslogConfigName, []byte(waf), 0600,
+			legacyWAF, _, legacyRenderErr := renderLegacyV4032WAFRsyslogConfig(activeConfig.ModsecLogs)
+			if legacyRenderErr != nil {
+				return legacyRenderErr
+			}
+			selected, present, exact, selectErr := selectExactOwnedArtifactAlternativeInDirectory(
+				directory,
+				wafRsyslogConfigName,
+				"SysWarden WAF rsyslog bridge",
+				uid,
+				gid,
+				[]byte(waf),
+				[]byte(legacyWAF),
 			)
-			hasWAFProvenance = true
+			if selectErr != nil {
+				return fmt.Errorf("select exact WAF rsyslog variant before removal: %w", selectErr)
+			}
+			if exact {
+				wafExpectation = selected
+				hasWAFExpectation = true
+			} else if present {
+				options.warn("Preserving the WAF rsyslog bridge: bytes do not match the current or v4.03.2 generated variant.")
+			}
 		}
 	}
-	if hasWAFProvenance {
+	if hasWAFExpectation {
 		removed, err := removeExpectedRsyslogArtifactInDirectoryUsing(
 			directory, uid, gid,
 			wafExpectation,
@@ -929,14 +988,14 @@ func removeOwnedGeneratedArtifactsForPackageRemovalAtUsing(
 		}
 	}
 
-	siemExpectation, hasSIEMProvenance := exactOwnedArtifactExpectation{}, false
+	siemExpectation, hasSIEMExpectation := exactOwnedArtifactExpectation{}, false
 	if record, exists := provenance.records[rsyslogSIEMConfigName]; exists {
 		siemExpectation = provenanceExpectation(
 			"SysWarden SIEM rsyslog forwarder", rsyslogSIEMConfigName, record,
 		)
-		hasSIEMProvenance = true
+		hasSIEMExpectation = true
 	}
-	if !hasSIEMProvenance && activeConfig.SiemEnabled {
+	if !hasSIEMExpectation && activeConfig.SiemEnabled {
 		siem, renderErr := renderSIEMRsyslogConfig(
 			activeConfig.SiemIP, activeConfig.SiemPort,
 			activeConfig.SiemProto, activeConfig.SiemTLSCA,
@@ -944,13 +1003,34 @@ func removeOwnedGeneratedArtifactsForPackageRemovalAtUsing(
 		if renderErr != nil {
 			options.warn(fmt.Sprintf("Preserving the SIEM rsyslog forwarder: cannot render expected bytes: %v", renderErr))
 		} else {
-			siemExpectation = exactContentExpectation(
-				"SysWarden SIEM rsyslog forwarder", rsyslogSIEMConfigName, []byte(siem), 0600,
+			legacySIEM, legacyRenderErr := renderLegacyV4032SIEMRsyslogConfig(
+				activeConfig.SiemIP, activeConfig.SiemPort,
+				activeConfig.SiemProto, activeConfig.SiemTLSCA,
 			)
-			hasSIEMProvenance = true
+			if legacyRenderErr != nil {
+				return legacyRenderErr
+			}
+			selected, present, exact, selectErr := selectExactOwnedArtifactAlternativeInDirectory(
+				directory,
+				rsyslogSIEMConfigName,
+				"SysWarden SIEM rsyslog forwarder",
+				uid,
+				gid,
+				[]byte(siem),
+				[]byte(legacySIEM),
+			)
+			if selectErr != nil {
+				return fmt.Errorf("select exact SIEM rsyslog variant before removal: %w", selectErr)
+			}
+			if exact {
+				siemExpectation = selected
+				hasSIEMExpectation = true
+			} else if present {
+				options.warn("Preserving the SIEM rsyslog forwarder: bytes do not match the current or v4.03.2 generated variant.")
+			}
 		}
 	}
-	if hasSIEMProvenance {
+	if hasSIEMExpectation {
 		removed, err := removeExpectedRsyslogArtifactInDirectoryUsing(
 			directory, uid, gid, siemExpectation, rsyslogOptions,
 		)

--- a/src/core/syswarden-cli/pkg/integration/removal_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/removal_linux_test.go
@@ -636,7 +636,7 @@ func TestExactOwnedArtifactRemovalAcceptsGeneratedConfigBeyond64KiB_SW2_PKG_001(
 			0600,
 		)
 	}
-	rendered, active, err := renderWAFRsyslogConfig(filepath.Join(logDirectory, "*.log"))
+	rendered, active, err := renderWAFRsyslogConfig(filepath.Join(logDirectory, "*.log"), false)
 	if err != nil || active != logCount {
 		t.Fatalf("render large WAF glob = %d, %v", active, err)
 	}
@@ -845,7 +845,7 @@ func TestGeneratedRsyslogRemovalReactivatesAndPropagatesServiceFailure_SW2_PKG_0
 	}
 	stat := parentInfo.Sys().(*syscall.Stat_t)
 	activeConfig := config.NewFailSafeConfig()
-	waf, _, err := renderWAFRsyslogConfig(activeConfig.ModsecLogs)
+	waf, _, err := renderWAFRsyslogConfig(activeConfig.ModsecLogs, activeConfig.SiemEnabled)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -919,6 +919,65 @@ func TestGeneratedRsyslogRemovalSkipsDisabledSIEMArtifact_SW2_PKG_001(t *testing
 	}
 	if got, err := os.ReadFile(siemPath); err != nil || !bytes.Equal(got, operatorSIEM) { // #nosec G304 -- siemPath is confined to the private disabled-SIEM fixture root
 		t.Fatalf("disabled SIEM artifact = %q, %v", got, err)
+	}
+}
+
+func TestGeneratedRsyslogRemovalAcceptsCurrentAndV4032WAFWithoutProvenanceWhenSIEMEnabled_SW2_PKG_001(t *testing.T) {
+	activeConfig := config.NewFailSafeConfig()
+	activeConfig.SiemEnabled = true
+	activeConfig.SiemIP = "192.0.2.40"
+	activeConfig.SiemPort = "514"
+	activeConfig.SiemProto = "udp"
+	current, _, err := renderWAFRsyslogConfig(activeConfig.ModsecLogs, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, _, err := renderLegacyV4032WAFRsyslogConfig(activeConfig.ModsecLogs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current == legacy {
+		t.Fatal("current SIEM-enabled and legacy WAF fixtures are identical")
+	}
+	for name, rendered := range map[string]string{
+		"current":        current,
+		"legacy v4.03.2": legacy,
+	} {
+		t.Run(name, func(t *testing.T) {
+			parent := t.TempDir()
+			directory := filepath.Join(parent, wafRsyslogDirectoryName)
+			if err := os.Mkdir(directory, 0750); err != nil {
+				t.Fatal(err)
+			}
+			parentInfo, err := os.Stat(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stat := parentInfo.Sys().(*syscall.Stat_t)
+			path := filepath.Join(directory, wafRsyslogConfigName)
+			writeOwnedArtifactFixture(t, path, []byte(rendered), 0600)
+			activationCalls := 0
+			removeErr := removeOwnedGeneratedArtifactsForPackageRemovalAtUsing(
+				activeConfig,
+				parent,
+				stat.Uid,
+				stat.Gid,
+				defaultExactOwnedArtifactRemovalOptions(),
+				func(changed bool) error {
+					if !changed {
+						t.Fatal("WAF removal did not request changed-state activation")
+					}
+					activationCalls++
+					return nil
+				},
+			)
+			if removeErr != nil || activationCalls != 1 {
+				t.Fatalf("remove unprovenanced WAF variant = calls %d, %v", activationCalls, removeErr)
+			}
+			if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("unprovenanced WAF variant remains: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go
@@ -80,7 +80,7 @@ func TestRsyslogRenderersDoNotPermitContextBreakout_SW_CFG_002(t *testing.T) {
 	if err := os.WriteFile(pattern, []byte("fixture\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	waf, active, err := renderWAFRsyslogConfig(pattern)
+	waf, active, err := renderWAFRsyslogConfig(pattern, false)
 	if err != nil || active != 1 {
 		t.Fatalf("renderWAFRsyslogConfig() active=%d error=%v", active, err)
 	}
@@ -108,8 +108,69 @@ func TestRsyslogRenderersDoNotPermitContextBreakout_SW_CFG_002(t *testing.T) {
 	}
 }
 
+func TestRsyslogRenderersGiveWAFExclusiveImfileOwnership_SW2_PKG_001(t *testing.T) {
+	siem, err := renderSIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(siem, "imfile") || strings.Contains(siem, "/var/log/syswarden/waf.json") {
+		t.Fatalf("SIEM forwarding config retained input-module ownership:\n%s", siem)
+	}
+
+	wafWithoutSIEM, active, err := renderWAFRsyslogConfig("", false)
+	if err != nil || active != 0 {
+		t.Fatalf("render WAF without SIEM telemetry = active %d, %v", active, err)
+	}
+	if strings.Contains(wafWithoutSIEM, "/var/log/syswarden/waf.json") {
+		t.Fatalf("disabled SIEM telemetry remains in WAF config:\n%s", wafWithoutSIEM)
+	}
+
+	wafWithSIEM, active, err := renderWAFRsyslogConfig("", true)
+	if err != nil || active != 0 {
+		t.Fatalf("render WAF with SIEM telemetry = active %d, %v", active, err)
+	}
+	if strings.Count(wafWithSIEM, `module(load="imfile"`) != 1 {
+		t.Fatalf("WAF config does not own exactly one imfile load:\n%s", wafWithSIEM)
+	}
+	if strings.Count(siem+wafWithSIEM, `module(load="imfile"`) != 1 {
+		t.Fatalf("combined SIEM and WAF config does not contain exactly one imfile load:\n%s\n%s", siem, wafWithSIEM)
+	}
+	if strings.Count(wafWithSIEM, `File="/var/log/syswarden/waf.json"`) != 1 ||
+		strings.Count(wafWithSIEM, `Tag="syswarden-waf-json"`) != 1 {
+		t.Fatalf("WAF config does not contain exactly one SIEM telemetry input:\n%s", wafWithSIEM)
+	}
+	telemetryStart := strings.Index(wafWithSIEM, "# SYSWARDEN WAAP Native JSON Telemetry")
+	if telemetryStart < 0 {
+		t.Fatalf("WAF SIEM telemetry block is incomplete:\n%s", wafWithSIEM)
+	}
+	telemetryEnd := strings.Index(wafWithSIEM[telemetryStart:], "template(name=\"SYSWARDENRaw\"")
+	if telemetryEnd < 0 {
+		t.Fatalf("WAF SIEM telemetry block is incomplete:\n%s", wafWithSIEM)
+	}
+	telemetry := wafWithSIEM[telemetryStart : telemetryStart+telemetryEnd]
+	if strings.Contains(telemetry, `ruleset="waf_bridge"`) {
+		t.Fatalf("SIEM telemetry would recurse through the WAF ruleset:\n%s", telemetry)
+	}
+
+	legacy, err := renderLegacyV4032SIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLegacy := "*.* @192.0.2.40:514\n\n" +
+		"# SYSWARDEN WAAP Native JSON Telemetry\n" +
+		"module(load=\"imfile\" PollingInterval=\"10\")\n" +
+		"input(type=\"imfile\"\n" +
+		"      File=\"/var/log/syswarden/waf.json\"\n" +
+		"      Tag=\"syswarden-waf-json\"\n" +
+		"      Severity=\"alert\"\n" +
+		"      Facility=\"local7\")\n"
+	if legacy != wantLegacy {
+		t.Fatalf("legacy v4.03.2 SIEM bytes changed:\nwant:\n%s\ngot:\n%s", wantLegacy, legacy)
+	}
+}
+
 func TestWAFRsyslogBridgeStopsAllSysWardenOwnedMarkers_SW2_H2(t *testing.T) {
-	waf, active, err := renderWAFRsyslogConfig("")
+	waf, active, err := renderWAFRsyslogConfig("", false)
 	if err != nil || active != 0 {
 		t.Fatalf("renderWAFRsyslogConfig() active=%d error=%v", active, err)
 	}

--- a/src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/rsyslog_provenance_linux_test.go
@@ -328,44 +328,162 @@ func TestSIEMDisableServiceFailureRestoresForwarderAndKeepsProvenance_SW2_PKG_00
 	}
 }
 
-func TestSIEMDisableRemovesExactPreRegistryV4028ForwarderFromRetainedFields_SW2_PKG_001(t *testing.T) {
+func TestSIEMDisableRemovesExactUntrackedCurrentAndV4032Forwarders_SW2_PKG_001(t *testing.T) {
+	current, err := renderSIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := renderLegacyV4032SIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alternatives := [][]byte{[]byte(current), []byte(legacy)}
+	for name, rendered := range map[string]string{
+		"current action-only": current,
+		"legacy v4.03.2":      legacy,
+	} {
+		t.Run(name, func(t *testing.T) {
+			parent := t.TempDir()
+			uid, gid := testOwnedParentIdentity(t, parent)
+			directory := filepath.Join(parent, wafRsyslogDirectoryName)
+			if err := os.Mkdir(directory, 0750); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(directory, rsyslogSIEMConfigName)
+			writeOwnedArtifactFixture(t, path, []byte(rendered), 0600)
+			activationCalls := 0
+			err := disableSIEMRsyslogForwarderAtUsing(
+				parent,
+				uid,
+				gid,
+				alternatives,
+				defaultExactOwnedArtifactRemovalOptions(),
+				func(changed bool) error {
+					if !changed {
+						t.Fatal("untracked SIEM disable did not request changed-state activation")
+					}
+					activationCalls++
+					return nil
+				},
+				allowTestRsyslogMutation,
+			)
+			if err != nil || activationCalls != 1 {
+				t.Fatalf("untracked SIEM disable = calls %d, %v", activationCalls, err)
+			}
+			if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("untracked SIEM forwarder remains: %v", statErr)
+			}
+			registry, readErr := readRsyslogProvenanceRegistryAtUsing(parent, uid, gid)
+			if readErr != nil || registry.exists {
+				t.Fatalf("untracked SIEM disable invented provenance = %#v, %v", registry, readErr)
+			}
+		})
+	}
+}
+
+func TestSIEMDisablePreservesUntrackedNonGeneratedBytes_SW2_PKG_001(t *testing.T) {
 	parent := t.TempDir()
 	uid, gid := testOwnedParentIdentity(t, parent)
 	directory := filepath.Join(parent, wafRsyslogDirectoryName)
 	if err := os.Mkdir(directory, 0750); err != nil {
 		t.Fatal(err)
 	}
-	rendered, err := renderSIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	current, err := renderSIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
 	if err != nil {
 		t.Fatal(err)
 	}
+	legacy, err := renderLegacyV4032SIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	operator := []byte("operator-owned SIEM bytes\n")
 	path := filepath.Join(directory, rsyslogSIEMConfigName)
-	writeOwnedArtifactFixture(t, path, []byte(rendered), 0600)
+	writeOwnedArtifactFixture(t, path, operator, 0600)
+	warnings := []string{}
+	options := defaultExactOwnedArtifactRemovalOptions()
+	options.warn = func(message string) { warnings = append(warnings, message) }
 	activationCalls := 0
 	err = disableSIEMRsyslogForwarderAtUsing(
 		parent,
 		uid,
 		gid,
-		[]byte(rendered),
-		defaultExactOwnedArtifactRemovalOptions(),
+		[][]byte{[]byte(current), []byte(legacy)},
+		options,
+		func(bool) error { activationCalls++; return nil },
+		allowTestRsyslogMutation,
+	)
+	if err == nil || !strings.Contains(err.Error(), "do not match the current or v4.03.2") {
+		t.Fatalf("untracked operator SIEM disable error = %v", err)
+	}
+	if activationCalls != 0 {
+		t.Fatalf("untracked operator SIEM triggered %d activations", activationCalls)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || !bytes.Equal(got, operator) { // #nosec G304 -- path is confined to the private untracked SIEM fixture root
+		t.Fatalf("untracked operator SIEM bytes = %q, %v", got, readErr)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("untracked operator SIEM warnings = %v", warnings)
+	}
+}
+
+func TestSIEMProducerMigratesV4032ConfigAndRecordsCurrentProvenanceBeforeWAF_SW2_PKG_001(t *testing.T) {
+	parent := t.TempDir()
+	uid, gid := testOwnedParentIdentity(t, parent)
+	directory := filepath.Join(parent, wafRsyslogDirectoryName)
+	if err := os.Mkdir(directory, 0750); err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := renderLegacyV4032SIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := renderSIEMRsyslogConfig("192.0.2.40", "514", "udp", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, rsyslogSIEMConfigName)
+	writeOwnedArtifactFixture(t, path, []byte(legacy), 0600)
+	record := func(directory *os.File, name string, content []byte) error {
+		return recordRsyslogArtifactProvenanceInDirectoryUsing(
+			directory,
+			uid,
+			gid,
+			name,
+			content,
+			func(directory *os.File) error { return directory.Sync() },
+		)
+	}
+	activationCalls := 0
+	err = reconcileRsyslogArtifactWithProvenanceAtUsing(
+		parent,
+		uid,
+		gid,
+		rsyslogSIEMConfigName,
+		"SIEM forwarder",
+		[]byte(current),
 		func(changed bool) error {
 			if !changed {
-				t.Fatal("pre-registry SIEM disable did not request changed-state activation")
+				t.Fatal("legacy SIEM migration was not reported as changed")
 			}
 			activationCalls++
 			return nil
 		},
+		record,
 		allowTestRsyslogMutation,
 	)
 	if err != nil || activationCalls != 1 {
-		t.Fatalf("pre-registry SIEM disable = calls %d, %v", activationCalls, err)
+		t.Fatalf("migrate v4.03.2 SIEM config = calls %d, %v", activationCalls, err)
 	}
-	if _, statErr := os.Lstat(path); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("pre-registry SIEM forwarder remains: %v", statErr)
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != current { // #nosec G304 -- path is confined to the private SIEM migration fixture root
+		t.Fatalf("migrated SIEM config = %q, %v", got, readErr)
 	}
 	registry, readErr := readRsyslogProvenanceRegistryAtUsing(parent, uid, gid)
-	if readErr != nil || registry.exists {
-		t.Fatalf("pre-registry SIEM disable invented provenance = %#v, %v", registry, readErr)
+	if readErr != nil || !registry.exists {
+		t.Fatalf("migrated SIEM provenance = %#v, %v", registry, readErr)
+	}
+	recorded, exists := registry.records[rsyslogSIEMConfigName]
+	if !exists || recorded.size != int64(len(current)) || recorded.digest != sha256.Sum256([]byte(current)) {
+		t.Fatalf("migrated SIEM provenance record = %#v", recorded)
 	}
 }
 

--- a/src/core/syswarden-cli/pkg/integration/siem_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/siem_linux.go
@@ -40,14 +40,25 @@ func renderSIEMRsyslogConfig(ip, port, protocol, tlsCA string) (string, error) {
 		return "", fmt.Errorf("unsupported rsyslog transport %q", protocol)
 	}
 
-	rendered.WriteString("\n# SYSWARDEN WAAP Native JSON Telemetry\n")
-	rendered.WriteString("module(load=\"imfile\" PollingInterval=\"10\")\n")
-	rendered.WriteString("input(type=\"imfile\"\n")
-	rendered.WriteString("      File=\"/var/log/syswarden/waf.json\"\n")
-	rendered.WriteString("      Tag=\"syswarden-waf-json\"\n")
-	rendered.WriteString("      Severity=\"alert\"\n")
-	rendered.WriteString("      Facility=\"local7\")\n")
 	return rendered.String(), nil
+}
+
+const rsyslogLegacyV4032SIEMTelemetryInput = `
+# SYSWARDEN WAAP Native JSON Telemetry
+module(load="imfile" PollingInterval="10")
+input(type="imfile"
+      File="/var/log/syswarden/waf.json"
+      Tag="syswarden-waf-json"
+      Severity="alert"
+      Facility="local7")
+`
+
+func renderLegacyV4032SIEMRsyslogConfig(ip, port, protocol, tlsCA string) (string, error) {
+	rendered, err := renderSIEMRsyslogConfig(ip, port, protocol, tlsCA)
+	if err != nil {
+		return "", err
+	}
+	return rendered + rsyslogLegacyV4032SIEMTelemetryInput, nil
 }
 
 func reconcileSIEMRsyslogConfigAtUsing(
@@ -68,20 +79,28 @@ func reconcileSIEMRsyslogConfigAtUsing(
 }
 
 func disableSIEMRsyslogForwarder() error {
-	var historicalExpected []byte
+	var untrackedExpected [][]byte
 	if rendered, err := renderSIEMRsyslogConfig(
 		config.GlobalConfig.SiemIP,
 		config.GlobalConfig.SiemPort,
 		config.GlobalConfig.SiemProto,
 		config.GlobalConfig.SiemTLSCA,
 	); err == nil {
-		historicalExpected = []byte(rendered)
+		untrackedExpected = append(untrackedExpected, []byte(rendered))
+	}
+	if rendered, err := renderLegacyV4032SIEMRsyslogConfig(
+		config.GlobalConfig.SiemIP,
+		config.GlobalConfig.SiemPort,
+		config.GlobalConfig.SiemProto,
+		config.GlobalConfig.SiemTLSCA,
+	); err == nil {
+		untrackedExpected = append(untrackedExpected, []byte(rendered))
 	}
 	return disableSIEMRsyslogForwarderAtUsing(
 		wafRsyslogParentDirectory,
 		0,
 		0,
-		historicalExpected,
+		untrackedExpected,
 		defaultExactOwnedArtifactRemovalOptions(),
 		reconcileWAFRsyslogService,
 		requireRsyslogMutationWithoutRemovalBarrier,
@@ -91,7 +110,7 @@ func disableSIEMRsyslogForwarder() error {
 func disableSIEMRsyslogForwarderAtUsing(
 	parentPath string,
 	uid, gid uint32,
-	historicalExpected []byte,
+	untrackedExpected [][]byte,
 	options exactOwnedArtifactRemovalOptions,
 	activate func(bool) error,
 	preflight rsyslogMutationPreflight,
@@ -122,21 +141,35 @@ func disableSIEMRsyslogForwarderAtUsing(
 		expectation = provenanceExpectation(
 			"SysWarden SIEM rsyslog forwarder", rsyslogSIEMConfigName, record,
 		)
-	} else if historicalExpected != nil {
-		expectation = exactContentExpectation(
-			"historical SysWarden SIEM rsyslog forwarder",
-			rsyslogSIEMConfigName,
-			historicalExpected,
-			0600,
-		)
 	} else {
-		if err := requireOwnedArtifactAbsent(
-			directory, rsyslogSIEMConfigName, "untracked SysWarden SIEM rsyslog forwarder",
-		); err != nil {
-			options.warn("Preserving the SIEM rsyslog forwarder because no exact SysWarden provenance is available.")
-			return fmt.Errorf("cannot safely disable untracked SIEM rsyslog forwarder: %w", err)
+		if len(untrackedExpected) == 0 {
+			if err := requireOwnedArtifactAbsent(
+				directory, rsyslogSIEMConfigName, "untracked SysWarden SIEM rsyslog forwarder",
+			); err != nil {
+				options.warn("Preserving the SIEM rsyslog forwarder because no exact SysWarden provenance is available.")
+				return fmt.Errorf("cannot safely disable untracked SIEM rsyslog forwarder: %w", err)
+			}
+			return nil
 		}
-		return nil
+		selected, present, exact, selectErr := selectExactOwnedArtifactAlternativeInDirectory(
+			directory,
+			rsyslogSIEMConfigName,
+			"untracked SysWarden SIEM rsyslog forwarder",
+			uid,
+			gid,
+			untrackedExpected...,
+		)
+		if selectErr != nil {
+			return fmt.Errorf("select exact untracked SIEM rsyslog variant: %w", selectErr)
+		}
+		if !present {
+			return nil
+		}
+		if !exact {
+			options.warn("Preserving the SIEM rsyslog forwarder because no exact SysWarden provenance is available.")
+			return fmt.Errorf("cannot safely disable untracked SIEM rsyslog forwarder: bytes do not match the current or v4.03.2 generated variant")
+		}
+		expectation = selected
 	}
 	removalOptions := options
 	removalOptions.beforeCommit = func() error {

--- a/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/waf_logs_linux.go
@@ -157,6 +157,15 @@ input(type="imfile" File="/var/log/syslog" Tag="syswarden-waf" ruleset="waf_brid
 input(type="imfile" File="/var/log/messages" Tag="syswarden-waf" ruleset="waf_bridge")
 `
 
+const rsyslogSIEMTelemetryInput = `
+# SYSWARDEN WAAP Native JSON Telemetry
+input(type="imfile"
+      File="/var/log/syswarden/waf.json"
+      Tag="syswarden-waf-json"
+      Severity="alert"
+      Facility="local7")
+`
+
 const rsyslogWAFRuleset = `
 template(name="SYSWARDENRaw" type="string" string="%msg%\n")
 
@@ -168,7 +177,7 @@ ruleset(name="waf_bridge") {
 }
 `
 
-func renderWAFRsyslogConfig(rawPatterns string) (string, int, error) {
+func renderWAFRsyslogConfig(rawPatterns string, includeSIEMTelemetry bool) (string, int, error) {
 	patterns, err := validatedRsyslogLogPatterns(rawPatterns)
 	if err != nil {
 		return "", 0, err
@@ -185,15 +194,25 @@ func renderWAFRsyslogConfig(rawPatterns string) (string, int, error) {
 		}
 		fmt.Fprintf(&rendered, "input(type=\"imfile\" File=%s Tag=\"syswarden-waf\" ruleset=\"waf_bridge\")\n", quoted)
 	}
+	if includeSIEMTelemetry {
+		rendered.WriteString(rsyslogSIEMTelemetryInput)
+	}
 	rendered.WriteString(rsyslogWAFRuleset)
 	return rendered.String(), len(patterns), nil
+}
+
+func renderLegacyV4032WAFRsyslogConfig(rawPatterns string) (string, int, error) {
+	return renderWAFRsyslogConfig(rawPatterns, false)
 }
 
 // SetupWAFLogForwarder configures Rsyslog to bridge local Web/Docker logs into the Go WAF Socket
 func SetupWAFLogForwarder() error {
 	fmt.Println("[INFO] Configuring WAF Multi-Tenant Log Bridge (Rsyslog -> UDS)...")
 
-	rsyslogConf, activePatterns, err := renderWAFRsyslogConfig(config.GlobalConfig.ModsecLogs)
+	rsyslogConf, activePatterns, err := renderWAFRsyslogConfig(
+		config.GlobalConfig.ModsecLogs,
+		config.GlobalConfig.SiemEnabled,
+	)
 	if err != nil {
 		return fmt.Errorf("render WAF bridge config: %w", err)
 	}


### PR DESCRIPTION
## Summary

- make the WAF bridge the sole owner of the rsyslog imfile module and preserve exact current or v4.03.2 generated configurations
- keep installation and reload ordering deterministic across SIEM and WAF integration paths
- isolate lifecycle package temporary storage from the runner global temporary directory
- repair the exact v4.03.2 to v4.03.3 lifecycle contract without weakening unknown-transition handling
- bind the one-time v4.03.3 release-manager repair to the reviewed parent, subject, ancestry and 16-file diff

## Qualification

- Go CLI suite: pass
- complete Python CI gate suite: 545 tests pass, 9 skipped
- independent UID/GID 1001 portability suite: 152 tests pass, 2 skipped
- lifecycle harness: 127 tests pass, 2 skipped
- qualification workflow: 29 tests pass
- lifecycle contract: 78 tests pass, 6 skipped
- release gate: 70 tests pass
- Gitleaks v8.24.3 history and clean-tree scans: pass
- native AMD64 package lab: Debian, Ubuntu, Fedora, AlmaLinux and Alpine pass
- 13 lifecycle scenarios and 2,319 evidence events pass
- install, upgrade, reinstall, two real restarts, rollback, recovery, remove and purge contracts pass
- blockers and unexpected failed checks are empty
- final lab report SHA-256: fc6b7cfc8199f271a9f182334adb4639e390235065fd0b56a3f25901e0233989

## Version contract

This is a non-versioning qualification repair. It preserves the already versioned v4.03.3 candidate. README.md, the wiki, documentation and changelog.md are unchanged.
