### PR TITLE
Docs : disclose TUI OSINT enrichment source

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The latest qualified, stable public release is
 | --- | --- |
 | [Data-Shield](https://github.com/duggytuxy/Data-Shield_IPv4_Blocklist) | Official maintainer-curated IPv4 feed for the standard and critical profiles; SysWarden accepts it locally only after canonical validation and quorum controls |
 | [IPverse country IP blocks](https://github.com/ipverse/country-ip-blocks) | Pinned CC0-1.0 RIR allocation snapshot embedded in the release-bound CLI; allocation country is not physical or current operational geolocation |
+| [WiredAlter IP Service](https://ip.wiredalter.com/) ([source](https://github.com/buildplan/ip-service)) | Best-effort cached country, ASN, organization and threat labels for Top Attackers / OSINT History display only; responses never influence severity or firewall decisions |
 | [CINS Score](https://cinsscore.com/list/ci-badguys.txt) and [blocklist.de](https://lists.blocklist.de/lists/all.txt) | Only exact entries found at both independent origins are published |
 | [Spamhaus](https://www.spamhaus.org/) and [RADB](https://www.radb.net/) | Signals may be operator-provisioned; neither source is accepted as firewall authority by itself |
 | Custom HTTPS feed | Choice 3 requires an HTTPS URL and its exact SHA-256 digest for each configured address family |


### PR DESCRIPTION
## Summary

- link the WiredAlter IP Service and its public source repository in the README intelligence-source inventory
- document its country, ASN, organization and threat enrichment for TUI Top Attackers / OSINT History
- state the exact trust boundary: responses influence neither severity nor firewall decisions

## Validation

- documentation truth gate passed for README, manual and seven wiki files
- versionctl commit validation passed with v4.04.0 preserved
- git diff check passed
- commit signature verified valid by GitHub