### PR TITLE
CI : avoid Go 1.26 fuzz deadline race

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -261,6 +261,114 @@ jobs:
                   --base-ref "${v4033_repair_release_base_sha}" \
                   --tag-phase \
                   --commit-message "${v4033_repair_versioning_message}"
+              elif [[ "${v4033_parent_sha}" == "4ca08128cdf553ec7af0db7f1c8c5febb704e188" ]]; then
+                # Authorize exactly one fuzz-budget repair after the reviewed
+                # PR120 lifecycle repair. The exact parent and four-file diff
+                # keep this Go 1.26 workaround bounded and non-replayable.
+                v4033_fuzz_repair_base_sha="$(git rev-parse HEAD^^)"
+                if [[ "${v4033_fuzz_repair_base_sha}" != "19e4add763e935a29219c20c86586b3557a441c9" ]]; then
+                  echo "ERROR: the reviewed PR120 squash is not based on the reviewed PR119 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_version_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${v4033_fuzz_version_base_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                  echo "ERROR: the reviewed PR119 squash is not based on the reviewed PR118 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_release_base_sha="$(git rev-parse HEAD^^^^)"
+                if [[ "${v4033_fuzz_release_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                  echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_parent_subject="$(git log -1 --format=%s HEAD^)"
+                v4033_expected_fuzz_parent_subject='Qualification : repair v4.03.3 lifecycle qualification (#120)'
+                if [[ "${v4033_fuzz_parent_subject}" != "${v4033_expected_fuzz_parent_subject}" ]]; then
+                  echo "ERROR: the reviewed PR120 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_repair_base_subject="$(git log -1 --format=%s HEAD^^)"
+                v4033_expected_fuzz_repair_base_subject='CI : bind one-time v4.03.3 changelog seal (#119)'
+                if [[ "${v4033_fuzz_repair_base_subject}" != "${v4033_expected_fuzz_repair_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR119 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_version_base_subject="$(git log -1 --format=%s HEAD^^^)"
+                v4033_expected_fuzz_version_base_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+                if [[ "${v4033_fuzz_version_base_subject}" != "${v4033_expected_fuzz_version_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_release_base_subject="$(git log -1 --format=%s HEAD^^^^)"
+                v4033_expected_fuzz_release_base_subject='CI : make release inventory comparison portable (#117)'
+                if [[ "${v4033_fuzz_release_base_subject}" != "${v4033_expected_fuzz_release_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR117 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_subject_pattern='^CI : avoid Go 1\.26 fuzz deadline race \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${v4033_fuzz_subject_pattern} ]]; then
+                  echo "ERROR: the v4.03.3 fuzz repair requires the exact reviewed CI subject." >&2
+                  exit 1
+                fi
+                read -r -a v4033_fuzz_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a v4033_fuzz_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                read -r -a v4033_fuzz_repair_base_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+                read -r -a v4033_fuzz_version_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^)"
+                read -r -a v4033_fuzz_release_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^^)"
+                if (( ${#v4033_fuzz_head_line[@]} != 2 ||
+                      ${#v4033_fuzz_parent_line[@]} != 2 ||
+                      ${#v4033_fuzz_repair_base_line[@]} != 2 ||
+                      ${#v4033_fuzz_version_base_line[@]} != 2 ||
+                      ${#v4033_fuzz_release_base_line[@]} != 2 )); then
+                  echo "ERROR: the v4.03.3 fuzz repair and reviewed PR120/PR119/PR118/PR117 chain must be linear." >&2
+                  exit 1
+                fi
+                # BEGIN exact v4.03.3 fuzz-budget diff contract
+                expected_v4033_fuzz_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M ".github/workflows/security-audit.yml"
+                  M "scripts/ci/release_gate_test.py"
+                  M "scripts/ci/security_gate_test.py"
+                )
+                mapfile -d '' -t actual_v4033_fuzz_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_v4033_fuzz_diff[@]} != ${#expected_v4033_fuzz_diff[@]} )); then
+                  echo "ERROR: the v4.03.3 fuzz repair must modify exactly the four reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_v4033_fuzz_diff[@]}; index++)); do
+                  if [[ "${actual_v4033_fuzz_diff[index]}" != "${expected_v4033_fuzz_diff[index]}" ]]; then
+                    echo "ERROR: the v4.03.3 fuzz repair contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                v4033_fuzz_paths=(
+                  ".github/workflows/release-manager.yml"
+                  ".github/workflows/security-audit.yml"
+                  "scripts/ci/release_gate_test.py"
+                  "scripts/ci/security_gate_test.py"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${v4033_fuzz_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed v4.03.3 fuzz-repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact v4.03.3 fuzz-budget diff contract
+                v4033_fuzz_versioning_message="$(git log -1 --format=%B HEAD^^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${v4033_fuzz_release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${v4033_fuzz_versioning_message}"
               elif [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
                 echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
                 exit 1
@@ -1034,6 +1142,114 @@ jobs:
                   --base-ref "${v4033_repair_release_base_sha}" \
                   --tag-phase \
                   --commit-message "${v4033_repair_versioning_message}"
+              elif [[ "${v4033_parent_sha}" == "4ca08128cdf553ec7af0db7f1c8c5febb704e188" ]]; then
+                # Authorize exactly one fuzz-budget repair after the reviewed
+                # PR120 lifecycle repair. The exact parent and four-file diff
+                # keep this Go 1.26 workaround bounded and non-replayable.
+                v4033_fuzz_repair_base_sha="$(git rev-parse HEAD^^)"
+                if [[ "${v4033_fuzz_repair_base_sha}" != "19e4add763e935a29219c20c86586b3557a441c9" ]]; then
+                  echo "ERROR: the reviewed PR120 squash is not based on the reviewed PR119 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_version_base_sha="$(git rev-parse HEAD^^^)"
+                if [[ "${v4033_fuzz_version_base_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
+                  echo "ERROR: the reviewed PR119 squash is not based on the reviewed PR118 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_release_base_sha="$(git rev-parse HEAD^^^^)"
+                if [[ "${v4033_fuzz_release_base_sha}" != "b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449" ]]; then
+                  echo "ERROR: the reviewed PR118 squash is not based on the reviewed PR117 squash." >&2
+                  exit 1
+                fi
+                v4033_fuzz_parent_subject="$(git log -1 --format=%s HEAD^)"
+                v4033_expected_fuzz_parent_subject='Qualification : repair v4.03.3 lifecycle qualification (#120)'
+                if [[ "${v4033_fuzz_parent_subject}" != "${v4033_expected_fuzz_parent_subject}" ]]; then
+                  echo "ERROR: the reviewed PR120 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_repair_base_subject="$(git log -1 --format=%s HEAD^^)"
+                v4033_expected_fuzz_repair_base_subject='CI : bind one-time v4.03.3 changelog seal (#119)'
+                if [[ "${v4033_fuzz_repair_base_subject}" != "${v4033_expected_fuzz_repair_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR119 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_version_base_subject="$(git log -1 --format=%s HEAD^^^)"
+                v4033_expected_fuzz_version_base_subject='Patch : correct webhook, firewall and OSINT handling (#118)'
+                if [[ "${v4033_fuzz_version_base_subject}" != "${v4033_expected_fuzz_version_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR118 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_release_base_subject="$(git log -1 --format=%s HEAD^^^^)"
+                v4033_expected_fuzz_release_base_subject='CI : make release inventory comparison portable (#117)'
+                if [[ "${v4033_fuzz_release_base_subject}" != "${v4033_expected_fuzz_release_base_subject}" ]]; then
+                  echo "ERROR: the reviewed PR117 squash subject is not exact." >&2
+                  exit 1
+                fi
+                v4033_fuzz_subject_pattern='^CI : avoid Go 1\.26 fuzz deadline race \(#[1-9][0-9]*\)$'
+                if [[ ! "${commit_subject}" =~ ${v4033_fuzz_subject_pattern} ]]; then
+                  echo "ERROR: the v4.03.3 fuzz repair requires the exact reviewed CI subject." >&2
+                  exit 1
+                fi
+                read -r -a v4033_fuzz_head_line <<< "$(git rev-list --parents -n 1 HEAD)"
+                read -r -a v4033_fuzz_parent_line <<< "$(git rev-list --parents -n 1 HEAD^)"
+                read -r -a v4033_fuzz_repair_base_line <<< "$(git rev-list --parents -n 1 HEAD^^)"
+                read -r -a v4033_fuzz_version_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^)"
+                read -r -a v4033_fuzz_release_base_line <<< "$(git rev-list --parents -n 1 HEAD^^^^)"
+                if (( ${#v4033_fuzz_head_line[@]} != 2 ||
+                      ${#v4033_fuzz_parent_line[@]} != 2 ||
+                      ${#v4033_fuzz_repair_base_line[@]} != 2 ||
+                      ${#v4033_fuzz_version_base_line[@]} != 2 ||
+                      ${#v4033_fuzz_release_base_line[@]} != 2 )); then
+                  echo "ERROR: the v4.03.3 fuzz repair and reviewed PR120/PR119/PR118/PR117 chain must be linear." >&2
+                  exit 1
+                fi
+                # BEGIN exact v4.03.3 fuzz-budget diff contract
+                expected_v4033_fuzz_diff=(
+                  M ".github/workflows/release-manager.yml"
+                  M ".github/workflows/security-audit.yml"
+                  M "scripts/ci/release_gate_test.py"
+                  M "scripts/ci/security_gate_test.py"
+                )
+                mapfile -d '' -t actual_v4033_fuzz_diff < <(
+                  git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD
+                )
+                if (( ${#actual_v4033_fuzz_diff[@]} != ${#expected_v4033_fuzz_diff[@]} )); then
+                  echo "ERROR: the v4.03.3 fuzz repair must modify exactly the four reviewed files." >&2
+                  exit 1
+                fi
+                for ((index = 0; index < ${#expected_v4033_fuzz_diff[@]}; index++)); do
+                  if [[ "${actual_v4033_fuzz_diff[index]}" != "${expected_v4033_fuzz_diff[index]}" ]]; then
+                    echo "ERROR: the v4.03.3 fuzz repair contains an unauthorized path, status, or rename." >&2
+                    exit 1
+                  fi
+                done
+                v4033_fuzz_paths=(
+                  ".github/workflows/release-manager.yml"
+                  ".github/workflows/security-audit.yml"
+                  "scripts/ci/release_gate_test.py"
+                  "scripts/ci/security_gate_test.py"
+                )
+                for tree_ref in HEAD^ HEAD; do
+                  for fix_path in "${v4033_fuzz_paths[@]}"; do
+                    tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"
+                    IFS=$' \t' read -r tree_mode tree_type tree_object tree_path tree_extra <<< "${tree_entry}"
+                    if [[ "${tree_mode}" != "100644" || \
+                          "${tree_type}" != "blob" || \
+                          ! "${tree_object}" =~ ^[0-9a-f]{40}$ || \
+                          "${tree_path}" != "${fix_path}" || \
+                          -n "${tree_extra:-}" ]]; then
+                      echo "ERROR: reviewed v4.03.3 fuzz-repair path ${fix_path} is not one exact 100644 blob at ${tree_ref}." >&2
+                      exit 1
+                    fi
+                  done
+                done
+                # END exact v4.03.3 fuzz-budget diff contract
+                v4033_fuzz_versioning_message="$(git log -1 --format=%B HEAD^^^)"
+                ./scripts/versioning.sh validate-commit \
+                  --repo "${GITHUB_WORKSPACE}" \
+                  --base-ref "${v4033_fuzz_release_base_sha}" \
+                  --tag-phase \
+                  --commit-message "${v4033_fuzz_versioning_message}"
               elif [[ "${v4033_parent_sha}" != "689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then
                 echo "ERROR: the v4.03.3 candidate is not based on the reviewed PR118 squash." >&2
                 exit 1

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -194,8 +194,10 @@ jobs:
             echo "Fuzzing ${module}/${package}: ${target}"
             (
               cd "${module}"
+              # Avoid the Go 1.26 deadline race tracked by golang/go#75804.
+              # A fixed execution budget still fails on every crash or panic.
               go test -mod=readonly -run '^$' \
-                -fuzz "^${target}$" -fuzztime=5s -parallel=2 "${package}"
+                -fuzz "^${target}$" -fuzztime=100000x -parallel=2 "${package}"
             )
           }
           fuzz_target src/core/syswarden-cli ./config FuzzMigratorParseFromMemory

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -44,6 +44,12 @@ V4033_LIFECYCLE_REPAIR_PATHS = (
     "src/core/syswarden-cli/pkg/integration/siem_linux.go",
     "src/core/syswarden-cli/pkg/integration/waf_logs_linux.go",
 )
+V4033_FUZZ_BUDGET_PATHS = (
+    ".github/workflows/release-manager.yml",
+    ".github/workflows/security-audit.yml",
+    "scripts/ci/release_gate_test.py",
+    "scripts/ci/security_gate_test.py",
+)
 
 
 def workflow_step_script(workflow: str, step_name: str) -> str:
@@ -1485,10 +1491,10 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD)"), 10
+            workflow.count("git rev-list --parents -n 1 HEAD)"), 12
         )
         self.assertEqual(
-            workflow.count("git rev-list --parents -n 1 HEAD^)"), 10
+            workflow.count("git rev-list --parents -n 1 HEAD^)"), 12
         )
         self.assertEqual(
             workflow.count(
@@ -1528,8 +1534,8 @@ class ReleaseGateTests(unittest.TestCase):
             2,
         )
         for script in scripts:
-            self.assertEqual(script.count("--tag-phase"), 5)
-            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 7)
+            self.assertEqual(script.count("--tag-phase"), 6)
+            self.assertEqual(script.count("./scripts/versioning.sh validate-commit"), 8)
             self.assertEqual(
                 script.count("# BEGIN exact second preserved-version fix diff contract"),
                 1,
@@ -1542,18 +1548,20 @@ class ReleaseGateTests(unittest.TestCase):
                 script.count(
                     "git diff-tree --no-commit-id --name-status -r --no-renames -z HEAD^ HEAD"
                 ),
-                4,
+                5,
             )
-            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 4)
+            self.assertEqual(script.count('for tree_ref in HEAD^ HEAD; do'), 5)
             self.assertEqual(
                 script.count('tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"'),
-                4,
+                5,
             )
-            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 4)
-            self.assertEqual(script.count('"${tree_type}" != "blob"'), 4)
+            self.assertEqual(script.count('"${tree_mode}" != "100644"'), 5)
+            self.assertEqual(script.count('"${tree_type}" != "blob"'), 5)
             expected_path_counts = {
-                ".github/workflows/release-manager.yml": 8,
-                "scripts/ci/release_gate_test.py": 8,
+                ".github/workflows/release-manager.yml": 10,
+                ".github/workflows/security-audit.yml": 2,
+                "scripts/ci/release_gate_test.py": 10,
+                "scripts/ci/security_gate_test.py": 2,
                 "src/core/syswarden-cli/pkg/firewall/firewall_linux_golden_test.go": 2,
             }
             for path, count in expected_path_counts.items():
@@ -1634,7 +1642,7 @@ class ReleaseGateTests(unittest.TestCase):
                 "--tag-phase",
                 '--commit-message "${v4033_parent_message}"',
             )
-            shared_with_lifecycle_repair = {
+            shared_with_lifecycle_and_fuzz_repairs = {
                 "git diff-tree --no-commit-id --name-status -r "
                 "--no-renames -z HEAD^ HEAD",
                 'for tree_ref in HEAD^ HEAD; do',
@@ -1644,11 +1652,17 @@ class ReleaseGateTests(unittest.TestCase):
                 "--tag-phase",
             }
             for contract in required:
-                expected_count = 2 if contract in shared_with_lifecycle_repair else 1
+                expected_count = (
+                    3
+                    if contract in shared_with_lifecycle_and_fuzz_repairs
+                    else 1
+                )
                 self.assertEqual(block.count(contract), expected_count, contract)
             expected_followup_path_counts = {
-                ".github/workflows/release-manager.yml": (2, 4),
-                "scripts/ci/release_gate_test.py": (2, 4),
+                ".github/workflows/release-manager.yml": (3, 6),
+                ".github/workflows/security-audit.yml": (1, 2),
+                "scripts/ci/release_gate_test.py": (3, 6),
+                "scripts/ci/security_gate_test.py": (1, 2),
                 "scripts/versionctl/repository.go": (1, 2),
                 "scripts/versionctl/repository_test.go": (1, 2),
             }
@@ -1674,8 +1688,8 @@ class ReleaseGateTests(unittest.TestCase):
                     else 1
                 )
                 self.assertEqual(block.count(path), expected_count, path)
-            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 2)
-            self.assertEqual(block.count("--tag-phase"), 2)
+            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 3)
+            self.assertEqual(block.count("--tag-phase"), 3)
 
     def v4033_followup_subject_gate_script(self) -> str:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -1766,8 +1780,8 @@ class ReleaseGateTests(unittest.TestCase):
             '"19e4add763e935a29219c20c86586b3557a441c9" ]]; then\n'
         )
         end = (
-            '\n    elif [[ "${v4033_parent_sha}" != '
-            '"689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then\n'
+            '\n    elif [[ "${v4033_parent_sha}" == '
+            '"4ca08128cdf553ec7af0db7f1c8c5febb704e188" ]]; then\n'
         )
         blocks = []
         for recovery_block in recovery_blocks:
@@ -1929,6 +1943,193 @@ class ReleaseGateTests(unittest.TestCase):
         subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
         subprocess.run(
             ["git", "-C", repository, "commit", "-q", "-m", "reviewed repair"],
+            check=True,
+        )
+        return repository
+
+    def v4033_fuzz_budget_blocks(self, workflow: str) -> list[str]:
+        recovery_blocks = self.v4033_recovery_blocks(workflow)
+        start = (
+            'elif [[ "${v4033_parent_sha}" == '
+            '"4ca08128cdf553ec7af0db7f1c8c5febb704e188" ]]; then\n'
+        )
+        end = (
+            '\n    elif [[ "${v4033_parent_sha}" != '
+            '"689871803bdef1bc2a25d3eece0a7c35fdb5c447" ]]; then\n'
+        )
+        blocks = []
+        for recovery_block in recovery_blocks:
+            self.assertEqual(recovery_block.count(start), 1)
+            remainder = recovery_block.split(start, 1)[1]
+            self.assertIn(end, remainder)
+            blocks.append(start + remainder.split(end, 1)[0])
+        self.assertEqual(blocks[0], blocks[1])
+        return blocks
+
+    def assert_v4033_fuzz_budget_contract(self, workflow: str) -> None:
+        fuzz_blocks = self.v4033_fuzz_budget_blocks(workflow)
+        for block in fuzz_blocks:
+            required = (
+                '"4ca08128cdf553ec7af0db7f1c8c5febb704e188"',
+                'v4033_fuzz_repair_base_sha="$(git rev-parse HEAD^^)"',
+                '"${v4033_fuzz_repair_base_sha}" != '
+                '"19e4add763e935a29219c20c86586b3557a441c9"',
+                'v4033_fuzz_version_base_sha="$(git rev-parse HEAD^^^)"',
+                '"${v4033_fuzz_version_base_sha}" != '
+                '"689871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+                'v4033_fuzz_release_base_sha="$(git rev-parse HEAD^^^^)"',
+                '"${v4033_fuzz_release_base_sha}" != '
+                '"b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+                'v4033_fuzz_parent_subject="$(git log -1 --format=%s HEAD^)"',
+                "v4033_expected_fuzz_parent_subject="
+                "'Qualification : repair v4.03.3 lifecycle qualification (#120)'",
+                '"${v4033_fuzz_parent_subject}" != '
+                '"${v4033_expected_fuzz_parent_subject}"',
+                'v4033_fuzz_repair_base_subject="$(git log -1 --format=%s HEAD^^)"',
+                "v4033_expected_fuzz_repair_base_subject="
+                "'CI : bind one-time v4.03.3 changelog seal (#119)'",
+                '"${v4033_fuzz_repair_base_subject}" != '
+                '"${v4033_expected_fuzz_repair_base_subject}"',
+                'v4033_fuzz_version_base_subject="$(git log -1 --format=%s HEAD^^^)"',
+                "v4033_expected_fuzz_version_base_subject="
+                "'Patch : correct webhook, firewall and OSINT handling (#118)'",
+                '"${v4033_fuzz_version_base_subject}" != '
+                '"${v4033_expected_fuzz_version_base_subject}"',
+                'v4033_fuzz_release_base_subject="$(git log -1 --format=%s HEAD^^^^)"',
+                "v4033_expected_fuzz_release_base_subject="
+                "'CI : make release inventory comparison portable (#117)'",
+                '"${v4033_fuzz_release_base_subject}" != '
+                '"${v4033_expected_fuzz_release_base_subject}"',
+                "v4033_fuzz_subject_pattern="
+                "'^CI : avoid Go 1\\.26 fuzz deadline race "
+                "\\(#[1-9][0-9]*\\)$'",
+                '[[ ! "${commit_subject}" =~ ${v4033_fuzz_subject_pattern} ]]',
+                'v4033_fuzz_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_fuzz_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4033_fuzz_repair_base_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
+                'v4033_fuzz_version_base_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^^)"',
+                'v4033_fuzz_release_base_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^^^)"',
+                "${#v4033_fuzz_head_line[@]} != 2",
+                "${#v4033_fuzz_parent_line[@]} != 2",
+                "${#v4033_fuzz_repair_base_line[@]} != 2",
+                "${#v4033_fuzz_version_base_line[@]} != 2",
+                "${#v4033_fuzz_release_base_line[@]} != 2",
+                "# BEGIN exact v4.03.3 fuzz-budget diff contract",
+                "# END exact v4.03.3 fuzz-budget diff contract",
+                "expected_v4033_fuzz_diff=(",
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "${#actual_v4033_fuzz_diff[@]} != "
+                "${#expected_v4033_fuzz_diff[@]}",
+                'for tree_ref in HEAD^ HEAD; do',
+                'tree_entry="$(git ls-tree "${tree_ref}" -- "${fix_path}")"',
+                '"${tree_mode}" != "100644"',
+                '"${tree_type}" != "blob"',
+                'v4033_fuzz_versioning_message="$(git log -1 --format=%B HEAD^^^)"',
+                '--base-ref "${v4033_fuzz_release_base_sha}"',
+                "--tag-phase",
+                '--commit-message "${v4033_fuzz_versioning_message}"',
+            )
+            for contract in required:
+                self.assertEqual(block.count(contract), 1, contract)
+            self.assertEqual(len(V4033_FUZZ_BUDGET_PATHS), 4)
+            for path in V4033_FUZZ_BUDGET_PATHS:
+                self.assertEqual(block.count(f'M "{path}"'), 1, path)
+                self.assertEqual(block.count(f'"{path}"'), 2, path)
+            for protected_path in (
+                "changelog.md",
+                "README.md",
+                "docs/",
+                ".github/workflows/release-qualification.yml",
+                "scripts/versionctl/repository.go",
+                "scripts/versionctl/repository_test.go",
+                "src/core/syswarden-cli/pkg/system/upgrade.go",
+            ):
+                self.assertNotIn(protected_path, block)
+            self.assertEqual(block.count("./scripts/versioning.sh validate-commit"), 1)
+
+    def v4033_fuzz_budget_subject_gate_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_fuzz_budget_blocks(workflow)[0]
+        start = "v4033_fuzz_subject_pattern="
+        end = (
+            'read -r -a v4033_fuzz_head_line <<< '
+            '"$(git rev-list --parents -n 1 HEAD)"'
+        )
+        self.assertEqual(block.count(start), 1)
+        self.assertEqual(block.count(end), 1)
+        fragment = start + block.split(start, 1)[1].split(end, 1)[0]
+        return 'set -euo pipefail\ncommit_subject="${COMMIT_SUBJECT:?}"\n' + fragment
+
+    def exact_v4033_fuzz_budget_diff_script(self) -> str:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        block = self.v4033_fuzz_budget_blocks(workflow)[0]
+        begin = "# BEGIN exact v4.03.3 fuzz-budget diff contract\n"
+        end = "# END exact v4.03.3 fuzz-budget diff contract"
+        self.assertEqual(block.count(begin), 1)
+        self.assertEqual(block.count(end), 1)
+        return "set -euo pipefail\n" + block.split(begin, 1)[1].split(end, 1)[0]
+
+    def make_v4033_fuzz_budget_diff_repository(
+        self, name: str, mutation: str | None
+    ) -> Path:
+        repository = self.root / name
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        fuzz_paths = [repository / path for path in V4033_FUZZ_BUDGET_PATHS]
+        protected_paths = {
+            "changelog": repository / "changelog.md",
+            "readme": repository / "README.md",
+            "documentation": repository / "docs/maintainers/release.md",
+            "version target": repository
+            / "src/core/syswarden-cli/pkg/system/upgrade.go",
+        }
+        for path in [*fuzz_paths, *protected_paths.values()]:
+            self.write_file(path, b"reviewed PR120 parent\n")
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed PR120"],
+            check=True,
+        )
+        for path in fuzz_paths:
+            if mutation != "unchanged path" or path != fuzz_paths[-1]:
+                path.write_bytes(b"reviewed Go 1.26 fuzz-budget repair\n")
+        if mutation in protected_paths:
+            protected_paths[mutation].write_bytes(b"unauthorized release drift\n")
+        elif mutation == "extra file":
+            self.write_file(repository / "unauthorized.txt", b"unexpected\n")
+        elif mutation == "mode":
+            fuzz_paths[0].chmod(0o755)
+        elif mutation == "symlink":
+            fuzz_paths[1].unlink()
+            fuzz_paths[1].symlink_to("unauthorized-target")
+        elif mutation == "rename":
+            fuzz_paths[-1].rename(
+                fuzz_paths[-1].with_name("renamed_security_gate_test.py")
+            )
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "reviewed fix"],
             check=True,
         )
         return repository
@@ -2165,6 +2366,7 @@ class ReleaseGateTests(unittest.TestCase):
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         self.assert_v4033_preserved_version_recovery_contract(workflow)
         self.assert_v4033_lifecycle_repair_contract(workflow)
+        self.assert_v4033_fuzz_budget_contract(workflow)
 
     def test_release_manager_v4033_contract_rejects_mutations(self) -> None:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
@@ -2609,6 +2811,280 @@ class ReleaseGateTests(unittest.TestCase):
                 "HEAD",
                 "--commit-message",
                 "Qualification : repair v4.03.3 lifecycle qualification (#120)",
+            ],
+            cwd=REPOSITORY,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "Commit validation passed: non-versioning commit preserves v4.03.3",
+            result.stdout,
+        )
+
+    def test_release_manager_v4033_fuzz_budget_contract_rejects_mutations(
+        self,
+    ) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        mutations = {
+            "exact PR120 parent": workflow.replace(
+                "4ca08128cdf553ec7af0db7f1c8c5febb704e188",
+                "5ca08128cdf553ec7af0db7f1c8c5febb704e188",
+            ),
+            "PR119 resolution": workflow.replace(
+                'v4033_fuzz_repair_base_sha="$(git rev-parse HEAD^^)"',
+                'v4033_fuzz_repair_base_sha="$(git rev-parse HEAD^^^)"',
+            ),
+            "exact PR119": workflow.replace(
+                '"${v4033_fuzz_repair_base_sha}" != '
+                '"19e4add763e935a29219c20c86586b3557a441c9"',
+                '"${v4033_fuzz_repair_base_sha}" != '
+                '"29e4add763e935a29219c20c86586b3557a441c9"',
+            ),
+            "PR118 resolution": workflow.replace(
+                'v4033_fuzz_version_base_sha="$(git rev-parse HEAD^^^)"',
+                'v4033_fuzz_version_base_sha="$(git rev-parse HEAD^^)"',
+            ),
+            "exact PR118": workflow.replace(
+                '"${v4033_fuzz_version_base_sha}" != '
+                '"689871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+                '"${v4033_fuzz_version_base_sha}" != '
+                '"789871803bdef1bc2a25d3eece0a7c35fdb5c447"',
+            ),
+            "PR117 resolution": workflow.replace(
+                'v4033_fuzz_release_base_sha="$(git rev-parse HEAD^^^^)"',
+                'v4033_fuzz_release_base_sha="$(git rev-parse HEAD^^^)"',
+            ),
+            "exact PR117": workflow.replace(
+                '"${v4033_fuzz_release_base_sha}" != '
+                '"b9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+                '"${v4033_fuzz_release_base_sha}" != '
+                '"c9fbfe2ee292a53e6e19dd3e27a071f78fe2f449"',
+            ),
+            "PR120 subject": workflow.replace(
+                "Qualification : repair v4.03.3 lifecycle qualification (#120)",
+                "Qualification : repair reusable lifecycle qualification (#120)",
+            ),
+            "PR119 subject": workflow.replace(
+                "CI : bind one-time v4.03.3 changelog seal (#119)",
+                "CI : bind reusable v4.03.3 changelog seal (#119)",
+            ),
+            "PR118 subject": workflow.replace(
+                "Patch : correct webhook, firewall and OSINT handling (#118)",
+                "Patch : correct webhook and firewall handling (#118)",
+            ),
+            "PR117 subject": workflow.replace(
+                "CI : make release inventory comparison portable (#117)",
+                "CI : make release inventory comparison broad (#117)",
+            ),
+            "fuzz subject": workflow.replace(
+                "CI : avoid Go 1\\.26 fuzz deadline race",
+                "CI : avoid reusable fuzz deadline race",
+            ),
+            "fuzz subject comparison": workflow.replace(
+                '[[ ! "${commit_subject}" =~ ${v4033_fuzz_subject_pattern} ]]',
+                '[[ "${commit_subject}" =~ ${v4033_fuzz_subject_pattern} ]]',
+            ),
+            "linear head": workflow.replace(
+                'v4033_fuzz_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD)"',
+                'v4033_fuzz_head_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+            ),
+            "linear parent": workflow.replace(
+                'v4033_fuzz_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^)"',
+                'v4033_fuzz_parent_line <<< '
+                '"$(git rev-list --parents -n 1 HEAD^^)"',
+            ),
+            "linearity comparison": workflow.replace(
+                "${#v4033_fuzz_release_base_line[@]} != 2",
+                "${#v4033_fuzz_release_base_line[@]} == 2",
+            ),
+            "diff rename policy": workflow.replace(
+                "git diff-tree --no-commit-id --name-status -r "
+                "--no-renames -z HEAD^ HEAD",
+                "git diff-tree --no-commit-id --name-status -r -z HEAD^ HEAD",
+            ),
+            "diff status": workflow.replace(
+                'M ".github/workflows/security-audit.yml"',
+                'A ".github/workflows/security-audit.yml"',
+            ),
+            "diff path": workflow.replace(
+                'M "scripts/ci/security_gate_test.py"',
+                'M "scripts/ci/security_workflow_test.py"',
+            ),
+            "diff count comparison": workflow.replace(
+                "${#actual_v4033_fuzz_diff[@]} != "
+                "${#expected_v4033_fuzz_diff[@]}",
+                "${#actual_v4033_fuzz_diff[@]} == "
+                "${#expected_v4033_fuzz_diff[@]}",
+            ),
+            "tree path": workflow.replace(
+                '\n                  "scripts/ci/security_gate_test.py"\n',
+                '\n                  "scripts/ci/security_workflow_test.py"\n',
+            ),
+            "blob mode": workflow.replace(
+                '"${tree_mode}" != "100644"',
+                '"${tree_mode}" != "100755"',
+            ),
+            "replay base": workflow.replace(
+                '--base-ref "${v4033_fuzz_release_base_sha}"',
+                "--base-ref HEAD^",
+            ),
+            "replay subject": workflow.replace(
+                'v4033_fuzz_versioning_message="$(git log -1 --format=%B HEAD^^^)"',
+                'v4033_fuzz_versioning_message="$(git log -1 --format=%B HEAD^)"',
+            ),
+        }
+        mutations["duplicated block divergence"] = workflow.replace(
+            "4ca08128cdf553ec7af0db7f1c8c5febb704e188",
+            "5ca08128cdf553ec7af0db7f1c8c5febb704e188",
+            1,
+        )
+        for name, mutation in mutations.items():
+            with self.subTest(name=name):
+                self.assertNotEqual(mutation, workflow)
+                with self.assertRaises(AssertionError):
+                    self.assert_v4033_fuzz_budget_contract(mutation)
+
+    def test_release_manager_v4033_fuzz_budget_subject_is_exact(self) -> None:
+        script = self.v4033_fuzz_budget_subject_gate_script()
+        cases = {
+            "valid": ("CI : avoid Go 1.26 fuzz deadline race (#121)", True),
+            "bare": ("CI : avoid Go 1.26 fuzz deadline race", False),
+            "zero": ("CI : avoid Go 1.26 fuzz deadline race (#0)", False),
+            "leading zero": (
+                "CI : avoid Go 1.26 fuzz deadline race (#0121)",
+                False,
+            ),
+            "non-numeric": (
+                "CI : avoid Go 1.26 fuzz deadline race (#PR)",
+                False,
+            ),
+            "wrong category": (
+                "Qualification : avoid Go 1.26 fuzz deadline race (#121)",
+                False,
+            ),
+            "wrong Go version": (
+                "CI : avoid Go 1.25 fuzz deadline race (#121)",
+                False,
+            ),
+            "double space": (
+                "CI : avoid Go 1.26 fuzz deadline race  (#121)",
+                False,
+            ),
+            "trailing space": (
+                "CI : avoid Go 1.26 fuzz deadline race (#121) ",
+                False,
+            ),
+            "extra text": (
+                "CI : avoid Go 1.26 fuzz deadline race (#121) extra",
+                False,
+            ),
+        }
+        for name, (subject, accepted) in cases.items():
+            with self.subTest(name=name):
+                environment = dict(os.environ)
+                environment["COMMIT_SUBJECT"] = subject
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=REPOSITORY,
+                    env=environment,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_release_manager_v4033_fuzz_budget_diff_is_exact(self) -> None:
+        script = self.exact_v4033_fuzz_budget_diff_script()
+        mutations = (
+            None,
+            "extra file",
+            "changelog",
+            "readme",
+            "documentation",
+            "version target",
+            "unchanged path",
+            "mode",
+            "symlink",
+            "rename",
+        )
+        for index, mutation in enumerate(mutations):
+            with self.subTest(mutation=mutation or "exact"):
+                repository = self.make_v4033_fuzz_budget_diff_repository(
+                    f"v4033-fuzz-budget-diff-{index}", mutation
+                )
+                result = subprocess.run(
+                    ["/bin/bash", "-c", script],
+                    cwd=repository,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if mutation is None:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_v4033_fuzz_budget_subject_preserves_version_contract(self) -> None:
+        repository = self.root / "v4033-fuzz-budget-version-contract"
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", repository], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "config", "user.name", "Release Gate Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repository,
+                "config",
+                "user.email",
+                "release-gate@example.invalid",
+            ],
+            check=True,
+        )
+        version_paths = (
+            "src/core/syswarden-cli/pkg/system/upgrade.go",
+            "src/core/syswarden-tui/main.go",
+            "src/core/syswarden-cli/cmd/install.go",
+            "src/core/syswarden-cli/config/default.go",
+            "src/core/syswarden-cli/pkg/integration/webhook.go",
+            "src/core/syswarden-core/webhook/discord.go",
+            "README.md",
+            "changelog.md",
+        )
+        for relative in version_paths:
+            self.write_file(repository / relative, (REPOSITORY / relative).read_bytes())
+        subprocess.run(["git", "-C", repository, "add", "--all"], check=True)
+        subprocess.run(
+            ["git", "-C", repository, "commit", "-q", "-m", "v4.03.3 baseline"],
+            check=True,
+        )
+        go_cache = self.root / "fuzz-budget-go-cache"
+        go_tmp = self.root / "fuzz-budget-go-tmp"
+        go_cache.mkdir(mode=0o700)
+        go_tmp.mkdir(mode=0o700)
+        environment = dict(os.environ)
+        environment.update({"GOCACHE": str(go_cache), "GOTMPDIR": str(go_tmp)})
+        result = subprocess.run(
+            [
+                str(REPOSITORY / "scripts/versioning.sh"),
+                "validate-commit",
+                "--repo",
+                str(repository),
+                "--base-ref",
+                "HEAD",
+                "--commit-message",
+                "CI : avoid Go 1.26 fuzz deadline race (#121)",
             ],
             cwd=REPOSITORY,
             env=environment,

--- a/scripts/ci/security_gate_test.py
+++ b/scripts/ci/security_gate_test.py
@@ -826,7 +826,9 @@ class ActFixtureTests(unittest.TestCase):
             self.repository / ".github" / "workflows" / "security-audit.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("Run bounded parser and network fuzz campaigns", workflow)
-        self.assertIn("-fuzztime=5s -parallel=2", workflow)
+        self.assertEqual(workflow.count("-fuzztime="), 1)
+        self.assertEqual(workflow.count("-fuzztime=100000x -parallel=2"), 1)
+        self.assertNotIn("-fuzztime=5s", workflow)
         for target in (
             "FuzzMigratorParseFromMemory",
             "FuzzIPCIDRPortValidators",


### PR DESCRIPTION
## Summary

- replace the Go 1.26 wall-clock fuzz deadline with a deterministic budget of 100,000 executions for each of the five mandatory targets
- preserve `-parallel=2` and fail normally on every panic, crash, invalid corpus entry or test failure
- bind this one-shot v4.03.3 follow-up to the exact PR120 parent, reviewed PR117 to PR120 ancestry, exact squash subject, four-file diff and regular `100644` blobs
- keep product code, version targets, changelog, README, wiki and documentation unchanged

## Root cause

Post-merge Security Audit run 32979754446 completed 29,172 HA payload executions without a crash or reproducer, then returned only `context deadline exceeded` at 5.03 seconds.

This matches the upstream Go race tracked in golang/go#75804. Go 1.26 can observe the parent deadline before the child fuzz context reports cancellation, which leaks a spurious test failure. The upstream correction is delivered on the Go 1.27 release branch. An execution-count budget avoids that defective deadline path without suppressing product failures.

References:

- https://github.com/golang/go/issues/75804
- https://go-review.googlesource.com/c/go/+/804900
- https://github.com/duggytuxy/syswarden/actions/runs/32979754446

## Validation

- exact tree equivalence confirmed between the merged PR120 content and protected main before this change
- 20 repeated local HA campaigns with the former five-second budget produced no crash or failing corpus entry
- five count-bounded campaigns completed exactly 100,000 executions each, 500,000 total, with Go 1.26.6
- 549 Python CI contract tests passed, 9 skipped by their documented local sandbox conditions
- 74 release-gate tests and 57 security-gate tests passed independently
- YAML parsing and `git diff --check` passed
- version validation passed: non-versioning commit preserves v4.03.3
- Gitleaks v8.24.3 found no leak in the final worktree or the complete 1,358-commit history
- commit `1c8a503231f7328c73ee2ef3b40739fe19690f83` is SSH signed and verified by GitHub

## Release impact

This PR does not publish or claim v4.03.3. After merge and a green post-merge gate, the exact new main artifacts still require qualification on the supported real hosts before the protected qualification attempt, signed annotated tag and release publication.
