### PR TITLE
Qualification: freeze v4.04.0 AMD64 matrix

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,6 +55,7 @@ jobs:
           set -euo pipefail
           (cd scripts/versionctl && GOWORK=off go test ./...)
           PYTHONDONTWRITEBYTECODE=1 python3 -m unittest \
+            scripts/ci/package_qualification_matrix_test.py \
             scripts/ci/package_lifecycle_contract_test.py \
             scripts/ci/package_lifecycle_lab_test.py \
             scripts/ci/package_stage_gate_test.py \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -230,6 +230,15 @@ jobs:
           git merge-base --is-ancestor "${previous_sha}" "${RELEASE_SHA}"
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
 
+      - name: Validate Frozen Package Qualification Matrix
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_qualification_matrix.py \
+            --expected-target-release "${RELEASE_TAG}"
+
       - name: Qualify Optional RHEL Image Extension Offline Contract
         shell: bash
         run: |

--- a/scripts/ci/package_qualification_matrix.json
+++ b/scripts/ci/package_qualification_matrix.json
@@ -1,0 +1,290 @@
+{
+  "schema_version": 1,
+  "matrix_id": "syswarden-package-qualification/v1",
+  "target_release": "v4.04.0",
+  "architecture": {
+    "oci_platform": "linux/amd64",
+    "kernel": "x86_64",
+    "deb": "amd64",
+    "rpm": "x86_64",
+    "apk": "x86_64"
+  },
+  "package_sources": {
+    "candidate": {
+      "workflow": "package.yml",
+      "successful_run_count": 1,
+      "commit_binding": "same-candidate-commit",
+      "local_rebuild_allowed": false
+    },
+    "baseline": {
+      "release": "v4.03.3",
+      "commit": "cdd66600a1505bae1f1e754dea096ee71e9cee82",
+      "release_id": 377680978,
+      "release_state": "public-stable",
+      "asset_selection": "github-asset-id",
+      "assets": [
+        {
+          "name": "SHA256SUMS.txt",
+          "id": 532015727,
+          "size": 283,
+          "architecture": "metadata",
+          "sha256": "91c89428bf20d2386adf0d7529dc5edb26da6d490db872fab0771ddfce5364c2"
+        },
+        {
+          "name": "syswarden_4.03.3_amd64.deb",
+          "id": 532015759,
+          "size": 13874730,
+          "architecture": "amd64",
+          "sha256": "4d17e74b16022be31a3e6db8851386f8c0df14772ea38f04f7df45540c818c9b"
+        },
+        {
+          "name": "syswarden-4.03.3-1.x86_64.rpm",
+          "id": 532015720,
+          "size": 14160347,
+          "architecture": "x86_64",
+          "sha256": "42e207f7f5ae47384c0c35764cf4da179feed1cac34f4fb3bfbd3b59aee8881e"
+        },
+        {
+          "name": "syswarden_4.03.3_x86_64.apk",
+          "id": 532015763,
+          "size": 14039148,
+          "architecture": "x86_64",
+          "sha256": "73f2d1cf67f62e781dc3d78cc9f9b2d5732ec876fee6587b305aeaaa3830f3d5"
+        }
+      ]
+    },
+    "artifact_inventory": [
+      "deb:amd64",
+      "rpm:x86_64",
+      "apk:x86_64",
+      "SHA256SUMS.txt"
+    ]
+  },
+  "budgets": {
+    "protected_qualification_seconds": 21600,
+    "package_build_or_extract_seconds": 900,
+    "lifecycle_scenario_seconds": 600,
+    "kernel_lab": {
+      "seconds": 240,
+      "pids": 128,
+      "memory_mib": 512,
+      "tmpfs_mib": 64
+    },
+    "container_cell_seconds": 2700,
+    "real_host_cell_seconds": 5400,
+    "post_reboot_ready_seconds": 600,
+    "updater_download_seconds": 600,
+    "updater_install_seconds": 1800
+  },
+  "required_evidence": [
+    "immutable-base-identity",
+    "kernel-architecture-and-package-manager",
+    "candidate-source-commit",
+    "candidate-workflow-run-id",
+    "candidate-artifact-id",
+    "baseline-release-asset-id",
+    "package-name-size-and-sha256",
+    "package-inventory-before-and-after",
+    "redacted-configuration-before-and-after",
+    "services-and-init-system",
+    "nftables-state-and-rule-ownership",
+    "selinux-and-firewalld-when-required",
+    "openrc-and-cronie-when-required",
+    "lifecycle-scenario-results",
+    "owned-residue-absence",
+    "required-real-reboots",
+    "complete-private-logs",
+    "redacted-public-summary",
+    "same-candidate-commit-verdict"
+  ],
+  "cells": [
+    {
+      "id": "DEB-13",
+      "distribution": "debian",
+      "version": "13",
+      "family": "deb",
+      "image": "docker.io/library/debian:13-slim@sha256:d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove",
+        "purge"
+      ],
+      "required_checks": [
+        "install",
+        "upgrade",
+        "rollback",
+        "remove",
+        "reinstall",
+        "purge"
+      ],
+      "real_host": {
+        "mode": "required",
+        "reboot_count": 2
+      }
+    },
+    {
+      "id": "DEB-U2404",
+      "distribution": "ubuntu",
+      "version": "24.04",
+      "family": "deb",
+      "image": "docker.io/library/ubuntu:24.04@sha256:019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove",
+        "purge"
+      ],
+      "required_checks": [
+        "install",
+        "upgrade",
+        "confined-recovery",
+        "remove",
+        "reinstall",
+        "purge"
+      ],
+      "real_host": {
+        "mode": "none",
+        "reboot_count": 0
+      }
+    },
+    {
+      "id": "DEB-U2604",
+      "distribution": "ubuntu",
+      "version": "26.04",
+      "family": "deb",
+      "image": "docker.io/library/ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove",
+        "purge"
+      ],
+      "required_checks": [
+        "install",
+        "signed-updater",
+        "confined-recovery",
+        "remove",
+        "reinstall",
+        "purge"
+      ],
+      "real_host": {
+        "mode": "required",
+        "reboot_count": 2
+      }
+    },
+    {
+      "id": "RPM-F44",
+      "distribution": "fedora",
+      "version": "44",
+      "family": "rpm",
+      "image": "docker.io/library/fedora:44@sha256:89f61a124414261868224666aa7fb8df1b78397a53623774bdfb105d1612b48b",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove"
+      ],
+      "required_checks": [
+        "install",
+        "upgrade",
+        "nftables",
+        "cronie",
+        "remove"
+      ],
+      "real_host": {
+        "mode": "conditional",
+        "reboot_count": 1
+      }
+    },
+    {
+      "id": "RPM-A9",
+      "distribution": "almalinux",
+      "version": "9",
+      "family": "rpm",
+      "image": "docker.io/library/almalinux:9@sha256:28db580abb508f7ccbc0ac6d53e1d8da9d42a26c77fa3dcc26ac2726673fbe3e",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove"
+      ],
+      "required_checks": [
+        "install",
+        "upgrade",
+        "selinux-enforcing",
+        "firewalld",
+        "remove"
+      ],
+      "real_host": {
+        "mode": "none",
+        "reboot_count": 0
+      }
+    },
+    {
+      "id": "RPM-A10",
+      "distribution": "almalinux",
+      "version": "10",
+      "family": "rpm",
+      "image": "docker.io/library/almalinux:10@sha256:cc24bc5b6ac7e284f2f62a07bdaa1b15d3319fdcf46413c6b8fe9fa245068ddd",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove"
+      ],
+      "required_checks": [
+        "install",
+        "upgrade",
+        "selinux-enforcing",
+        "firewalld",
+        "remove"
+      ],
+      "real_host": {
+        "mode": "required",
+        "reboot_count": 2
+      }
+    },
+    {
+      "id": "APK-322",
+      "distribution": "alpine",
+      "version": "3.22",
+      "family": "apk",
+      "image": "docker.io/library/alpine:3.22@sha256:7c8cb692ae09657cbc4a3f3cbd0e8d5a2690ba38386aaaf252dbb060bf5eb2e6",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove",
+        "purge"
+      ],
+      "required_checks": [
+        "payload-only",
+        "activation",
+        "upgrade",
+        "openrc",
+        "cronie",
+        "remove",
+        "purge"
+      ],
+      "real_host": {
+        "mode": "none",
+        "reboot_count": 0
+      }
+    },
+    {
+      "id": "APK-324",
+      "distribution": "alpine",
+      "version": "3.24",
+      "family": "apk",
+      "image": "docker.io/library/alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+      "container_scenarios": [
+        "upgrade-rollback",
+        "remove",
+        "purge"
+      ],
+      "required_checks": [
+        "payload-only",
+        "activation",
+        "upgrade",
+        "openrc",
+        "cronie",
+        "remove",
+        "purge"
+      ],
+      "real_host": {
+        "mode": "required",
+        "reboot_count": 2
+      }
+    }
+  ]
+}

--- a/scripts/ci/package_qualification_matrix.py
+++ b/scripts/ci/package_qualification_matrix.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+"""Validate the frozen SysWarden AMD64 package qualification matrix."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+DEFAULT_MATRIX = Path(__file__).with_suffix(".json")
+MAX_MATRIX_BYTES = 128 * 1024
+IMAGE_PATTERN = re.compile(
+    r"^(?P<repository>[a-z0-9][a-z0-9./_-]*):"
+    r"(?P<tag>[A-Za-z0-9._-]+)@sha256:(?P<digest>[0-9a-f]{64})$"
+)
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class QualificationMatrixError(ValueError):
+    """Raised when the package qualification matrix violates its contract."""
+
+
+@dataclass(frozen=True)
+class CellContract:
+    identifier: str
+    distribution: str
+    version: str
+    family: str
+    image: str
+    container_scenarios: tuple[str, ...]
+    required_checks: tuple[str, ...]
+    real_host_mode: str
+    reboot_count: int
+
+
+@dataclass(frozen=True)
+class BaselineAsset:
+    name: str
+    identifier: int
+    size: int
+    architecture: str
+    sha256: str
+
+
+EXPECTED_ARCHITECTURE = {
+    "oci_platform": "linux/amd64",
+    "kernel": "x86_64",
+    "deb": "amd64",
+    "rpm": "x86_64",
+    "apk": "x86_64",
+}
+
+EXPECTED_CANDIDATE_SOURCE = {
+    "workflow": "package.yml",
+    "successful_run_count": 1,
+    "commit_binding": "same-candidate-commit",
+    "local_rebuild_allowed": False,
+}
+
+EXPECTED_BASELINE_SOURCE = {
+    "release": "v4.03.3",
+    "commit": "cdd66600a1505bae1f1e754dea096ee71e9cee82",
+    "release_id": 377680978,
+    "release_state": "public-stable",
+    "asset_selection": "github-asset-id",
+}
+
+EXPECTED_BASELINE_ASSETS = (
+    BaselineAsset(
+        "SHA256SUMS.txt",
+        532015727,
+        283,
+        "metadata",
+        "91c89428bf20d2386adf0d7529dc5edb26da6d490db872fab0771ddfce5364c2",
+    ),
+    BaselineAsset(
+        "syswarden_4.03.3_amd64.deb",
+        532015759,
+        13874730,
+        "amd64",
+        "4d17e74b16022be31a3e6db8851386f8c0df14772ea38f04f7df45540c818c9b",
+    ),
+    BaselineAsset(
+        "syswarden-4.03.3-1.x86_64.rpm",
+        532015720,
+        14160347,
+        "x86_64",
+        "42e207f7f5ae47384c0c35764cf4da179feed1cac34f4fb3bfbd3b59aee8881e",
+    ),
+    BaselineAsset(
+        "syswarden_4.03.3_x86_64.apk",
+        532015763,
+        14039148,
+        "x86_64",
+        "73f2d1cf67f62e781dc3d78cc9f9b2d5732ec876fee6587b305aeaaa3830f3d5",
+    ),
+)
+
+EXPECTED_ARTIFACT_INVENTORY = (
+    "deb:amd64",
+    "rpm:x86_64",
+    "apk:x86_64",
+    "SHA256SUMS.txt",
+)
+
+EXPECTED_BUDGETS = {
+    "protected_qualification_seconds": 21600,
+    "package_build_or_extract_seconds": 900,
+    "lifecycle_scenario_seconds": 600,
+    "kernel_lab": {
+        "seconds": 240,
+        "pids": 128,
+        "memory_mib": 512,
+        "tmpfs_mib": 64,
+    },
+    "container_cell_seconds": 2700,
+    "real_host_cell_seconds": 5400,
+    "post_reboot_ready_seconds": 600,
+    "updater_download_seconds": 600,
+    "updater_install_seconds": 1800,
+}
+
+EXPECTED_EVIDENCE = (
+    "immutable-base-identity",
+    "kernel-architecture-and-package-manager",
+    "candidate-source-commit",
+    "candidate-workflow-run-id",
+    "candidate-artifact-id",
+    "baseline-release-asset-id",
+    "package-name-size-and-sha256",
+    "package-inventory-before-and-after",
+    "redacted-configuration-before-and-after",
+    "services-and-init-system",
+    "nftables-state-and-rule-ownership",
+    "selinux-and-firewalld-when-required",
+    "openrc-and-cronie-when-required",
+    "lifecycle-scenario-results",
+    "owned-residue-absence",
+    "required-real-reboots",
+    "complete-private-logs",
+    "redacted-public-summary",
+    "same-candidate-commit-verdict",
+)
+
+EXPECTED_CELLS = (
+    CellContract(
+        "DEB-13",
+        "debian",
+        "13",
+        "deb",
+        "docker.io/library/debian:13-slim@sha256:"
+        "d7e12182ce18b85b93007c1dedf31f2d29e01ccf3182cc4017c709b6259bc132",
+        ("upgrade-rollback", "remove", "purge"),
+        (
+            "install",
+            "upgrade",
+            "rollback",
+            "remove",
+            "reinstall",
+            "purge",
+        ),
+        "required",
+        2,
+    ),
+    CellContract(
+        "DEB-U2404",
+        "ubuntu",
+        "24.04",
+        "deb",
+        "docker.io/library/ubuntu:24.04@sha256:"
+        "019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467",
+        ("upgrade-rollback", "remove", "purge"),
+        (
+            "install",
+            "upgrade",
+            "confined-recovery",
+            "remove",
+            "reinstall",
+            "purge",
+        ),
+        "none",
+        0,
+    ),
+    CellContract(
+        "DEB-U2604",
+        "ubuntu",
+        "26.04",
+        "deb",
+        "docker.io/library/ubuntu:26.04@sha256:"
+        "2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b",
+        ("upgrade-rollback", "remove", "purge"),
+        (
+            "install",
+            "signed-updater",
+            "confined-recovery",
+            "remove",
+            "reinstall",
+            "purge",
+        ),
+        "required",
+        2,
+    ),
+    CellContract(
+        "RPM-F44",
+        "fedora",
+        "44",
+        "rpm",
+        "docker.io/library/fedora:44@sha256:"
+        "89f61a124414261868224666aa7fb8df1b78397a53623774bdfb105d1612b48b",
+        ("upgrade-rollback", "remove"),
+        (
+            "install",
+            "upgrade",
+            "nftables",
+            "cronie",
+            "remove",
+        ),
+        "conditional",
+        1,
+    ),
+    CellContract(
+        "RPM-A9",
+        "almalinux",
+        "9",
+        "rpm",
+        "docker.io/library/almalinux:9@sha256:"
+        "28db580abb508f7ccbc0ac6d53e1d8da9d42a26c77fa3dcc26ac2726673fbe3e",
+        ("upgrade-rollback", "remove"),
+        ("install", "upgrade", "selinux-enforcing", "firewalld", "remove"),
+        "none",
+        0,
+    ),
+    CellContract(
+        "RPM-A10",
+        "almalinux",
+        "10",
+        "rpm",
+        "docker.io/library/almalinux:10@sha256:"
+        "cc24bc5b6ac7e284f2f62a07bdaa1b15d3319fdcf46413c6b8fe9fa245068ddd",
+        ("upgrade-rollback", "remove"),
+        (
+            "install",
+            "upgrade",
+            "selinux-enforcing",
+            "firewalld",
+            "remove",
+        ),
+        "required",
+        2,
+    ),
+    CellContract(
+        "APK-322",
+        "alpine",
+        "3.22",
+        "apk",
+        "docker.io/library/alpine:3.22@sha256:"
+        "7c8cb692ae09657cbc4a3f3cbd0e8d5a2690ba38386aaaf252dbb060bf5eb2e6",
+        ("upgrade-rollback", "remove", "purge"),
+        (
+            "payload-only",
+            "activation",
+            "upgrade",
+            "openrc",
+            "cronie",
+            "remove",
+            "purge",
+        ),
+        "none",
+        0,
+    ),
+    CellContract(
+        "APK-324",
+        "alpine",
+        "3.24",
+        "apk",
+        "docker.io/library/alpine:3.24@sha256:"
+        "28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+        ("upgrade-rollback", "remove", "purge"),
+        (
+            "payload-only",
+            "activation",
+            "upgrade",
+            "openrc",
+            "cronie",
+            "remove",
+            "purge",
+        ),
+        "required",
+        2,
+    ),
+)
+
+TOP_LEVEL_KEYS = {
+    "schema_version",
+    "matrix_id",
+    "target_release",
+    "architecture",
+    "package_sources",
+    "budgets",
+    "required_evidence",
+    "cells",
+}
+CELL_KEYS = {
+    "id",
+    "distribution",
+    "version",
+    "family",
+    "image",
+    "container_scenarios",
+    "required_checks",
+    "real_host",
+}
+REAL_HOST_KEYS = {"mode", "reboot_count"}
+REAL_HOST_REBOOT_COUNTS = {"none": 0, "conditional": 1, "required": 2}
+BASELINE_ASSET_KEYS = {"name", "id", "size", "architecture", "sha256"}
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise QualificationMatrixError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise QualificationMatrixError(f"non-finite JSON value is forbidden: {value}")
+
+
+def _stable_regular_file_bytes(path: Path) -> bytes:
+    absolute = path.expanduser().absolute()
+    try:
+        before = absolute.lstat()
+    except OSError as exc:
+        raise QualificationMatrixError(f"cannot inspect matrix {absolute}: {exc}") from exc
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise QualificationMatrixError(f"matrix is not a regular non-symlink file: {absolute}")
+    if before.st_size <= 0 or before.st_size > MAX_MATRIX_BYTES:
+        raise QualificationMatrixError(
+            f"matrix size must be between 1 and {MAX_MATRIX_BYTES} bytes: {absolute}"
+        )
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(absolute, flags)
+    except OSError as exc:
+        raise QualificationMatrixError(f"cannot open matrix {absolute}: {exc}") from exc
+    try:
+        opened_before = os.fstat(descriptor)
+        if not stat.S_ISREG(opened_before.st_mode):
+            raise QualificationMatrixError(f"opened matrix is not a regular file: {absolute}")
+        if (before.st_dev, before.st_ino) != (
+            opened_before.st_dev,
+            opened_before.st_ino,
+        ):
+            raise QualificationMatrixError(f"matrix identity changed before read: {absolute}")
+        chunks: list[bytes] = []
+        consumed = 0
+        while True:
+            chunk = os.read(descriptor, min(64 * 1024, MAX_MATRIX_BYTES + 1 - consumed))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            consumed += len(chunk)
+            if consumed > MAX_MATRIX_BYTES:
+                raise QualificationMatrixError(f"matrix exceeds size limit: {absolute}")
+        opened_after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+    identity_fields = (
+        "st_dev",
+        "st_ino",
+        "st_mode",
+        "st_uid",
+        "st_gid",
+        "st_size",
+        "st_mtime_ns",
+        "st_ctime_ns",
+    )
+    if any(
+        getattr(opened_before, field) != getattr(opened_after, field)
+        for field in identity_fields
+    ):
+        raise QualificationMatrixError(f"matrix changed while being read: {absolute}")
+    data = b"".join(chunks)
+    if len(data) != opened_after.st_size:
+        raise QualificationMatrixError(f"matrix read size changed: {absolute}")
+    return data
+
+
+def _strict_json(data: bytes, label: str) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            data.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=_reject_non_finite,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise QualificationMatrixError(f"invalid JSON in {label}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise QualificationMatrixError(f"{label} root must be a JSON object")
+    return document
+
+
+def _require_exact_keys(value: object, expected: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise QualificationMatrixError(f"{label} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise QualificationMatrixError(
+            f"{label} keys are not exact; missing={missing}, unexpected={unexpected}"
+        )
+    return value
+
+
+def _reject_active_arm_tokens(value: object, path: str = "matrix") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _reject_active_arm_tokens(key, f"{path}.<key>")
+            _reject_active_arm_tokens(item, f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_active_arm_tokens(item, f"{path}[{index}]")
+        return
+    if isinstance(value, str):
+        folded = value.casefold()
+        if "arm64" in folded or "aarch64" in folded:
+            raise QualificationMatrixError(
+                f"retired architecture token is forbidden at {path}"
+            )
+
+
+def _require_exact_mapping(value: object, expected: dict[str, Any], label: str) -> None:
+    mapping = _require_exact_keys(value, set(expected), label)
+    for key, expected_value in expected.items():
+        actual = mapping[key]
+        if type(actual) is not type(expected_value) or actual != expected_value:
+            raise QualificationMatrixError(f"{label} does not match the frozen contract")
+
+
+def _require_exact_list(value: object, expected: tuple[str, ...], label: str) -> None:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise QualificationMatrixError(f"{label} must be a string array")
+    if tuple(value) != expected:
+        raise QualificationMatrixError(f"{label} does not match the frozen order")
+
+
+def _validate_baseline_assets(value: object) -> None:
+    if not isinstance(value, list):
+        raise QualificationMatrixError("package_sources.baseline.assets must be an array")
+    if len(value) != len(EXPECTED_BASELINE_ASSETS):
+        raise QualificationMatrixError(
+            "package_sources.baseline.assets must contain exactly four entries"
+        )
+    names: list[str] = []
+    identifiers: list[int] = []
+    for index, (raw, contract) in enumerate(
+        zip(value, EXPECTED_BASELINE_ASSETS, strict=True)
+    ):
+        label = f"package_sources.baseline.assets[{index}]"
+        asset = _require_exact_keys(raw, BASELINE_ASSET_KEYS, label)
+        expected = {
+            "name": contract.name,
+            "id": contract.identifier,
+            "size": contract.size,
+            "architecture": contract.architecture,
+            "sha256": contract.sha256,
+        }
+        _require_exact_mapping(asset, expected, label)
+        if type(asset["id"]) is not int or asset["id"] <= 0:
+            raise QualificationMatrixError(f"{label}.id must be a positive integer")
+        if type(asset["size"]) is not int or asset["size"] <= 0:
+            raise QualificationMatrixError(f"{label}.size must be a positive integer")
+        if re.fullmatch(r"[0-9a-f]{64}", asset["sha256"]) is None:
+            raise QualificationMatrixError(f"{label}.sha256 is not canonical")
+        names.append(asset["name"])
+        identifiers.append(asset["id"])
+    if len(set(names)) != len(names):
+        raise QualificationMatrixError("baseline asset names must be unique")
+    if len(set(identifiers)) != len(identifiers):
+        raise QualificationMatrixError("baseline asset IDs must be unique")
+
+
+def _validate_package_sources(value: object) -> None:
+    sources = _require_exact_keys(
+        value, {"candidate", "baseline", "artifact_inventory"}, "package_sources"
+    )
+    _require_exact_mapping(
+        sources["candidate"], EXPECTED_CANDIDATE_SOURCE, "package_sources.candidate"
+    )
+    baseline = _require_exact_keys(
+        sources["baseline"],
+        set(EXPECTED_BASELINE_SOURCE) | {"assets"},
+        "package_sources.baseline",
+    )
+    _require_exact_mapping(
+        {key: baseline[key] for key in EXPECTED_BASELINE_SOURCE},
+        EXPECTED_BASELINE_SOURCE,
+        "package_sources.baseline identity",
+    )
+    if COMMIT_PATTERN.fullmatch(baseline["commit"]) is None:
+        raise QualificationMatrixError("baseline commit is not a full lowercase SHA")
+    if type(baseline["release_id"]) is not int or baseline["release_id"] <= 0:
+        raise QualificationMatrixError("baseline release_id must be a positive integer")
+    _validate_baseline_assets(baseline["assets"])
+    _require_exact_list(
+        sources["artifact_inventory"],
+        EXPECTED_ARTIFACT_INVENTORY,
+        "package_sources.artifact_inventory",
+    )
+
+
+def _validate_budgets(value: object) -> None:
+    budgets = _require_exact_keys(value, set(EXPECTED_BUDGETS), "budgets")
+    kernel = _require_exact_keys(
+        budgets["kernel_lab"], set(EXPECTED_BUDGETS["kernel_lab"]), "budgets.kernel_lab"
+    )
+    for label, actual, expected in (
+        *(
+            (f"budgets.{key}", budgets[key], expected)
+            for key, expected in EXPECTED_BUDGETS.items()
+            if key != "kernel_lab"
+        ),
+        *(
+            (f"budgets.kernel_lab.{key}", kernel[key], expected)
+            for key, expected in EXPECTED_BUDGETS["kernel_lab"].items()
+        ),
+    ):
+        if isinstance(actual, bool) or not isinstance(actual, int) or actual != expected:
+            raise QualificationMatrixError(
+                f"{label} must equal the frozen positive integer {expected}"
+            )
+
+
+def _validate_image(image: object, contract: CellContract, label: str) -> None:
+    if not isinstance(image, str):
+        raise QualificationMatrixError(f"{label} must be a string")
+    match = IMAGE_PATTERN.fullmatch(image)
+    if match is None:
+        raise QualificationMatrixError(
+            f"{label} must be an official tag-and-sha256 OCI reference"
+        )
+    expected_match = IMAGE_PATTERN.fullmatch(contract.image)
+    if expected_match is None:
+        raise AssertionError(f"invalid built-in image contract for {contract.identifier}")
+    if match.group("repository") != expected_match.group("repository"):
+        raise QualificationMatrixError(f"{label} does not use the frozen official repository")
+    if match.group("tag") != expected_match.group("tag"):
+        raise QualificationMatrixError(f"{label} does not use the frozen readable tag")
+    if image != contract.image:
+        raise QualificationMatrixError(f"{label} does not match the frozen OCI digest")
+
+
+def _validate_real_host(value: object, contract: CellContract, label: str) -> None:
+    real_host = _require_exact_keys(value, REAL_HOST_KEYS, label)
+    mode = real_host["mode"]
+    reboot_count = real_host["reboot_count"]
+    if not isinstance(mode, str) or mode not in REAL_HOST_REBOOT_COUNTS:
+        raise QualificationMatrixError(f"{label}.mode is unsupported")
+    if type(reboot_count) is not int or reboot_count < 0:
+        raise QualificationMatrixError(f"{label}.reboot_count must be a non-negative integer")
+    if reboot_count != REAL_HOST_REBOOT_COUNTS[mode]:
+        raise QualificationMatrixError(
+            f"{label} mode and reboot_count are an invalid combination"
+        )
+    if mode != contract.real_host_mode or reboot_count != contract.reboot_count:
+        raise QualificationMatrixError(f"{label} does not match the frozen obligation")
+
+
+def _validate_cells(value: object) -> None:
+    if not isinstance(value, list):
+        raise QualificationMatrixError("cells must be an array")
+    if len(value) != len(EXPECTED_CELLS):
+        raise QualificationMatrixError(
+            f"cells must contain exactly {len(EXPECTED_CELLS)} entries"
+        )
+    identifiers: list[str] = []
+    images: list[str] = []
+    for index, (raw, contract) in enumerate(zip(value, EXPECTED_CELLS, strict=True)):
+        label = f"cells[{index}]"
+        cell = _require_exact_keys(raw, CELL_KEYS, label)
+        for field, expected in (
+            ("id", contract.identifier),
+            ("distribution", contract.distribution),
+            ("version", contract.version),
+            ("family", contract.family),
+        ):
+            actual = cell[field]
+            if not isinstance(actual, str) or actual != expected:
+                raise QualificationMatrixError(
+                    f"{label}.{field} must equal the frozen value {expected!r}"
+                )
+        _validate_image(cell["image"], contract, f"{label}.image")
+        _require_exact_list(
+            cell["container_scenarios"],
+            contract.container_scenarios,
+            f"{label}.container_scenarios",
+        )
+        _require_exact_list(
+            cell["required_checks"],
+            contract.required_checks,
+            f"{label}.required_checks",
+        )
+        if any("reboot" in check.casefold() for check in cell["required_checks"]):
+            raise QualificationMatrixError(
+                f"{label}.required_checks must not encode real-host reboots"
+            )
+        _validate_real_host(cell["real_host"], contract, f"{label}.real_host")
+        identifiers.append(cell["id"])
+        images.append(cell["image"])
+    if len(set(identifiers)) != len(identifiers):
+        raise QualificationMatrixError("cell identifiers must be unique")
+    if len(set(images)) != len(images):
+        raise QualificationMatrixError("cell image identities must be unique")
+
+
+def validate_document(document: object) -> dict[str, Any]:
+    matrix = _require_exact_keys(document, TOP_LEVEL_KEYS, "matrix")
+    _reject_active_arm_tokens(matrix)
+    if type(matrix["schema_version"]) is not int or matrix["schema_version"] != 1:
+        raise QualificationMatrixError("schema_version must equal integer 1")
+    if matrix["matrix_id"] != "syswarden-package-qualification/v1":
+        raise QualificationMatrixError("matrix_id does not match the v1 contract")
+    if matrix["target_release"] != "v4.04.0":
+        raise QualificationMatrixError("target_release must equal v4.04.0")
+    _require_exact_mapping(matrix["architecture"], EXPECTED_ARCHITECTURE, "architecture")
+    _validate_package_sources(matrix["package_sources"])
+    _validate_budgets(matrix["budgets"])
+    _require_exact_list(matrix["required_evidence"], EXPECTED_EVIDENCE, "required_evidence")
+    _validate_cells(matrix["cells"])
+    return matrix
+
+
+def load_matrix_snapshot(
+    path: Path = DEFAULT_MATRIX,
+) -> tuple[dict[str, Any], str]:
+    data = _stable_regular_file_bytes(path)
+    document = validate_document(_strict_json(data, str(path)))
+    return document, hashlib.sha256(data).hexdigest()
+
+
+def load_matrix(path: Path = DEFAULT_MATRIX) -> dict[str, Any]:
+    document, _ = load_matrix_snapshot(path)
+    return document
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        type=Path,
+        default=DEFAULT_MATRIX,
+        metavar="PATH",
+        help=f"matrix to validate (default: {DEFAULT_MATRIX})",
+    )
+    parser.add_argument(
+        "--expected-target-release",
+        help="require the matrix target to match this exact release tag",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        matrix, matrix_sha256 = load_matrix_snapshot(args.check)
+        if (
+            args.expected_target_release is not None
+            and matrix["target_release"] != args.expected_target_release
+        ):
+            raise QualificationMatrixError(
+                "matrix target_release does not match --expected-target-release"
+            )
+    except QualificationMatrixError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "Package qualification matrix validated: "
+        f"{len(matrix['cells'])} AMD64 cells for {matrix['target_release']}; "
+        f"sha256={matrix_sha256}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/package_qualification_matrix_test.py
+++ b/scripts/ci/package_qualification_matrix_test.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Test the frozen SysWarden AMD64 package qualification matrix contract."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+try:
+    from scripts.ci import package_qualification_matrix as matrix
+except ModuleNotFoundError:  # Direct execution from scripts/ci.
+    import package_qualification_matrix as matrix
+
+
+class PackageQualificationMatrixTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.canonical = matrix.load_matrix()
+
+    def document(self) -> dict[str, object]:
+        return copy.deepcopy(self.canonical)
+
+    def assert_invalid(self, document: object, message: str) -> None:
+        with self.assertRaisesRegex(matrix.QualificationMatrixError, message):
+            matrix.validate_document(document)
+
+    def write_payload(self, root: Path, payload: bytes) -> Path:
+        path = root / "matrix.json"
+        path.write_bytes(payload)
+        return path
+
+    def test_repository_matrix_is_the_exact_frozen_contract(self) -> None:
+        document = self.canonical
+        self.assertEqual(document["schema_version"], 1)
+        self.assertEqual(document["target_release"], "v4.04.0")
+        self.assertEqual(document["architecture"], matrix.EXPECTED_ARCHITECTURE)
+        self.assertEqual(
+            tuple(cell["id"] for cell in document["cells"]),
+            tuple(contract.identifier for contract in matrix.EXPECTED_CELLS),
+        )
+        self.assertEqual(
+            tuple(cell["image"] for cell in document["cells"]),
+            tuple(contract.image for contract in matrix.EXPECTED_CELLS),
+        )
+        self.assertEqual(
+            tuple(tuple(cell["container_scenarios"]) for cell in document["cells"]),
+            tuple(contract.container_scenarios for contract in matrix.EXPECTED_CELLS),
+        )
+        self.assertEqual(
+            tuple(tuple(cell["required_checks"]) for cell in document["cells"]),
+            tuple(contract.required_checks for contract in matrix.EXPECTED_CELLS),
+        )
+        self.assertEqual(
+            tuple(
+                (cell["real_host"]["mode"], cell["real_host"]["reboot_count"])
+                for cell in document["cells"]
+            ),
+            tuple(
+                (contract.real_host_mode, contract.reboot_count)
+                for contract in matrix.EXPECTED_CELLS
+            ),
+        )
+
+    def test_cli_checks_repository_matrix_by_default_and_by_explicit_path(self) -> None:
+        for arguments in (
+            (),
+            ("--check", str(matrix.DEFAULT_MATRIX)),
+            ("--expected-target-release", "v4.04.0"),
+        ):
+            with self.subTest(arguments=arguments):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    result = matrix.main(arguments)
+                self.assertEqual(result, 0, stderr.getvalue())
+                self.assertEqual(stderr.getvalue(), "")
+                self.assertIn("8 AMD64 cells for v4.04.0", stdout.getvalue())
+                self.assertRegex(stdout.getvalue(), r"sha256=[0-9a-f]{64}\n$")
+
+    def test_cli_rejects_a_target_release_mismatch(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            result = matrix.main(("--expected-target-release", "v4.04.1"))
+        self.assertEqual(result, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("target_release", stderr.getvalue())
+
+    def test_snapshot_binds_validated_document_to_exact_file_sha256(self) -> None:
+        document, digest = matrix.load_matrix_snapshot()
+        expected = hashlib.sha256(matrix.DEFAULT_MATRIX.read_bytes()).hexdigest()
+        self.assertEqual(document, self.canonical)
+        self.assertEqual(matrix.load_matrix(), document)
+        self.assertEqual(digest, expected)
+        self.assertRegex(digest, r"^[0-9a-f]{64}$")
+
+    def test_top_level_schema_is_closed(self) -> None:
+        missing = self.document()
+        missing.pop("budgets")
+        self.assert_invalid(missing, "keys are not exact")
+        unexpected = self.document()
+        unexpected["waiver"] = True
+        self.assert_invalid(unexpected, "keys are not exact")
+        self.assert_invalid([], "matrix must be an object")
+
+    def test_schema_identity_and_target_release_are_exact(self) -> None:
+        for field, value, message in (
+            ("schema_version", 2, "schema_version"),
+            ("schema_version", True, "schema_version"),
+            ("schema_version", 1.0, "schema_version"),
+            ("schema_version", "1", "schema_version"),
+            ("schema_version", None, "schema_version"),
+            ("matrix_id", "syswarden-package-qualification/v2", "matrix_id"),
+            ("target_release", "v4.04.1", "target_release"),
+        ):
+            with self.subTest(field=field, value=value):
+                changed = self.document()
+                changed[field] = value
+                self.assert_invalid(changed, message)
+
+    def test_architecture_contract_is_closed_and_amd64_only(self) -> None:
+        for key, value in (
+            ("oci_platform", "linux/" + "arm64"),
+            ("kernel", "aarch" + "64"),
+            ("deb", "arm" + "64"),
+            ("rpm", "aarch" + "64"),
+            ("apk", "arm" + "64"),
+        ):
+            with self.subTest(key=key):
+                changed = self.document()
+                changed["architecture"][key] = value
+                self.assert_invalid(changed, "retired architecture token")
+        changed = self.document()
+        changed["architecture"]["extra"] = "amd64"
+        self.assert_invalid(changed, "architecture keys are not exact")
+
+    def test_active_arm_tokens_are_rejected_recursively_and_case_insensitively(self) -> None:
+        for value in ("arm" + "64", "aarch" + "64", "LiNuX/ARM" + "64"):
+            with self.subTest(value=value):
+                changed = self.document()
+                changed["cells"][0]["required_checks"][0] = value
+                self.assert_invalid(changed, "retired architecture token")
+        changed = self.document()
+        changed["cells"][0]["arm" + "64"] = "disabled"
+        self.assert_invalid(changed, "retired architecture token")
+
+    def test_candidate_source_is_same_commit_single_run_and_forbids_local_rebuild(self) -> None:
+        mutations = {
+            "workflow": "other.yml",
+            "successful_run_count": 2,
+            "commit_binding": "floating-branch",
+            "local_rebuild_allowed": True,
+        }
+        for key, value in mutations.items():
+            with self.subTest(key=key):
+                changed = self.document()
+                changed["package_sources"]["candidate"][key] = value
+                self.assert_invalid(changed, "candidate does not match")
+        for key, value in (
+            ("successful_run_count", True),
+            ("local_rebuild_allowed", 0),
+        ):
+            with self.subTest(key=key, wrong_type=value):
+                changed = self.document()
+                changed["package_sources"]["candidate"][key] = value
+                self.assert_invalid(changed, "candidate does not match")
+        changed = self.document()
+        changed["package_sources"]["candidate"]["retry"] = True
+        self.assert_invalid(changed, "candidate keys are not exact")
+
+    def test_baseline_source_is_exact_public_v4033_identity(self) -> None:
+        mutations = {
+            "release": "v4.03.2",
+            "commit": "0" * 40,
+            "release_id": 377680979,
+            "release_state": "prerelease",
+            "asset_selection": "filename",
+        }
+        for key, value in mutations.items():
+            with self.subTest(key=key):
+                changed = self.document()
+                changed["package_sources"]["baseline"][key] = value
+                self.assert_invalid(changed, "baseline identity does not match")
+        for value in (True, 377680978.0, "377680978", None):
+            with self.subTest(release_id=value):
+                changed = self.document()
+                changed["package_sources"]["baseline"]["release_id"] = value
+                self.assert_invalid(changed, "baseline identity does not match")
+        changed = self.document()
+        changed["package_sources"]["baseline"]["unexpected"] = True
+        self.assert_invalid(changed, "baseline keys are not exact")
+
+    def test_baseline_assets_are_exact_ordered_and_strictly_typed(self) -> None:
+        assets = self.canonical["package_sources"]["baseline"]["assets"]
+        self.assertEqual(
+            tuple(
+                (
+                    asset["name"],
+                    asset["id"],
+                    asset["size"],
+                    asset["architecture"],
+                    asset["sha256"],
+                )
+                for asset in assets
+            ),
+            tuple(
+                (
+                    asset.name,
+                    asset.identifier,
+                    asset.size,
+                    asset.architecture,
+                    asset.sha256,
+                )
+                for asset in matrix.EXPECTED_BASELINE_ASSETS
+            ),
+        )
+        missing = self.document()
+        missing["package_sources"]["baseline"]["assets"].pop()
+        self.assert_invalid(missing, "exactly four entries")
+        reordered = self.document()
+        reordered["package_sources"]["baseline"]["assets"].reverse()
+        self.assert_invalid(reordered, r"assets\[0\] does not match")
+        for field, value in (
+            ("name", "renamed.deb"),
+            ("id", 532015728),
+            ("size", 284),
+            ("architecture", "x86_64"),
+            ("sha256", "0" * 64),
+        ):
+            with self.subTest(field=field):
+                changed = self.document()
+                changed["package_sources"]["baseline"]["assets"][0][field] = value
+                self.assert_invalid(changed, r"assets\[0\] does not match")
+        for field, value in (
+            ("id", True),
+            ("id", 532015727.0),
+            ("id", "532015727"),
+            ("id", None),
+            ("size", True),
+            ("size", 283.0),
+            ("size", "283"),
+            ("size", None),
+        ):
+            with self.subTest(field=field, value=value):
+                changed = self.document()
+                changed["package_sources"]["baseline"]["assets"][0][field] = value
+                self.assert_invalid(changed, r"assets\[0\] does not match")
+        changed = self.document()
+        changed["package_sources"]["baseline"]["assets"][0]["extra"] = 1
+        self.assert_invalid(changed, r"assets\[0\] keys are not exact")
+
+    def test_artifact_inventory_is_exact_ordered_amd64_inventory(self) -> None:
+        for inventory in (
+            list(matrix.EXPECTED_ARTIFACT_INVENTORY[:-1]),
+            list(reversed(matrix.EXPECTED_ARTIFACT_INVENTORY)),
+            [*matrix.EXPECTED_ARTIFACT_INVENTORY, "extra"],
+            ["deb:" + "arm64", *matrix.EXPECTED_ARTIFACT_INVENTORY[1:]],
+        ):
+            with self.subTest(inventory=inventory):
+                changed = self.document()
+                changed["package_sources"]["artifact_inventory"] = inventory
+                message = (
+                    "retired architecture token"
+                    if any("arm64" in item for item in inventory)
+                    else "frozen order"
+                )
+                self.assert_invalid(changed, message)
+
+    def test_budgets_are_closed_exact_positive_integers(self) -> None:
+        changed = self.document()
+        changed["budgets"].pop("updater_install_seconds")
+        self.assert_invalid(changed, "budgets keys are not exact")
+        changed = self.document()
+        changed["budgets"]["extra"] = 1
+        self.assert_invalid(changed, "budgets keys are not exact")
+        for value in (True, 0, -1, 600.0, 601):
+            with self.subTest(value=value):
+                changed = self.document()
+                changed["budgets"]["lifecycle_scenario_seconds"] = value
+                self.assert_invalid(changed, "frozen positive integer 600")
+        changed = self.document()
+        changed["budgets"]["kernel_lab"]["memory_mib"] = 1024
+        self.assert_invalid(changed, "frozen positive integer 512")
+        changed = self.document()
+        changed["budgets"]["kernel_lab"]["unknown"] = 1
+        self.assert_invalid(changed, "kernel_lab keys are not exact")
+
+    def test_required_evidence_is_dynamic_exact_and_ordered(self) -> None:
+        for evidence in (
+            list(matrix.EXPECTED_EVIDENCE[:-1]),
+            list(reversed(matrix.EXPECTED_EVIDENCE)),
+            [*matrix.EXPECTED_EVIDENCE, "operator-waiver"],
+        ):
+            with self.subTest(evidence=evidence):
+                changed = self.document()
+                changed["required_evidence"] = evidence
+                self.assert_invalid(changed, "required_evidence does not match")
+        flattened = json.dumps(self.canonical).casefold()
+        self.assertNotIn("node01", flattened)
+        self.assertNotIn("node02", flattened)
+        self.assertNotIn("node03", flattened)
+        self.assertNotIn("node04", flattened)
+
+    def test_cell_set_and_order_are_exact(self) -> None:
+        missing = self.document()
+        missing["cells"].pop()
+        self.assert_invalid(missing, "exactly 8 entries")
+        extra = self.document()
+        extra["cells"].append(copy.deepcopy(extra["cells"][-1]))
+        self.assert_invalid(extra, "exactly 8 entries")
+        reordered = self.document()
+        reordered["cells"][0], reordered["cells"][1] = (
+            reordered["cells"][1],
+            reordered["cells"][0],
+        )
+        self.assert_invalid(reordered, "must equal the frozen value")
+
+    def test_cell_schema_and_identity_are_closed(self) -> None:
+        changed = self.document()
+        changed["cells"][0].pop("family")
+        self.assert_invalid(changed, r"cells\[0\] keys are not exact")
+        changed = self.document()
+        changed["cells"][0]["waiver"] = False
+        self.assert_invalid(changed, r"cells\[0\] keys are not exact")
+        for field, value in (
+            ("id", "DEB-OTHER"),
+            ("distribution", "other"),
+            ("version", "latest"),
+            ("family", "rpm"),
+        ):
+            with self.subTest(field=field):
+                changed = self.document()
+                changed["cells"][0][field] = value
+                self.assert_invalid(changed, f"cells\\[0\\].{field}")
+
+    def test_oci_images_require_exact_official_tag_and_digest(self) -> None:
+        original = self.canonical["cells"][0]["image"]
+        digest = original.rsplit("@sha256:", 1)[1]
+        mutations = (
+            original.split("@", 1)[0],
+            original.replace("docker.io/library/debian", "example.invalid/debian"),
+            original.replace(":13-slim@", ":latest@"),
+            original.replace(digest, digest.upper()),
+            original[:-1] + ("0" if original[-1] != "0" else "1"),
+            original.replace("@sha256:", "@sha512:"),
+        )
+        for image in mutations:
+            with self.subTest(image=image):
+                changed = self.document()
+                changed["cells"][0]["image"] = image
+                self.assert_invalid(
+                    changed,
+                    "tag-and-sha256|official repository|readable tag|OCI digest",
+                )
+
+    def test_container_scenarios_are_exact_and_ordered_for_every_cell(self) -> None:
+        for index, contract in enumerate(matrix.EXPECTED_CELLS):
+            for scenarios in (
+                list(contract.container_scenarios[:-1]),
+                list(reversed(contract.container_scenarios)),
+                [*contract.container_scenarios, "waived"],
+            ):
+                with self.subTest(cell=contract.identifier, scenarios=scenarios):
+                    changed = self.document()
+                    changed["cells"][index]["container_scenarios"] = scenarios
+                    self.assert_invalid(changed, "container_scenarios does not match")
+
+    def test_required_checks_are_exact_and_never_encode_reboots(self) -> None:
+        for index, contract in enumerate(matrix.EXPECTED_CELLS):
+            for checks in (
+                list(contract.required_checks[:-1]),
+                list(reversed(contract.required_checks)),
+                [*contract.required_checks, "waived"],
+            ):
+                with self.subTest(cell=contract.identifier, checks=checks):
+                    changed = self.document()
+                    changed["cells"][index]["required_checks"] = checks
+                    self.assert_invalid(changed, "required_checks does not match")
+            self.assertFalse(
+                any("reboot" in check for check in contract.required_checks),
+                contract.identifier,
+            )
+
+    def test_real_host_modes_and_reboot_counts_are_closed_and_exact(self) -> None:
+        expected = (
+            ("required", 2),
+            ("none", 0),
+            ("required", 2),
+            ("conditional", 1),
+            ("none", 0),
+            ("required", 2),
+            ("none", 0),
+            ("required", 2),
+        )
+        self.assertEqual(
+            tuple(
+                (cell["real_host"]["mode"], cell["real_host"]["reboot_count"])
+                for cell in self.canonical["cells"]
+            ),
+            expected,
+        )
+        for mode, count in (
+            ("none", 1),
+            ("conditional", 0),
+            ("conditional", 2),
+            ("required", 0),
+            ("required", 1),
+        ):
+            with self.subTest(mode=mode, count=count):
+                changed = self.document()
+                changed["cells"][0]["real_host"] = {
+                    "mode": mode,
+                    "reboot_count": count,
+                }
+                self.assert_invalid(changed, "invalid combination|frozen obligation")
+        for value in (True, 2.0, "2", None, -1):
+            with self.subTest(reboot_count=value):
+                changed = self.document()
+                changed["cells"][0]["real_host"]["reboot_count"] = value
+                self.assert_invalid(changed, "non-negative integer")
+        changed = self.document()
+        changed["cells"][0]["real_host"]["mode"] = "optional"
+        self.assert_invalid(changed, "mode is unsupported")
+        changed = self.document()
+        changed["cells"][0]["real_host"]["identity"] = "host"
+        self.assert_invalid(changed, "real_host keys are not exact")
+
+    def test_duplicate_keys_non_finite_values_and_trailing_json_are_rejected(self) -> None:
+        payloads = (
+            b'{"schema_version":1,"schema_version":1}',
+            b'{"schema_version":NaN}',
+            b'{}\n{}\n',
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload), tempfile.TemporaryDirectory() as raw:
+                path = self.write_payload(Path(raw), payload)
+                with self.assertRaises(matrix.QualificationMatrixError):
+                    matrix.load_matrix(path)
+
+    def test_non_utf8_empty_and_oversized_files_are_rejected(self) -> None:
+        payloads = (
+            b"\xff",
+            b"",
+            b"{" + b" " * matrix.MAX_MATRIX_BYTES + b"}",
+        )
+        for payload in payloads:
+            with self.subTest(size=len(payload)), tempfile.TemporaryDirectory() as raw:
+                path = self.write_payload(Path(raw), payload)
+                with self.assertRaises(matrix.QualificationMatrixError):
+                    matrix.load_matrix(path)
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symbolic links unavailable")
+    def test_symlink_matrix_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = root / "target.json"
+            target.write_text(json.dumps(self.canonical), encoding="utf-8")
+            link = root / "matrix.json"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(
+                matrix.QualificationMatrixError, "non-symlink"
+            ):
+                matrix.load_matrix(link)
+
+    def test_cli_failure_is_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            invalid = Path(raw) / "invalid.json"
+            invalid.write_text("{}\n", encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                result = matrix.main(("--check", str(invalid)))
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertTrue(stderr.getvalue().startswith("ERROR: "))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -12,11 +12,21 @@ import textwrap
 import unittest
 from pathlib import Path
 
+try:
+    from scripts.ci import package_lifecycle_lab
+    from scripts.ci import package_qualification_matrix
+except ModuleNotFoundError:  # Direct execution from scripts/ci.
+    import package_lifecycle_lab
+    import package_qualification_matrix
+
 
 REPOSITORY = Path(__file__).resolve().parents[2]
 WORKFLOW = REPOSITORY / ".github" / "workflows" / "release-qualification.yml"
 PACKAGE_WORKFLOW = REPOSITORY / ".github" / "workflows" / "package.yml"
 PACKAGE_LAB = REPOSITORY / "scripts" / "ci" / "package_lifecycle_lab.py"
+PACKAGE_QUALIFICATION_MATRIX = (
+    REPOSITORY / "scripts" / "ci" / "package_qualification_matrix.json"
+)
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
 ACTION = re.compile(r"(?m)^\s*uses:\s*([^@\s]+)@([^\s#]+)")
 RETIRED_PLATFORM = "free" + "bsd"
@@ -294,6 +304,9 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         cls.workflow = WORKFLOW.read_text(encoding="utf-8")
         cls.package_workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         cls.package_lab = PACKAGE_LAB.read_text(encoding="utf-8")
+        cls.package_qualification_matrix = package_qualification_matrix.load_matrix(
+            PACKAGE_QUALIFICATION_MATRIX
+        )
 
     def assert_read_only(self, workflow: str) -> None:
         self.assertIn("permissions:\n  actions: read\n  contents: read", workflow)
@@ -887,14 +900,41 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
                 assert_contract(self.workflow.replace(old, new, 1))
 
     def test_three_packages_and_five_native_platforms_are_exact(self) -> None:
-        matrix = self.package_lab.split("DEFAULT_PLATFORMS = (", 1)[1].split(
-            "\n)\n\nREQUIRED_PLATFORM_COORDINATES", 1
-        )[0]
-        self.assertEqual(matrix.count("PlatformSpec("), 5)
-        for name in ("Debian", "Ubuntu", "Fedora", "AlmaLinux", "Alpine"):
-            self.assertEqual(matrix.count(f'name="{name}"'), 1, name)
+        catalog = self.package_qualification_matrix
+        cells = catalog["cells"]
+        self.assertEqual(catalog["target_release"], "v4.04.0")
         self.assertEqual(
-            len(re.findall(r'(?m)^\s{8}architecture="amd64",$', matrix)), 5
+            catalog["architecture"],
+            package_qualification_matrix.EXPECTED_ARCHITECTURE,
+        )
+        self.assertEqual(len(cells), 8)
+        self.assertEqual(
+            tuple(cell["id"] for cell in cells),
+            tuple(
+                contract.identifier
+                for contract in package_qualification_matrix.EXPECTED_CELLS
+            ),
+        )
+        self.assertEqual(
+            tuple(cell["image"] for cell in cells),
+            tuple(
+                contract.image
+                for contract in package_qualification_matrix.EXPECTED_CELLS
+            ),
+        )
+
+        runtime_platforms = package_lifecycle_lab.DEFAULT_PLATFORMS
+        self.assertEqual(len(runtime_platforms), 5)
+        self.assertEqual(
+            tuple(platform.name for platform in runtime_platforms),
+            ("Debian", "Ubuntu", "Fedora", "AlmaLinux", "Alpine"),
+        )
+        self.assertEqual(
+            {platform.distribution for platform in runtime_platforms},
+            {"debian", "ubuntu", "fedora", "almalinux", "alpine"},
+        )
+        self.assertTrue(
+            all(platform.architecture == "amd64" for platform in runtime_platforms)
         )
         self.assertIn('REQUIRED_FAMILIES = ("deb", "rpm", "apk")', self.package_lab)
 
@@ -1068,12 +1108,45 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             self.package_workflow, "Test Package and Release Validators"
         )
         for test_file in (
+            "scripts/ci/package_qualification_matrix_test.py",
             "scripts/ci/package_lifecycle_lab_test.py",
             "scripts/ci/release_qualification_adapter_test.py",
             "scripts/ci/release_qualification_gate_test.py",
             "scripts/ci/release_qualification_workflow_test.py",
         ):
             self.assertEqual(step.count(test_file), 1, test_file)
+
+    def test_frozen_package_matrix_is_validated_before_costly_labs(self) -> None:
+        step_name = "Validate Frozen Package Qualification Matrix"
+        script = workflow_step_script(self.workflow, step_name)
+        expected = (
+            "set -euo pipefail\n"
+            "PYTHONDONTWRITEBYTECODE=1 python3 "
+            "scripts/ci/package_qualification_matrix.py \\\n"
+            '  --expected-target-release "${RELEASE_TAG}"\n'
+        )
+        self.assertEqual(script, expected)
+        step = workflow_step(self.workflow, step_name)
+        self.assertEqual(
+            step.count("        env:\n          RELEASE_TAG: ${{ inputs.release_tag }}\n"),
+            1,
+        )
+        self.assertEqual(
+            self.workflow.count("scripts/ci/package_qualification_matrix.py"), 1
+        )
+        qualify = workflow_job(self.workflow, "qualify-release")
+        self.assertLess(
+            qualify.index("Validate Manual Main Pre-Tag Context"),
+            qualify.index(step_name),
+        )
+        self.assertLess(
+            qualify.index(step_name),
+            qualify.index("Qualify Optional RHEL Image Extension Offline Contract"),
+        )
+        self.assertLess(
+            qualify.index(step_name),
+            qualify.index("Run and Aggregate Native AMD64 Package Lifecycle Shard"),
+        )
 
     def test_nftables_uses_private_verified_tmpdir_and_safe_cleanup(self) -> None:
         for contract in (


### PR DESCRIPTION
## Summary

- add a strict machine-readable AMD64 qualification policy for Debian 13, Ubuntu 24.04 and 26.04, Fedora 44, AlmaLinux 9 and 10, and Alpine 3.22 and 3.24;
- pin each official OCI image by readable tag and SHA-256 digest;
- bind the public v4.03.3 baseline release, release ID, package asset IDs, sizes, architectures, and SHA-256 digests;
- separate container lifecycle scenarios, required checks, and real-host reboot obligations;
- validate the frozen matrix in the package workflow and before expensive protected release laboratories;
- keep the existing five-cell runtime laboratory unchanged while the future cell-ID coordinator is developed.

## Security properties

- strict UTF-8 JSON with duplicate-key, non-finite value, unknown-field, symlink, size, type, architecture, image, digest, scenario, evidence, budget, and reboot validation;
- AMD64/x86_64 only, with retired architecture tokens rejected from the active policy;
- exact target-release binding to v4.04.0 in the protected qualification workflow;
- validated matrix bytes reported with their SHA-256 identity;
- no local package rebuild may replace the commit-bound candidate artifact.

## Verification

- 394 package and release validator tests passed; 8 expected sandbox-only UNIX socket cases were skipped;
- 54 focused matrix and workflow tests passed with Python warnings treated as errors;
- versionctl tests passed;
- commit version validation confirms this is a non-versioning change that preserves v4.03.3;
- the Debian 13 image digest was pulled and inspected as Linux AMD64;
- YAML parsing, Python compilation, JSON parsing, and diff checks passed.

## Scope

This PR freezes and enforces the prospective v4.04.0 policy. It does not claim that all eight cells have already executed. The current five runtime package cells remain unchanged. README.md and changelog.md are byte-identical, and no release version is changed.
