### PR TITLE
Fix : declare package license metadata

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -240,6 +240,8 @@ jobs:
           install -m 0644 \
             src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt \
             "${STAGING_AMD64}/usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt"
+          install -m 0644 LICENSE \
+            "${STAGING_AMD64}/usr/share/doc/syswarden/LICENSE.txt"
 
       - name: Build and Stage Static Alpine Binaries
         shell: bash
@@ -282,6 +284,8 @@ jobs:
             install -m 0644 \
               src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt \
               "${stage}/usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt"
+            install -m 0644 LICENSE \
+              "${stage}/usr/share/doc/syswarden/LICENSE.txt"
           }
 
           validate_static_apk_binary() {
@@ -339,14 +343,20 @@ jobs:
             --geoip-data-license-contract \
             scripts/ci/package_geoip_data_license_contract.json \
             --geoip-data-license-source \
-            src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt
+            src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt \
+            --project-license-contract \
+            scripts/ci/package_project_license_contract.json \
+            --project-license-source LICENSE
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_stage_gate.py \
             linux --root "${STAGING_APK_AMD64}" \
             --completion-contract scripts/ci/package_completion_contract.json \
             --geoip-data-license-contract \
             scripts/ci/package_geoip_data_license_contract.json \
             --geoip-data-license-source \
-            src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt
+            src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt \
+            --project-license-contract \
+            scripts/ci/package_project_license_contract.json \
+            --project-license-source LICENSE
 
       - name: Prepare Linux Maintainer Scripts
         run: |
@@ -712,6 +722,7 @@ jobs:
             --maintainer "SysWarden Engineering" \
             --description "SysWarden Host-based Security Orchestrator for Linux" \
             --url "https://github.com/${{ github.repository }}" \
+            --license "GPL-3.0-or-later" \
             --architecture amd64 \
             --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
             -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cron" -d "bash-completion" \
@@ -733,6 +744,7 @@ jobs:
             --maintainer "SysWarden Engineering" \
             --description "SysWarden Host-based Security Orchestrator for Linux" \
             --url "https://github.com/${{ github.repository }}" \
+            --license "GPL-3.0-or-later" \
             --architecture x86_64 \
             --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
             --rpm-changelog "${RPM_CHANGELOG}" \
@@ -764,6 +776,7 @@ jobs:
           description: "SysWarden Host-based Security Orchestrator for Alpine Linux"
           vendor: "SysWarden Security"
           homepage: "https://github.com/${{ github.repository }}"
+          license: "GPL-3.0-or-later"
           depends:
             - nftables
             - openrc
@@ -811,6 +824,7 @@ jobs:
             local architecture="$2"
             [[ "$(dpkg-deb --field "${path}" Version)" == "${VERSION}" ]]
             [[ "$(dpkg-deb --field "${path}" Architecture)" == "${architecture}" ]]
+            [[ "$(dpkg-deb --field "${path}" License)" == "GPL-3.0-or-later" ]]
           }
 
           validate_rpm_scriptlet() {
@@ -835,6 +849,7 @@ jobs:
             local actual_build_host
             local actual_build_time
             local actual_changelog_time
+            local actual_license
             local actual_version
             local forbidden_crontab_token
             local scriptlets
@@ -843,11 +858,13 @@ jobs:
             actual_build_time="$(rpm --query --package --queryformat '%{BUILDTIME}' "${path}")" || return 1
             actual_build_host="$(rpm --query --package --queryformat '%{BUILDHOST}' "${path}")" || return 1
             actual_changelog_time="$(rpm --query --package --queryformat '%{CHANGELOGTIME}' "${path}")" || return 1
+            actual_license="$(rpm --query --package --queryformat '%{LICENSE}' "${path}")" || return 1
             [[ "${actual_version}" == "${VERSION}" ]]
             [[ "${actual_architecture}" == "${architecture}" ]]
             [[ "${actual_build_time}" == "${SOURCE_DATE_EPOCH}" ]]
             [[ "${actual_build_host}" == "syswarden-build.invalid" ]]
             [[ "${actual_changelog_time}" == "${RPM_CHANGELOG_EPOCH}" ]]
+            [[ "${actual_license}" == "GPL-3.0-or-later" ]]
             scriptlets="$(rpm --query --package --scripts "${path}")" || return 1
             for forbidden_crontab_token in \
               syswarden_cron_candidate \
@@ -888,6 +905,7 @@ jobs:
             [[ "$(grep --count '^depend = openrc$' <<< "${metadata}")" -eq 1 ]]
             [[ "$(grep --count '^depend = cronie$' <<< "${metadata}")" -eq 1 ]]
             [[ "$(grep --count '^depend = cronie-openrc$' <<< "${metadata}")" -eq 1 ]]
+            [[ "$(grep --count '^license = GPL-3.0-or-later$' <<< "${metadata}")" -eq 1 ]]
             mapfile -t preinstall_members < <(
               tar --list --file "${path}" | awk '/(^|\/)\.pre-install$/ { print }'
             )

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -248,6 +248,9 @@ staging/opt/syswarden/bin/syswarden-cli completion bash > \
 install -m 0644 \
     "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt" \
     staging/usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt
+install -m 0644 \
+    "${REPOSITORY_ROOT}/LICENSE" \
+    staging/usr/share/doc/syswarden/LICENSE.txt
 cp "${REPOSITORY_ROOT}/src/core/syswarden-core/signatures.json" staging-apk/opt/syswarden/
 cp dist/bin-apk/syswarden-cli dist/bin-apk/syswarden-core dist/bin-apk/syswarden-tui staging-apk/opt/syswarden/bin/
 ln -s /opt/syswarden/bin/syswarden-cli staging-apk/usr/local/bin/syswarden
@@ -257,6 +260,9 @@ staging-apk/opt/syswarden/bin/syswarden-cli completion bash > \
 install -m 0644 \
     "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt" \
     staging-apk/usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt
+install -m 0644 \
+    "${REPOSITORY_ROOT}/LICENSE" \
+    staging-apk/usr/share/doc/syswarden/LICENSE.txt
 
 # Permissions
 chmod 750 staging/opt/syswarden/bin/*
@@ -272,7 +278,10 @@ PYTHONDONTWRITEBYTECODE=1 python3 \
     --geoip-data-license-contract \
     "${REPOSITORY_ROOT}/scripts/ci/package_geoip_data_license_contract.json" \
     --geoip-data-license-source \
-    "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt"
+    "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt" \
+    --project-license-contract \
+    "${REPOSITORY_ROOT}/scripts/ci/package_project_license_contract.json" \
+    --project-license-source "${REPOSITORY_ROOT}/LICENSE"
 PYTHONDONTWRITEBYTECODE=1 python3 \
     "${REPOSITORY_ROOT}/scripts/ci/package_stage_gate.py" \
     linux --root staging-apk \
@@ -280,7 +289,10 @@ PYTHONDONTWRITEBYTECODE=1 python3 \
     --geoip-data-license-contract \
     "${REPOSITORY_ROOT}/scripts/ci/package_geoip_data_license_contract.json" \
     --geoip-data-license-source \
-    "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt"
+    "${REPOSITORY_ROOT}/src/core/syswarden-cli/pkg/geoip/LICENSE-CC0-1.0.txt" \
+    --project-license-contract \
+    "${REPOSITORY_ROOT}/scripts/ci/package_project_license_contract.json" \
+    --project-license-source "${REPOSITORY_ROOT}/LICENSE"
 
 validate_static_apk_binary() {
     artifact="$1"
@@ -728,6 +740,7 @@ echo "[*] Generating .deb and .rpm packages via FPM..."
         --vendor "SysWarden Security" \
         --maintainer "SysWarden Engineering" \
         --description "SysWarden Host-based Security Orchestrator for Linux" \
+        --license "GPL-3.0-or-later" \
         --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
         -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cron" -d "bash-completion" \
         -d "wireguard-tools" -d "qrencode" -d "jq" -d "unattended-upgrades" -d "apt-listchanges" -d "procps" -d "e2fsprogs" \
@@ -751,6 +764,7 @@ echo "[*] Generating .deb and .rpm packages via FPM..."
         --vendor "SysWarden Security" \
         --maintainer "SysWarden Engineering" \
         --description "SysWarden Host-based Security Orchestrator for Linux" \
+        --license "GPL-3.0-or-later" \
         --source-date-epoch-default "${SOURCE_DATE_EPOCH}" \
         --rpm-changelog "${RPM_CHANGELOG}" \
         -d "nftables" -d "ipset" -d "curl" -d "wget" -d "rsyslog" -d "cronie" -d "bash-completion" \
@@ -780,6 +794,7 @@ maintainer: "SysWarden Engineering"
 description: "SysWarden Host-based Security Orchestrator for Alpine Linux"
 vendor: "SysWarden Security"
 homepage: "https://github.com/duggytuxy/syswarden"
+license: "GPL-3.0-or-later"
 depends:
   - nftables
   - openrc
@@ -837,6 +852,24 @@ validate_local_deb_changelog() {
     fi
 }
 
+validate_local_deb_license() {
+    local deb_path="$1"
+    local license_lines
+    license_lines="$(
+        ar p "${deb_path}" control.tar.gz |
+            LC_ALL=C tar -xOzf - ./control |
+            LC_ALL=C awk -F ': ' '$1 == "License" { print $2 }'
+    )" || return 1
+    [ "${license_lines}" = GPL-3.0-or-later ]
+}
+
+validate_local_apk_license() {
+    local apk_path="$1"
+    local metadata
+    metadata="$(LC_ALL=C tar -xOzf "${apk_path}" .PKGINFO)" || return 1
+    [ "$(grep -Fxc 'license = GPL-3.0-or-later' <<< "${metadata}")" -eq 1 ]
+}
+
 validate_local_rpm_scriptlet() {
     local rpm_path="$1"
     local tag="$2"
@@ -862,6 +895,7 @@ validate_local_rpm_build_ids() {
     [ "$(rpm -qp --qf '%{BUILDTIME}' "${rpm_path}")" = "${SOURCE_DATE_EPOCH}" ] || return 1
     [ "$(rpm -qp --qf '%{BUILDHOST}' "${rpm_path}")" = syswarden-build.invalid ] || return 1
     [ "$(rpm -qp --qf '%{CHANGELOGTIME}' "${rpm_path}")" = "${RPM_CHANGELOG_EPOCH}" ] || return 1
+    [ "$(rpm -qp --qf '%{LICENSE}' "${rpm_path}")" = GPL-3.0-or-later ] || return 1
     validate_local_rpm_scriptlet "${rpm_path}" PREIN preinst.sh || return 1
     validate_local_rpm_scriptlet "${rpm_path}" POSTIN postinst.sh || return 1
     validate_local_rpm_scriptlet "${rpm_path}" PREUN prerm.sh || return 1
@@ -919,12 +953,22 @@ if ! validate_local_deb_changelog \
     echo "[-] Local Debian archive validation failed." >&2
     exit 1
 fi
+if ! validate_local_deb_license \
+    "${PACKAGE_WORKSPACE}/syswarden_${VERSION}_amd64.deb"; then
+    echo "[-] Local Debian license metadata validation failed." >&2
+    exit 1
+fi
 if ! validate_local_rpm_build_ids \
     "${PACKAGE_WORKSPACE}/syswarden-${VERSION}-1.x86_64.rpm"; then
     echo "[-] Local RPM build-id validation failed." >&2
     rpm -qp --qf \
         '[%{FILENAMES}\t%{FILEMODES:perms}\t%{FILEUSERNAME}:%{FILEGROUPNAME}\t%{FILELINKTOS}\n]' \
         "${PACKAGE_WORKSPACE}/syswarden-${VERSION}-1.x86_64.rpm" >&2 || true
+    exit 1
+fi
+if ! validate_local_apk_license \
+    "${PACKAGE_WORKSPACE}/syswarden_${VERSION}_x86_64.apk"; then
+    echo "[-] Local Alpine license metadata validation failed." >&2
     exit 1
 fi
 

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -4708,6 +4708,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "  '%{BUILDTIME}') printf '%s' \"${SOURCE_DATE_EPOCH}\"; exit \"${RPM_BUILDTIME_EXIT}\" ;;\n"
                 "  '%{BUILDHOST}') printf syswarden-build.invalid; exit \"${RPM_BUILDHOST_EXIT}\" ;;\n"
                 "  '%{CHANGELOGTIME}') printf '%s' \"${RPM_CHANGELOG_EPOCH}\"; exit \"${RPM_CHANGELOGTIME_EXIT}\" ;;\n"
+                "  '%{LICENSE}') printf '%s' \"${RPM_LICENSE}\"; exit \"${RPM_LICENSE_EXIT}\" ;;\n"
                 "  '%{PREIN}') cat \"${RPM_PREIN_FILE}\" ;;\n"
                 "  '%{POSTIN}') cat \"${RPM_POSTIN_FILE}\" ;;\n"
                 "  '%{PREUN}') cat \"${RPM_PREUN_FILE}\" ;;\n"
@@ -4732,6 +4733,8 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "RPM_BUILDTIME_EXIT": "0",
                 "RPM_BUILDHOST_EXIT": "0",
                 "RPM_CHANGELOGTIME_EXIT": "0",
+                "RPM_LICENSE": "GPL-3.0-or-later",
+                "RPM_LICENSE_EXIT": "0",
             }
             tag_to_name = {
                 "PREIN": "preinst.sh",
@@ -4759,6 +4762,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 programs: dict[str, str] | None = None,
                 program_statuses: dict[str, str] | None = None,
                 metadata_statuses: dict[str, str] | None = None,
+                license_value: str = "GPL-3.0-or-later",
                 scriptlet_payload: str | None = None,
             ) -> subprocess.CompletedProcess[bytes]:
                 sources = source_bodies or canonical_bodies
@@ -4767,6 +4771,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                     tag: "0" for tag in tag_to_name
                 }
                 case_environment = dict(environment)
+                case_environment["RPM_LICENSE"] = license_value
                 for field, status in (metadata_statuses or {}).items():
                     case_environment[f"RPM_{field}_EXIT"] = status
                 for tag, name in tag_to_name.items():
@@ -4857,6 +4862,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
                 "BUILDTIME",
                 "BUILDHOST",
                 "CHANGELOGTIME",
+                "LICENSE",
             ):
                 with self.subTest(mutation="metadata-query-failure", field=field):
                     rejected = validate(
@@ -4864,6 +4870,11 @@ class PackageLifecycleContractTests(unittest.TestCase):
                         metadata_statuses={field: "92"},
                     )
                     self.assertNotEqual(rejected.returncode, 0, rejected)
+
+            wrong_license = validate(
+                dict(canonical_bodies), license_value="unknown"
+            )
+            self.assertNotEqual(wrong_license.returncode, 0, wrong_license)
 
             for forbidden in forbidden_tokens:
                 with self.subTest(forbidden=forbidden):
@@ -5187,13 +5198,15 @@ class PackageLifecycleContractTests(unittest.TestCase):
             path: Path,
             architecture: str,
             archive_hooks: dict[str, bytes],
+            licenses: tuple[str, ...] = ("GPL-3.0-or-later",),
         ) -> None:
             members = {
                 ".PKGINFO": (
                     "pkgname = syswarden\n"
                     "pkgver = 4.02.14\n"
                     f"arch = {architecture}\n"
-                    "depend = openrc\n"
+                    + "".join(f"license = {license_name}\n" for license_name in licenses)
+                    + "depend = openrc\n"
                     "depend = cronie\n"
                     "depend = cronie-openrc\n"
                 ).encode("utf-8"),
@@ -5228,6 +5241,20 @@ class PackageLifecycleContractTests(unittest.TestCase):
             write_apk(x86, "x86_64", hooks)
             accepted = validate(x86, "x86_64")
             self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            for name, licenses in {
+                "missing-license": (),
+                "wrong-license": ("unknown",),
+                "duplicate-license": (
+                    "GPL-3.0-or-later",
+                    "GPL-3.0-or-later",
+                ),
+            }.items():
+                with self.subTest(mutation=name):
+                    mutated = root / f"{name}.apk"
+                    write_apk(mutated, "x86_64", hooks, licenses)
+                    rejected = validate(mutated, "x86_64")
+                    self.assertNotEqual(rejected.returncode, 0, rejected)
 
             mutations = {
                 "missing-preupgrade": {
@@ -5493,7 +5520,7 @@ class PackageLifecycleContractTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(workflow_stage.count("install -m 0644"), 2)
+        self.assertEqual(workflow_stage.count("install -m 0644"), 4)
 
         local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
         self.assertEqual(local.count("GEOIP-DATA-LICENSE.txt"), 2)
@@ -5503,6 +5530,58 @@ class PackageLifecycleContractTests(unittest.TestCase):
             self.workflow.count("package_geoip_data_license_contract.json"), 2
         )
         self.assertEqual(local.count("package_geoip_data_license_contract.json"), 2)
+
+    def test_project_license_is_declared_and_byte_pinned_in_linux_packages(
+        self,
+    ) -> None:
+        source = REPOSITORY / "LICENSE"
+        contract_path = REPOSITORY / "scripts/ci/package_project_license_contract.json"
+        contract = json.loads(contract_path.read_text(encoding="ascii"))
+        payload = source.read_bytes()
+        self.assertEqual(contract["size"], len(payload))
+        self.assertEqual(contract["sha256"], hashlib.sha256(payload).hexdigest())
+        self.assertEqual(
+            contract["sha256"], package_lifecycle_lab.PROJECT_LICENSE_SHA256
+        )
+
+        workflow_stage = workflow_step_script(
+            self.workflow, "Prepare Staging Environment (AMD64)"
+        ) + workflow_step_script(
+            self.workflow, "Build and Stage Static Alpine Binaries"
+        )
+        self.assertEqual(
+            workflow_stage.count("usr/share/doc/syswarden/LICENSE.txt"), 2
+        )
+        self.assertEqual(workflow_stage.count("install -m 0644 LICENSE"), 2)
+        self.assertEqual(self.workflow.count("--project-license-contract"), 2)
+        self.assertEqual(
+            self.workflow.count("package_project_license_contract.json"), 2
+        )
+        self.assertEqual(self.workflow.count('--license "GPL-3.0-or-later"'), 2)
+        self.assertEqual(self.workflow.count('license: "GPL-3.0-or-later"'), 1)
+        validation_step = workflow_step_script(
+            self.workflow, "Validate Package Metadata"
+        )
+        self.assertIn(
+            'dpkg-deb --field "${path}" License', validation_step
+        )
+        self.assertIn(
+            '[[ "${actual_license}" == "GPL-3.0-or-later" ]]',
+            validation_step,
+        )
+        self.assertIn(
+            "^license = GPL-3.0-or-later$", validation_step
+        )
+
+        local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
+        self.assertEqual(local.count("usr/share/doc/syswarden/LICENSE.txt"), 2)
+        self.assertEqual(local.count("--project-license-contract"), 2)
+        self.assertEqual(local.count("package_project_license_contract.json"), 2)
+        self.assertEqual(local.count('--license "GPL-3.0-or-later"'), 2)
+        self.assertEqual(local.count('license: "GPL-3.0-or-later"'), 1)
+        self.assertIn("validate_local_deb_license", local)
+        self.assertIn("validate_local_apk_license", local)
+        self.assertIn("'%{LICENSE}'", local)
 
     def test_final_removal_deletes_dedicated_state_only_for_purge_equivalents(self) -> None:
         postremove = self.script("postrm.sh")

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -572,6 +572,11 @@ GEOIP_DATA_LICENSE_FIRST_VERSION = "4.04.0"
 GEOIP_DATA_LICENSE_SHA256 = (
     "a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499"
 )
+PROJECT_LICENSE_PATH = "/usr/share/doc/syswarden/LICENSE.txt"
+PROJECT_LICENSE_SHA256 = (
+    "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
+)
+PROJECT_LICENSE_EXPRESSION = "GPL-3.0-or-later"
 LEGACY_BASH_COMPLETION_PATH = "/etc/bash_completion.d/syswarden"
 LEGACY_BASH_COMPLETION_VERSION = "4.03.2"
 LEGACY_BASH_COMPLETION_SIZE = 16_339
@@ -590,9 +595,10 @@ PACKAGE_PAYLOAD_PATHS = (
     *LEGACY_PACKAGE_PAYLOAD_PATHS,
     BASH_COMPLETION_PATH,
 )
-GEOIP_LICENSE_PACKAGE_PAYLOAD_PATHS = (
+LICENSED_PACKAGE_PAYLOAD_PATHS = (
     *PACKAGE_PAYLOAD_PATHS,
     GEOIP_DATA_LICENSE_PATH,
+    PROJECT_LICENSE_PATH,
 )
 FORWARD_ONLY_APK_CANDIDATE_VERSION = "4.03.2"
 FORWARD_ONLY_APK_PREVIOUS_VERSION = "4.02.8"
@@ -635,13 +641,13 @@ DEB_PACKAGE_PATHS = frozenset(
         "/usr/share/bash-completion/completions",
     )
 )
-GEOIP_LICENSE_DEB_PACKAGE_PATHS = frozenset(
-    (*DEB_PACKAGE_PATHS, GEOIP_DATA_LICENSE_PATH)
+LICENSED_DEB_PACKAGE_PATHS = frozenset(
+    (*DEB_PACKAGE_PATHS, GEOIP_DATA_LICENSE_PATH, PROJECT_LICENSE_PATH)
 )
 LEGACY_APK_PACKAGE_PATHS = frozenset(LEGACY_PACKAGE_PAYLOAD_PATHS)
 APK_PACKAGE_PATHS = frozenset(PACKAGE_PAYLOAD_PATHS)
-GEOIP_LICENSE_APK_PACKAGE_PATHS = frozenset(
-    GEOIP_LICENSE_PACKAGE_PAYLOAD_PATHS
+LICENSED_APK_PACKAGE_PATHS = frozenset(
+    LICENSED_PACKAGE_PAYLOAD_PATHS
 )
 RPM_BUILD_ID_DIRECTORY_PATTERN = re.compile(r"^/usr/lib/\.build-id/[0-9a-f]{2}$")
 RPM_BUILD_ID_LINK_PATTERN = re.compile(
@@ -757,8 +763,12 @@ def expected_inventory_phase_labels(scenario: str) -> tuple[str, ...]:
     raise LifecycleLabError(f"unsupported inventory scenario: {scenario!r}")
 
 
-def _preparation_event_checks(scenario: str) -> tuple[str, ...]:
-    return (
+def _preparation_event_checks(
+    scenario: str,
+    *,
+    candidate_version: str | None = None,
+) -> tuple[str, ...]:
+    checks = [
         f"{scenario}.platform.uname",
         f"{scenario}.extract.previous",
         f"{scenario}.extract.candidate",
@@ -768,15 +778,29 @@ def _preparation_event_checks(scenario: str) -> tuple[str, ...]:
         f"{scenario}.metadata.candidate.version",
         f"{scenario}.metadata.previous.architecture",
         f"{scenario}.metadata.candidate.architecture",
-        f"{scenario}.metadata.previous.manager_manifest",
-        f"{scenario}.metadata.previous.payload_inventory",
-        f"{scenario}.metadata.candidate.manager_manifest",
-        f"{scenario}.metadata.candidate.payload_inventory",
-        f"{scenario}.metadata.candidate.runtime_dependencies",
+    ]
+    if candidate_version is not None and _uses_geoip_data_license_payload(
+        "candidate", candidate_version
+    ):
+        checks.append(f"{scenario}.metadata.candidate.license")
+    checks.extend(
+        (
+            f"{scenario}.metadata.previous.manager_manifest",
+            f"{scenario}.metadata.previous.payload_inventory",
+            f"{scenario}.metadata.candidate.manager_manifest",
+            f"{scenario}.metadata.candidate.payload_inventory",
+            f"{scenario}.metadata.candidate.runtime_dependencies",
+        )
     )
+    return tuple(checks)
 
 
-def expected_event_checks(family: str, scenario: str) -> tuple[str, ...]:
+def expected_event_checks(
+    family: str,
+    scenario: str,
+    *,
+    candidate_version: str | None = None,
+) -> tuple[str, ...]:
     """Return the exact ordered evidence contract for one lifecycle scenario."""
 
     if family not in EXPECTED_SCENARIOS or scenario not in EXPECTED_SCENARIOS[family]:
@@ -784,7 +808,12 @@ def expected_event_checks(family: str, scenario: str) -> tuple[str, ...]:
             f"unsupported lifecycle evidence coordinate: {family}/{scenario}"
         )
 
-    checks = list(_preparation_event_checks(scenario))
+    checks = list(
+        _preparation_event_checks(
+            scenario,
+            candidate_version=candidate_version,
+        )
+    )
 
     def installed(
         command: str,
@@ -2061,6 +2090,37 @@ package_architecture() {
     esac
 }
 
+package_license() {
+    package="$1"
+    case "${PACKAGE_FAMILY}" in
+        deb)
+            dpkg-deb --field "${package}" License
+            ;;
+        rpm)
+            rpm -qp --queryformat '%{LICENSE}' "${package}"
+            ;;
+        apk)
+            members="$(tar --list --file "${package}")" || return 1
+            member_count="$(
+                printf '%s\n' "${members}" | \
+                    awk '$0 == ".PKGINFO" { count++ } END { print count + 0 }'
+            )" || return 1
+            [ "${member_count}" -eq 1 ] || return 1
+            metadata="$(tar --extract --to-stdout --file "${package}" .PKGINFO)" || \
+                return 1
+            license_count="$(
+                printf '%s\n' "${metadata}" | \
+                    awk '$0 ~ /^license = / { count++ } END { print count + 0 }'
+            )" || return 1
+            [ "${license_count}" -eq 1 ] || return 1
+            printf '%s\n' "${metadata}" | sed -n 's/^license = //p'
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+}
+
 expected_runtime_dependencies() {
     case "${PACKAGE_FAMILY}" in
         deb)
@@ -2430,11 +2490,15 @@ validate_manifest_contract() {
         geoip_data_license_payload=1
         required_manifest_path "${manifest}" \
             /usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt || return 1
+        required_manifest_path "${manifest}" \
+            /usr/share/doc/syswarden/LICENSE.txt || return 1
     else
         geoip_data_license_rc=$?
         [ "${geoip_data_license_rc}" -eq 1 ] || return 1
         required_manifest_path "${manifest}" \
             /usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt && return 1
+        required_manifest_path "${manifest}" \
+            /usr/share/doc/syswarden/LICENSE.txt && return 1
     fi
 
     case "${PACKAGE_FAMILY}" in
@@ -2443,8 +2507,8 @@ validate_manifest_contract() {
                 allowed='^/(opt|opt/syswarden|opt/syswarden/bin|usr|usr/local|usr/local/bin|usr/share|usr/share/doc|usr/share/doc/syswarden|usr/share/doc/syswarden/changelog\.gz|opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?)$'
                 expected_manifest_count=16
             elif [ "${geoip_data_license_payload}" -eq 1 ]; then
-                allowed='^/(opt|opt/syswarden|opt/syswarden/bin|usr|usr/local|usr/local/bin|usr/share|usr/share/bash-completion|usr/share/bash-completion/completions|usr/share/bash-completion/completions/syswarden|usr/share/doc|usr/share/doc/syswarden|usr/share/doc/syswarden/(changelog\.gz|GEOIP-DATA-LICENSE\.txt)|opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?)$'
-                expected_manifest_count=20
+                allowed='^/(opt|opt/syswarden|opt/syswarden/bin|usr|usr/local|usr/local/bin|usr/share|usr/share/bash-completion|usr/share/bash-completion/completions|usr/share/bash-completion/completions/syswarden|usr/share/doc|usr/share/doc/syswarden|usr/share/doc/syswarden/(changelog\.gz|GEOIP-DATA-LICENSE\.txt|LICENSE\.txt)|opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?)$'
+                expected_manifest_count=21
             else
                 allowed='^/(opt|opt/syswarden|opt/syswarden/bin|usr|usr/local|usr/local/bin|usr/share|usr/share/bash-completion|usr/share/bash-completion/completions|usr/share/bash-completion/completions/syswarden|usr/share/doc|usr/share/doc/syswarden|usr/share/doc/syswarden/changelog\.gz|opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?)$'
                 expected_manifest_count=19
@@ -2458,8 +2522,8 @@ validate_manifest_contract() {
                 allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?)$'
                 expected_manifest_count=6
             elif [ "${geoip_data_license_payload}" -eq 1 ]; then
-                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden/GEOIP-DATA-LICENSE\.txt)$'
-                expected_manifest_count=8
+                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden/(GEOIP-DATA-LICENSE|LICENSE)\.txt)$'
+                expected_manifest_count=9
             else
                 allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden)$'
                 expected_manifest_count=7
@@ -2472,7 +2536,7 @@ validate_manifest_contract() {
             if [ "${legacy_completion_payload}" -eq 1 ]; then
                 allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
             elif [ "${geoip_data_license_payload}" -eq 1 ]; then
-                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden/GEOIP-DATA-LICENSE\.txt|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
+                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden/(GEOIP-DATA-LICENSE|LICENSE)\.txt|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
             else
                 allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
             fi
@@ -2549,6 +2613,9 @@ validate_inventory_contract() {
         inventory_has_exact_entry "${inventory}" \
             /usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt file 644 \
             a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499 || return 1
+        inventory_has_exact_entry "${inventory}" \
+            /usr/share/doc/syswarden/LICENSE.txt file 644 \
+            3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986 || return 1
     else
         geoip_data_license_rc=$?
         [ "${geoip_data_license_rc}" -eq 1 ] || return 1
@@ -5067,6 +5134,20 @@ prepare_expected_payloads() {
        [ "${CANDIDATE_ARCHITECTURE}" != "${EXPECTED_PACKAGE_ARCHITECTURE}" ]; then
         return 1
     fi
+    if package_uses_geoip_data_license_payload candidate; then
+        if ! CANDIDATE_LICENSE="$(
+            package_license "${CANDIDATE_PACKAGE}" 2>> "${COMMAND_LOG}"
+        )"; then
+            record fail "${PREFIX}.metadata.candidate.license" \
+                "native package license metadata could not be read exactly"
+            return 1
+        fi
+        check_equal metadata.candidate.license GPL-3.0-or-later "${CANDIDATE_LICENSE}"
+        [ "${CANDIDATE_LICENSE}" = GPL-3.0-or-later ] || return 1
+    else
+        license_contract_rc=$?
+        [ "${license_contract_rc}" -eq 1 ] || return 1
+    fi
     verify_package_artifact previous "${PREVIOUS_PACKAGE}" "${PERSIST_ROOT}/expected-previous"
     verify_package_artifact candidate "${CANDIDATE_PACKAGE}" "${PERSIST_ROOT}/expected-candidate"
     return 0
@@ -5298,11 +5379,19 @@ def parse_events(path: Path) -> list[dict[str, str]]:
 
 
 def validate_event_contract(
-    events: Sequence[dict[str, str]], family: str, scenario: str
+    events: Sequence[dict[str, str]],
+    family: str,
+    scenario: str,
+    *,
+    candidate_version: str | None = None,
 ) -> None:
     """Reject missing, duplicated, reordered, synthetic, or informational evidence."""
 
-    expected = expected_event_checks(family, scenario)
+    expected = expected_event_checks(
+        family,
+        scenario,
+        candidate_version=candidate_version,
+    )
     observed: list[str] = []
     for index, event in enumerate(events):
         if not isinstance(event, dict):
@@ -5430,13 +5519,13 @@ def _validate_manager_paths(
         candidate_version,
         forward_only_apk=forward_only_apk,
     )
-    geoip_data_license = _uses_geoip_data_license_payload(role, version)
+    license_payloads = _uses_geoip_data_license_payload(role, version)
     expected_payload_paths = set(
         LEGACY_PACKAGE_PAYLOAD_PATHS
         if legacy_completion
         else (
-            GEOIP_LICENSE_PACKAGE_PAYLOAD_PATHS
-            if geoip_data_license
+            LICENSED_PACKAGE_PAYLOAD_PATHS
+            if license_payloads
             else PACKAGE_PAYLOAD_PATHS
         )
     )
@@ -5445,8 +5534,8 @@ def _validate_manager_paths(
             LEGACY_DEB_PACKAGE_PATHS
             if legacy_completion
             else (
-                GEOIP_LICENSE_DEB_PACKAGE_PATHS
-                if geoip_data_license
+                LICENSED_DEB_PACKAGE_PATHS
+                if license_payloads
                 else DEB_PACKAGE_PATHS
             )
         )
@@ -5458,8 +5547,8 @@ def _validate_manager_paths(
             LEGACY_APK_PACKAGE_PATHS
             if legacy_completion
             else (
-                GEOIP_LICENSE_APK_PACKAGE_PATHS
-                if geoip_data_license
+                LICENSED_APK_PACKAGE_PATHS
+                if license_payloads
                 else APK_PACKAGE_PATHS
             )
         )
@@ -5518,7 +5607,7 @@ def validate_inventory_snapshot(
         candidate_version,
         forward_only_apk=forward_only_apk,
     )
-    geoip_data_license = _uses_geoip_data_license_payload(role, version)
+    license_payloads = _uses_geoip_data_license_payload(role, version)
     if len(filesystem) != len(manager_paths):
         raise LifecycleLabError(
             "filesystem inventory does not cover every native package path"
@@ -5579,7 +5668,7 @@ def validate_inventory_snapshot(
             raise LifecycleLabError(
                 f"package file type/mode/digest contract failed at {path}"
             )
-    if geoip_data_license:
+    if license_payloads:
         attribution = entries[GEOIP_DATA_LICENSE_PATH]
         if (
             attribution["type"] != "file"
@@ -5588,6 +5677,15 @@ def validate_inventory_snapshot(
         ):
             raise LifecycleLabError(
                 "GeoIP data license payload is not the pinned intact source"
+            )
+        project_license = entries[PROJECT_LICENSE_PATH]
+        if (
+            project_license["type"] != "file"
+            or project_license["mode"] != "644"
+            or project_license["value"] != PROJECT_LICENSE_SHA256
+        ):
+            raise LifecycleLabError(
+                "project license payload is not the pinned intact source"
             )
     link_targets = {
         "/usr/local/bin/syswarden": "/opt/syswarden/bin/syswarden-cli",
@@ -5608,8 +5706,8 @@ def validate_inventory_snapshot(
             LEGACY_DEB_PACKAGE_PATHS
             if legacy_completion
             else (
-                GEOIP_LICENSE_DEB_PACKAGE_PATHS
-                if geoip_data_license
+                LICENSED_DEB_PACKAGE_PATHS
+                if license_payloads
                 else DEB_PACKAGE_PATHS
             )
         )
@@ -5617,8 +5715,8 @@ def validate_inventory_snapshot(
             LEGACY_PACKAGE_PAYLOAD_PATHS
             if legacy_completion
             else (
-                GEOIP_LICENSE_PACKAGE_PAYLOAD_PATHS
-                if geoip_data_license
+                LICENSED_PACKAGE_PAYLOAD_PATHS
+                if license_payloads
                 else PACKAGE_PAYLOAD_PATHS
             )
         )
@@ -8395,7 +8493,12 @@ def run_platform(
             command_log = result_root / "commands.log"
             try:
                 events = parse_events(event_file)
-                validate_event_contract(events, spec.family, scenario)
+                validate_event_contract(
+                    events,
+                    spec.family,
+                    scenario,
+                    candidate_version=pair.candidate.version,
+                )
                 inventory_evidence = parse_scenario_inventory_evidence(
                     result_root,
                     spec.family,
@@ -9563,7 +9666,14 @@ def classify_lifecycle_evidence(
                 try:
                     if not isinstance(events, list):
                         raise LifecycleLabError("scenario event list is absent")
-                    validate_event_contract(events, family, scenario_name)
+                    validate_event_contract(
+                        events,
+                        family,
+                        scenario_name,
+                        candidate_version=str(
+                            platform_result.get("candidate_version", "")
+                        ),
+                    )
                 except LifecycleLabError:
                     coordinate_structural.append(
                         f"{coordinate_name}:{scenario_name}:event-contract-invalid"
@@ -10023,7 +10133,12 @@ def validate_report_version_contract(
                     raise LifecycleLabError(
                         "package lifecycle scenario lacks event evidence"
                     )
-                validate_event_contract(scenario_events, family, scenario_name)
+                validate_event_contract(
+                    scenario_events,
+                    family,
+                    scenario_name,
+                    candidate_version=candidate_version,
+                )
         expected_coordinates.add(f"{family}:{package_architecture}")
         candidate = platform_result.get("candidate")
         previous = platform_result.get("previous")

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -3583,6 +3583,170 @@ probe
             sorted(script.index(fragment) for fragment in lifecycle_order),
         )
 
+    def test_candidate_native_license_metadata_is_versioned_and_exact(self) -> None:
+        check = "upgrade-rollback.metadata.candidate.license"
+        baseline = package_lifecycle_lab.expected_event_checks(
+            "deb",
+            "upgrade-rollback",
+            candidate_version="4.03.3",
+        )
+        candidate = package_lifecycle_lab.expected_event_checks(
+            "deb",
+            "upgrade-rollback",
+            candidate_version="4.04.0",
+        )
+        future = package_lifecycle_lab.expected_event_checks(
+            "deb",
+            "upgrade-rollback",
+            candidate_version="5.00.0",
+        )
+        self.assertNotIn(check, baseline)
+        self.assertIn(check, candidate)
+        self.assertIn(check, future)
+        self.assertNotIn("upgrade-rollback.metadata.previous.license", candidate)
+        self.assertLess(
+            candidate.index("upgrade-rollback.metadata.candidate.architecture"),
+            candidate.index(check),
+        )
+        self.assertLess(
+            candidate.index(check),
+            candidate.index("upgrade-rollback.metadata.previous.manager_manifest"),
+        )
+
+        events = [
+            {"status": "pass", "check": item, "detail": "verified"}
+            for item in candidate
+        ]
+        package_lifecycle_lab.validate_event_contract(
+            events,
+            "deb",
+            "upgrade-rollback",
+            candidate_version="4.04.0",
+        )
+        without_license = [event for event in events if event["check"] != check]
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "event contract mismatch",
+        ):
+            package_lifecycle_lab.validate_event_contract(
+                without_license,
+                "deb",
+                "upgrade-rollback",
+                candidate_version="4.04.0",
+            )
+
+    def test_native_package_license_extraction_is_fail_closed_for_all_families(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        function = source[
+            source.index("package_license() {") : source.index(
+                "\nexpected_runtime_dependencies() {"
+            )
+        ]
+        fake_bin = self.root / "license-bin"
+        fake_bin.mkdir()
+        tool = (
+            "#!/bin/sh\n"
+            "case \"${0##*/}:$1\" in\n"
+            "  dpkg-deb:--field|rpm:-qp)\n"
+            "    printf '%s' \"${TEST_LICENSE-}\"\n"
+            "    exit \"${TEST_STATUS-0}\"\n"
+            "    ;;\n"
+            "  tar:--list)\n"
+            "    printf '%s' \"${TEST_APK_MEMBERS-}\"\n"
+            "    exit \"${TEST_LIST_STATUS-0}\"\n"
+            "    ;;\n"
+            "  tar:--extract)\n"
+            "    printf '%s' \"${TEST_APK_METADATA-}\"\n"
+            "    exit \"${TEST_EXTRACT_STATUS-0}\"\n"
+            "    ;;\n"
+            "esac\n"
+            "exit 90\n"
+        )
+        for name in ("dpkg-deb", "rpm", "tar"):
+            path = fake_bin / name
+            path.write_text(tool, encoding="ascii")
+            path.chmod(0o700)
+
+        harness = self.root / "package-license.sh"
+        harness.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            + function
+            + "\nactual=\"$(package_license \"$1\")\"\n"
+            + "[ \"${actual}\" = GPL-3.0-or-later ]\n",
+            encoding="ascii",
+        )
+        harness.chmod(0o700)
+
+        def validate(
+            family: str,
+            *,
+            license_value: str = package_lifecycle_lab.PROJECT_LICENSE_EXPRESSION,
+            status: str = "0",
+            members: str = ".PKGINFO\n",
+            metadata: str | None = None,
+            list_status: str = "0",
+            extract_status: str = "0",
+        ) -> subprocess.CompletedProcess[bytes]:
+            environment = {
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "PACKAGE_FAMILY": family,
+                "TEST_LICENSE": license_value,
+                "TEST_STATUS": status,
+                "TEST_APK_MEMBERS": members,
+                "TEST_APK_METADATA": (
+                    f"license = {license_value}\n"
+                    if metadata is None
+                    else metadata
+                ),
+                "TEST_LIST_STATUS": list_status,
+                "TEST_EXTRACT_STATUS": extract_status,
+            }
+            return subprocess.run(
+                ("/bin/sh", str(harness), str(self.root / "package")),
+                check=False,
+                capture_output=True,
+                env=environment,
+            )
+
+        for family in ("deb", "rpm", "apk"):
+            with self.subTest(family=family, mutation="accepted"):
+                self.assertEqual(validate(family).returncode, 0)
+            with self.subTest(family=family, mutation="wrong-license"):
+                self.assertNotEqual(
+                    validate(family, license_value="unknown").returncode,
+                    0,
+                )
+            with self.subTest(family=family, mutation="missing-license"):
+                self.assertNotEqual(
+                    validate(family, license_value="").returncode,
+                    0,
+                )
+            with self.subTest(family=family, mutation="metadata-command-failure"):
+                kwargs = (
+                    {"extract_status": "42"}
+                    if family == "apk"
+                    else {"status": "42"}
+                )
+                self.assertNotEqual(validate(family, **kwargs).returncode, 0)
+
+        for name, arguments in {
+            "missing-license": {"metadata": "pkgname = syswarden\n"},
+            "duplicate-license": {
+                "metadata": (
+                    "license = GPL-3.0-or-later\n"
+                    "license = GPL-3.0-or-later\n"
+                )
+            },
+            "duplicate-pkginfo": {"members": ".PKGINFO\n.PKGINFO\n"},
+            "list-failure": {"list_status": "42"},
+        }.items():
+            with self.subTest(family="apk", mutation=name):
+                self.assertNotEqual(validate("apk", **arguments).returncode, 0)
+
     def test_seed_state_uses_separate_address_family_files(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         seed = source[
@@ -4244,7 +4408,7 @@ probe
                 )
                 self.assertNotEqual(missing_completion.returncode, 0)
 
-    def test_v4040_packages_require_exact_geoip_data_license_payload(self) -> None:
+    def test_v4040_packages_require_exact_license_payloads(self) -> None:
         build_id_paths = {
             "/usr/lib/.build-id",
             "/usr/lib/.build-id/11",
@@ -4255,10 +4419,10 @@ probe
             "/usr/lib/.build-id/33/" + "3" * 38,
         }
         manifests = {
-            "deb": sorted(package_lifecycle_lab.GEOIP_LICENSE_DEB_PACKAGE_PATHS),
-            "apk": sorted(package_lifecycle_lab.GEOIP_LICENSE_APK_PACKAGE_PATHS),
+            "deb": sorted(package_lifecycle_lab.LICENSED_DEB_PACKAGE_PATHS),
+            "apk": sorted(package_lifecycle_lab.LICENSED_APK_PACKAGE_PATHS),
             "rpm": sorted(
-                set(package_lifecycle_lab.GEOIP_LICENSE_PACKAGE_PAYLOAD_PATHS)
+                set(package_lifecycle_lab.LICENSED_PACKAGE_PAYLOAD_PATHS)
                 | build_id_paths
             ),
         }
@@ -4269,6 +4433,7 @@ probe
             "/opt/syswarden/signatures.json": "640",
             package_lifecycle_lab.BASH_COMPLETION_PATH: "644",
             package_lifecycle_lab.GEOIP_DATA_LICENSE_PATH: "644",
+            package_lifecycle_lab.PROJECT_LICENSE_PATH: "644",
         }
         link_targets = {
             "/usr/local/bin/syswarden": "/opt/syswarden/bin/syswarden-cli",
@@ -4290,7 +4455,11 @@ probe
                     value = (
                         package_lifecycle_lab.GEOIP_DATA_LICENSE_SHA256
                         if path == package_lifecycle_lab.GEOIP_DATA_LICENSE_PATH
-                        else "a" * 64
+                        else (
+                            package_lifecycle_lab.PROJECT_LICENSE_SHA256
+                            if path == package_lifecycle_lab.PROJECT_LICENSE_PATH
+                            else "a" * 64
+                        )
                     )
                     kind, mode = "file", file_modes[path]
                 elif path == "/usr/share/doc/syswarden/changelog.gz":
@@ -4301,9 +4470,28 @@ probe
                     kind, mode, value = "directory", "755", "-"
                 inventory.append(f"{path}\t{kind}\t{mode}\t0\t0\t{value}")
             with self.subTest(family=family):
+                filesystem = [
+                    {
+                        "path": fields[0],
+                        "type": fields[1],
+                        "mode": fields[2],
+                        "uid": int(fields[3]),
+                        "gid": int(fields[4]),
+                        "value": fields[5],
+                    }
+                    for fields in (line.split("\t") for line in inventory)
+                ]
                 package_lifecycle_lab._validate_manager_paths(
                     family,
                     manifest,
+                    role="candidate",
+                    version="4.04.0",
+                    candidate_version="4.04.0",
+                )
+                package_lifecycle_lab.validate_inventory_snapshot(
+                    family,
+                    manifest,
+                    filesystem,
                     role="candidate",
                     version="4.04.0",
                     candidate_version="4.04.0",
@@ -4332,6 +4520,21 @@ probe
                     0,
                 )
 
+                without_project_license = [
+                    path
+                    for path in manifest
+                    if path != package_lifecycle_lab.PROJECT_LICENSE_PATH
+                ]
+                self.assertNotEqual(
+                    self.run_embedded_inventory_contract(
+                        family,
+                        without_project_license,
+                        version="4.04.0",
+                        candidate_version="4.04.0",
+                    ).returncode,
+                    0,
+                )
+
                 altered_inventory = [
                     line.replace(
                         package_lifecycle_lab.GEOIP_DATA_LICENSE_SHA256,
@@ -4344,6 +4547,50 @@ probe
                         family,
                         manifest,
                         altered_inventory,
+                        version="4.04.0",
+                        candidate_version="4.04.0",
+                    ).returncode,
+                    0,
+                )
+
+                altered_project_license_inventory = [
+                    line.replace(
+                        package_lifecycle_lab.PROJECT_LICENSE_SHA256,
+                        "0" * 64,
+                    )
+                    for line in inventory
+                ]
+                altered_project_filesystem = [
+                    {
+                        "path": fields[0],
+                        "type": fields[1],
+                        "mode": fields[2],
+                        "uid": int(fields[3]),
+                        "gid": int(fields[4]),
+                        "value": fields[5],
+                    }
+                    for fields in (
+                        line.split("\t")
+                        for line in altered_project_license_inventory
+                    )
+                ]
+                with self.assertRaisesRegex(
+                    package_lifecycle_lab.LifecycleLabError,
+                    "project license payload",
+                ):
+                    package_lifecycle_lab.validate_inventory_snapshot(
+                        family,
+                        manifest,
+                        altered_project_filesystem,
+                        role="candidate",
+                        version="4.04.0",
+                        candidate_version="4.04.0",
+                    )
+                self.assertNotEqual(
+                    self.run_embedded_inventory_contract(
+                        family,
+                        manifest,
+                        altered_project_license_inventory,
                         version="4.04.0",
                         candidate_version="4.04.0",
                     ).returncode,

--- a/scripts/ci/package_project_license_contract.json
+++ b/scripts/ci/package_project_license_contract.json
@@ -1,0 +1,4 @@
+{
+  "sha256": "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986",
+  "size": 35149
+}

--- a/scripts/ci/package_stage_gate.py
+++ b/scripts/ci/package_stage_gate.py
@@ -71,6 +71,9 @@ LINUX_ENTRIES = {
     "usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt": ExpectedEntry(
         "file", mode=0o644, nonempty=True
     ),
+    "usr/share/doc/syswarden/LICENSE.txt": ExpectedEntry(
+        "file", mode=0o644, nonempty=True
+    ),
 }
 
 def entry_kind(metadata: os.stat_result) -> str:
@@ -214,6 +217,7 @@ def validate(
     expected: dict[str, ExpectedEntry],
     completion_contract: ContentContract | None = None,
     geoip_data_license_contract: ContentContract | None = None,
+    project_license_contract: ContentContract | None = None,
 ) -> None:
     actual = inventory(root)
     actual_paths = set(actual)
@@ -270,6 +274,11 @@ def validate(
             root / "usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt",
             geoip_data_license_contract,
         )
+    if project_license_contract is not None:
+        validate_exact_content(
+            root / "usr/share/doc/syswarden/LICENSE.txt",
+            project_license_contract,
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -279,6 +288,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--completion-contract", type=Path, required=True)
     parser.add_argument("--geoip-data-license-contract", type=Path, required=True)
     parser.add_argument("--geoip-data-license-source", type=Path, required=True)
+    parser.add_argument("--project-license-contract", type=Path, required=True)
+    parser.add_argument("--project-license-source", type=Path, required=True)
     return parser
 
 
@@ -289,14 +300,19 @@ def main() -> int:
         geoip_data_license_contract = load_content_contract(
             args.geoip_data_license_contract
         )
+        project_license_contract = load_content_contract(
+            args.project_license_contract
+        )
         validate_exact_content(
             args.geoip_data_license_source, geoip_data_license_contract
         )
+        validate_exact_content(args.project_license_source, project_license_contract)
         validate(
             args.root,
             LINUX_ENTRIES,
             completion_contract,
             geoip_data_license_contract,
+            project_license_contract,
         )
     except PackageStageError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/ci/package_stage_gate_test.py
+++ b/scripts/ci/package_stage_gate_test.py
@@ -118,6 +118,48 @@ class PackageStageGateTests(unittest.TestCase):
             contract,
         )
 
+    def test_accepts_exact_project_license_source(self) -> None:
+        self.create_stage(package_stage_gate.LINUX_ENTRIES)
+        license_path = self.root / "usr/share/doc/syswarden/LICENSE.txt"
+        payload = license_path.read_bytes()
+        contract = package_stage_gate.ContentContract(
+            sha256=hashlib.sha256(payload).hexdigest(),
+            size=len(payload),
+        )
+        package_stage_gate.validate(
+            self.root,
+            package_stage_gate.LINUX_ENTRIES,
+            project_license_contract=contract,
+        )
+
+    def test_rejects_project_license_content_drift(self) -> None:
+        self.create_stage(package_stage_gate.LINUX_ENTRIES)
+        license_path = self.root / "usr/share/doc/syswarden/LICENSE.txt"
+        payload = license_path.read_bytes()
+        contract = package_stage_gate.ContentContract(
+            sha256=hashlib.sha256(payload).hexdigest(),
+            size=len(payload),
+        )
+        license_path.write_bytes(b"altered project license\n")
+        with self.assertRaisesRegex(
+            package_stage_gate.PackageStageError, "size mismatch|SHA-256 mismatch"
+        ):
+            package_stage_gate.validate(
+                self.root,
+                package_stage_gate.LINUX_ENTRIES,
+                project_license_contract=contract,
+            )
+
+    def test_repository_project_license_matches_pinned_contract(self) -> None:
+        repository_root = Path(__file__).resolve().parents[2]
+        contract = package_stage_gate.load_content_contract(
+            repository_root / "scripts/ci/package_project_license_contract.json"
+        )
+        package_stage_gate.validate_exact_content(
+            repository_root / "LICENSE",
+            contract,
+        )
+
     def test_rejects_completion_size_or_digest_drift(self) -> None:
         self.create_stage(package_stage_gate.LINUX_ENTRIES)
         completion = self.root / "usr/share/bash-completion/completions/syswarden"


### PR DESCRIPTION
## Summary

- declare the project package license as `GPL-3.0-or-later` in DEB, RPM and APK metadata
- ship the byte-pinned root GPL license as `/usr/share/doc/syswarden/LICENSE.txt`
- enforce the exact payload, native metadata and version boundary in staging and lifecycle gates
- preserve the historical v4.03.3 package contract while applying the new requirement to v4.04.0 and later

## Validation

- 239 affected Python tests passed, with 8 environment-dependent skips
- `bash -n` and ShellCheck passed for the local package builder
- workflow YAML parsing and `git diff --check` passed
- synthetic packages built successfully with FPM 1.17.0 and nFPM 2.47.0
- DEB, RPM and APK all reported `GPL-3.0-or-later` and contained the exact 35,149-byte project license with SHA-256 `3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986`
- version control validation confirmed this non-versioning follow-up preserves v4.04.0 and leaves `changelog.md` byte-identical

## Qualification boundary

The previously tested v4.04.0 package artifact predates this correction. Its functional evidence remains useful, but its package bytes are superseded. The DEB, RPM and APK produced by this PR must become the new exact qualification inputs before any release claim.
