### PR TITLE
Fix : bind release qualification to the eight-cell matrix

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -34,6 +34,7 @@ jobs:
       candidate_artifact_id: ${{ steps.candidate.outputs.artifact_id }}
       candidate_artifact_name: ${{ steps.candidate.outputs.artifact_name }}
       candidate_run_id: ${{ steps.candidate.outputs.run_id }}
+      previous_commit_sha: ${{ steps.previous.outputs.commit_sha }}
       previous_release_id: ${{ steps.previous.outputs.release_id }}
       signed_update_required: ${{ steps.update_contract.outputs.required }}
       unsigned_artifact_name: ${{ steps.inventory.outputs.artifact_name }}
@@ -468,6 +469,18 @@ jobs:
           assets_json="$(gh api --paginate --slurp --method GET \
             "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets" \
             -f per_page=100)"
+          matrix_path="${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json"
+          baseline_release="$(jq -er '.package_sources.baseline.release' "${matrix_path}")"
+          baseline_commit="$(jq -er '.package_sources.baseline.commit' "${matrix_path}")"
+          baseline_release_id="$(jq -er '.package_sources.baseline.release_id' "${matrix_path}")"
+          previous_commit="$(git rev-parse --verify "refs/tags/${PREVIOUS_TAG}^{commit}")"
+          if [[ "${PREVIOUS_TAG}" != "${baseline_release}" || \
+                "${release_id}" != "${baseline_release_id}" || \
+                "${previous_commit}" != "${baseline_commit}" || \
+                "$(jq '.package_sources.baseline.assets | length' "${matrix_path}")" != "4" ]]; then
+            echo "ERROR: previous release identity differs from the frozen baseline." >&2
+            exit 1
+          fi
           transition_required=false
           transition_metadata="${TRANSITION_DIR}/public-release-assets.json"
           transition_source_manifest="${TRANSITION_DIR}/public-SHA256SUMS.txt"
@@ -497,10 +510,20 @@ jobs:
             asset_id="$(jq -r '.[0].id' <<< "${matches}")"
             asset_state="$(jq -r '.[0].state' <<< "${matches}")"
             asset_size="$(jq -r '.[0].size' <<< "${matches}")"
+            expected_asset="$(jq -ce --arg name "${asset_name}" '
+              [.package_sources.baseline.assets[] | select(.name == $name)]
+              | if length == 1 then .[0]
+                else error("baseline asset is absent or ambiguous") end
+            ' "${matrix_path}")"
+            expected_asset_id="$(jq -r '.id' <<< "${expected_asset}")"
+            expected_asset_size="$(jq -r '.size' <<< "${expected_asset}")"
+            expected_asset_sha256="$(jq -r '.sha256' <<< "${expected_asset}")"
             if [[ ! "${asset_id}" =~ ^[0-9]+$ || \
                   "${asset_state}" != "uploaded" || \
-                  ! "${asset_size}" =~ ^[1-9][0-9]*$ ]]; then
-              echo "ERROR: previous release asset ${asset_name} is not a non-empty uploaded asset." >&2
+                  ! "${asset_size}" =~ ^[1-9][0-9]*$ || \
+                  "${asset_id}" != "${expected_asset_id}" || \
+                  "${asset_size}" != "${expected_asset_size}" ]]; then
+              echo "ERROR: previous release asset ${asset_name} identity/size differs from the frozen uploaded asset." >&2
               exit 1
             fi
             destination="${PREVIOUS_PACKAGES_DIR}/${asset_name}"
@@ -515,6 +538,12 @@ jobs:
             test -s "${destination}"
             test -f "${destination}"
             test ! -L "${destination}"
+            if [[ "$(stat -c '%s' "${destination}")" != "${expected_asset_size}" || \
+                  "$(sha256sum "${destination}" | awk '{print $1}')" != \
+                    "${expected_asset_sha256}" ]]; then
+              echo "ERROR: previous release asset ${asset_name} bytes differ from the frozen baseline." >&2
+              exit 1
+            fi
             chmod 0600 "${destination}"
             asset_records="$(jq \
               --arg name "${asset_name}" \
@@ -522,6 +551,7 @@ jobs:
               '. + [{name: $name, id: $id}]' \
               <<< "${asset_records}")"
           done
+          printf 'commit_sha=%s\n' "${previous_commit}" >> "${GITHUB_OUTPUT}"
           printf 'release_id=%s\n' "${release_id}" >> "${GITHUB_OUTPUT}"
           printf 'asset_ids=%s\n' "$(jq -c -S . <<< "${asset_records}")" \
             >> "${GITHUB_OUTPUT}"
@@ -552,6 +582,7 @@ jobs:
           CANDIDATE_ARTIFACT_NAME: ${{ steps.candidate.outputs.artifact_name }}
           CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
           PREVIOUS_ASSET_IDS: ${{ steps.previous.outputs.asset_ids }}
+          PREVIOUS_COMMIT_SHA: ${{ steps.previous.outputs.commit_sha }}
           PREVIOUS_RELEASE_ID: ${{ steps.previous.outputs.release_id }}
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -563,17 +594,19 @@ jobs:
             --arg release_tag "${RELEASE_TAG}" \
             --arg release_sha "${RELEASE_SHA}" \
             --arg previous_tag "${PREVIOUS_TAG}" \
+            --arg previous_commit_sha "${PREVIOUS_COMMIT_SHA}" \
             --argjson candidate_run_id "${CANDIDATE_RUN_ID}" \
             --argjson candidate_artifact_id "${CANDIDATE_ARTIFACT_ID}" \
             --arg candidate_artifact_name "${CANDIDATE_ARTIFACT_NAME}" \
             --argjson previous_release_id "${PREVIOUS_RELEASE_ID}" \
             --argjson previous_asset_ids "${PREVIOUS_ASSET_IDS}" \
             '{
-              schema_version: 1,
+              schema_version: 2,
               repository: $repository,
               release_tag: $release_tag,
               release_sha: $release_sha,
               previous_tag: $previous_tag,
+              previous_commit_sha: $previous_commit_sha,
               candidate_package_workflow: "package.yml",
               candidate_package_run_id: $candidate_run_id,
               candidate_package_artifact_id: $candidate_artifact_id,
@@ -633,6 +666,7 @@ jobs:
             --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
             --package-tmp-dir "${PACKAGE_TMP_DIR}" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --architecture-shard amd64 \
             "${common_binding_arguments[@]}" \
             --pull-policy never \
@@ -646,6 +680,7 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_lifecycle_lab.py \
             --packages-dir "${CANDIDATE_PACKAGES_DIR}" \
             --previous-packages-dir "${PREVIOUS_PACKAGES_DIR}" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --aggregate-amd64-report "${RAW_DIR}/package-lifecycle-amd64.json" \
             "${common_binding_arguments[@]}" \
             --output "${RAW_DIR}/package-lifecycle-raw.json" \
@@ -715,6 +750,7 @@ jobs:
             --nft-raw "${RAW_DIR}/nftables-raw.json"
             --package-raw "${RAW_DIR}/package-lifecycle-raw.json"
             --package-amd64-shard "${RAW_DIR}/package-lifecycle-amd64.json"
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json"
             --expected-repository "${GITHUB_REPOSITORY}"
             --expected-workflow-run-id "${GITHUB_RUN_ID}"
             --expected-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}"
@@ -976,6 +1012,7 @@ jobs:
           summarize_raw_report() {
             local label="$1"
             local path="$2"
+            local qualification_matrix_sha256
             local size
             local summary
             if [[ ! -f "${path}" || -L "${path}" ]]; then
@@ -989,7 +1026,15 @@ jobs:
                 '{label: $label, parse_status: "invalid"}'
               return
             fi
-            if ! summary="$(jq -cS --arg label "${label}" '
+            qualification_matrix_sha256="$(sha256sum \
+              "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" |
+              awk '{print $1}')"
+            if ! summary="$(jq -cS \
+              --arg label "${label}" \
+              --arg qualification_matrix_sha256 \
+                "${qualification_matrix_sha256}" \
+              --slurpfile qualification_matrix \
+                "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" '
               if type != "object" then error("report is not an object") else . end
               | . as $report
               | {
@@ -1008,7 +1053,24 @@ jobs:
                     then $report.status else null end
                   ),
                   release_ready: (
-                    if ($report.release_ready | type) == "boolean"
+                    if $label == "package-lifecycle" then null
+                    elif ($report.release_ready | type) == "boolean"
+                    then $report.release_ready else null end
+                  ),
+                  container_lifecycle_release_ready: (
+                    if $label == "package-lifecycle" and
+                      ($report.release_ready | type) == "boolean" and
+                      $report.scope.evidence_kind == "container-lifecycle" and
+                      $report.scope.coverage_kind == "container_scenarios_only" and
+                      $report.scope.real_host_evidence_included == false and
+                      $report.scope.required_checks_complete == false and
+                      $report.scope.covered_scenarios ==
+                        [$qualification_matrix[0].cells[] |
+                          {cell_id: .id, scenarios: .container_scenarios}] and
+                      $report.qualification_matrix == {
+                        matrix_id: $qualification_matrix[0].matrix_id,
+                        sha256: $qualification_matrix_sha256
+                      }
                     then $report.release_ready else null end
                   ),
                   blocker_count: (
@@ -1108,6 +1170,7 @@ jobs:
             --nft-raw "${RAW_DIR}/nftables-raw.json" \
             --package-raw "${RAW_DIR}/package-lifecycle-raw.json" \
             --package-amd64-shard "${RAW_DIR}/package-lifecycle-amd64.json" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --expected-repository "${GITHUB_REPOSITORY}" \
             --expected-workflow-run-id "${GITHUB_RUN_ID}" \
             --expected-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \
@@ -1533,6 +1596,7 @@ jobs:
           EXPECTED_CANDIDATE_ARTIFACT_ID: ${{ needs.qualify-release.outputs.candidate_artifact_id }}
           EXPECTED_CANDIDATE_ARTIFACT_NAME: ${{ needs.qualify-release.outputs.candidate_artifact_name }}
           EXPECTED_CANDIDATE_RUN_ID: ${{ needs.qualify-release.outputs.candidate_run_id }}
+          EXPECTED_PREVIOUS_COMMIT_SHA: ${{ needs.qualify-release.outputs.previous_commit_sha }}
           EXPECTED_PREVIOUS_RELEASE_ID: ${{ needs.qualify-release.outputs.previous_release_id }}
           EXPECTED_SIGNED_UPDATE_REQUIRED: ${{ needs.qualify-release.outputs.signed_update_required }}
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
@@ -1643,16 +1707,20 @@ jobs:
             --arg release_tag "${RELEASE_TAG}" \
             --arg release_sha "${RELEASE_SHA}" \
             --arg previous_tag "${PREVIOUS_TAG}" \
+            --arg previous_commit_sha "${EXPECTED_PREVIOUS_COMMIT_SHA}" \
             --arg candidate_artifact_name "${CANDIDATE_ARTIFACT_NAME}" \
             --argjson candidate_run_id "${CANDIDATE_RUN_ID}" \
             --argjson candidate_artifact_id "${CANDIDATE_ARTIFACT_ID}" \
-            --argjson previous_release_id "${EXPECTED_PREVIOUS_RELEASE_ID}" '
+            --argjson previous_release_id "${EXPECTED_PREVIOUS_RELEASE_ID}" \
+            --slurpfile qualification_matrix \
+              "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" '
               (keys | sort) == ([
                 "candidate_package_artifact_id",
                 "candidate_package_artifact_name",
                 "candidate_package_run_id",
                 "candidate_package_workflow",
                 "previous_package_asset_ids",
+                "previous_commit_sha",
                 "previous_release_id",
                 "previous_tag",
                 "release_sha",
@@ -1660,16 +1728,23 @@ jobs:
                 "repository",
                 "schema_version"
               ] | sort) and
-              .schema_version == 1 and
+              .schema_version == 2 and
               .repository == $repository and
               .release_tag == $release_tag and
               .release_sha == $release_sha and
               .previous_tag == $previous_tag and
+              .previous_commit_sha == $previous_commit_sha and
               .candidate_package_workflow == "package.yml" and
               .candidate_package_run_id == $candidate_run_id and
               .candidate_package_artifact_id == $candidate_artifact_id and
               .candidate_package_artifact_name == $candidate_artifact_name and
               .previous_release_id == $previous_release_id and
+              $qualification_matrix[0].package_sources.baseline.release ==
+                $previous_tag and
+              $qualification_matrix[0].package_sources.baseline.commit ==
+                $previous_commit_sha and
+              $qualification_matrix[0].package_sources.baseline.release_id ==
+                $previous_release_id and
               (.previous_package_asset_ids | type == "array" and length == 4) and
               ([.previous_package_asset_ids[].name] | sort) == ([
                 "SHA256SUMS.txt",
@@ -1679,7 +1754,10 @@ jobs:
               ] | sort) and
               all(.previous_package_asset_ids[];
                 (.id | type == "number" and . > 0 and floor == .) and
-                (.name | type == "string" and length > 0))
+                (.name | type == "string" and length > 0)) and
+              (.previous_package_asset_ids | sort_by(.name)) ==
+                ($qualification_matrix[0].package_sources.baseline.assets |
+                  map({name, id}) | sort_by(.name))
             ' "${UNSIGNED_EVIDENCE_ROOT}/qualification-context.json" >/dev/null; then
             echo "ERROR: unsigned qualification context is not bound to hosted signing inputs." >&2
             exit 1
@@ -1750,6 +1828,7 @@ jobs:
             --nft-raw "${UNSIGNED_EVIDENCE_ROOT}/raw/nftables-raw.json" \
             --package-raw "${UNSIGNED_EVIDENCE_ROOT}/raw/package-lifecycle-raw.json" \
             --package-amd64-shard "${UNSIGNED_EVIDENCE_ROOT}/raw/package-lifecycle-amd64.json" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --expected-repository "${GITHUB_REPOSITORY}" \
             --expected-workflow-run-id "${GITHUB_RUN_ID}" \
             --expected-workflow-run-attempt "${GITHUB_RUN_ATTEMPT}" \

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -29,8 +29,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Sequence
 
+try:
+    from scripts.ci import package_qualification_matrix as qualification_matrix
+except ModuleNotFoundError:  # Direct execution from scripts/ci.
+    import package_qualification_matrix as qualification_matrix
 
-SCHEMA_VERSION = 4
+
+SCHEMA_VERSION = 5
 LOG_TAIL_LIMIT = 12_000
 NAMESPACE_DIAGNOSTIC_PREFIX_BYTES = 256
 MAX_VERSION_COMPONENT = 2_147_483_647
@@ -76,6 +81,8 @@ class LifecycleLabError(RuntimeError):
 
 @dataclass(frozen=True)
 class PlatformSpec:
+    cell_id: str
+    version: str
     name: str
     distribution: str
     family: str
@@ -118,6 +125,22 @@ ACTIVE_RESTART_CONTRACT = (
     "a non-copy-up /run tmpfs and revalidates native and filesystem "
     "inventories plus operator state"
 )
+AVAILABLE_ARCHITECTURE_PROBE_KEYS = frozenset(
+    {
+        "status",
+        "execution_mode",
+        "podman_platform",
+        "expected_uname",
+        "actual_uname",
+        "expected_distribution",
+        "actual_distribution",
+        "expected_distribution_version",
+        "actual_distribution_version",
+        "container_exit_code",
+        "network",
+        "filesystem",
+    }
+)
 
 OFFICIAL_REPOSITORIES = {
     "debian": "docker.io/library/debian",
@@ -126,6 +149,11 @@ OFFICIAL_REPOSITORIES = {
     "almalinux": "docker.io/library/almalinux",
     "alpine": "docker.io/library/alpine",
 }
+
+EXACT_OS_RELEASE_VERSION_DISTRIBUTIONS = frozenset(
+    {"debian", "ubuntu", "fedora"}
+)
+OS_RELEASE_VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+)*$")
 
 DEB_BOOTSTRAP = (
     "apt-get update && "
@@ -415,101 +443,72 @@ syswarden_namespace_file_record() {{
 """
 
 
-DEFAULT_PLATFORMS = (
-    PlatformSpec(
-        name="Debian",
-        distribution="debian",
-        family="deb",
-        architecture="amd64",
-        package_architecture="amd64",
-        podman_platform="linux/amd64",
-        uname_architecture="x86_64",
-        official_repository=OFFICIAL_REPOSITORIES["debian"],
-        image=(
-            "docker.io/library/debian:stable-slim@sha256:"
-            "0ef0f77425e6677ead26f893cb61707f7fc44467a480625d8974feb7ab2085fe"
-        ),
-        package_pattern=r"^syswarden_[0-9][0-9.]*_amd64\.deb$",
-        bootstrap_command=DEB_BOOTSTRAP,
-        scenarios=("upgrade-rollback", "remove", "purge"),
-        purge_semantics=DEB_PURGE_SEMANTICS,
-    ),
-    PlatformSpec(
-        name="Ubuntu",
-        distribution="ubuntu",
-        family="deb",
-        architecture="amd64",
-        package_architecture="amd64",
-        podman_platform="linux/amd64",
-        uname_architecture="x86_64",
-        official_repository=OFFICIAL_REPOSITORIES["ubuntu"],
-        image=(
-            "docker.io/library/ubuntu:24.04@sha256:"
-            "019e8eb29a85e74d64925745884f2ec79aa27e3feab36353d24656f4d6b89467"
-        ),
-        package_pattern=r"^syswarden_[0-9][0-9.]*_amd64\.deb$",
-        bootstrap_command=DEB_BOOTSTRAP,
-        scenarios=("upgrade-rollback", "remove", "purge"),
-        purge_semantics=DEB_PURGE_SEMANTICS,
-    ),
-    PlatformSpec(
-        name="Fedora",
-        distribution="fedora",
-        family="rpm",
-        architecture="amd64",
-        package_architecture="x86_64",
-        podman_platform="linux/amd64",
-        uname_architecture="x86_64",
-        official_repository=OFFICIAL_REPOSITORIES["fedora"],
-        image=(
-            "docker.io/library/fedora:44@sha256:"
-            "89f61a124414261868224666aa7fb8df1b78397a53623774bdfb105d1612b48b"
-        ),
-        package_pattern=r"^syswarden-[0-9][0-9.]*-1\.x86_64\.rpm$",
-        bootstrap_command=RPM_BOOTSTRAP,
-        scenarios=("upgrade-rollback", "remove"),
-        purge_semantics=RPM_PURGE_SEMANTICS,
-    ),
-    PlatformSpec(
-        name="AlmaLinux",
-        distribution="almalinux",
-        family="rpm",
-        architecture="amd64",
-        package_architecture="x86_64",
-        podman_platform="linux/amd64",
-        uname_architecture="x86_64",
-        official_repository=OFFICIAL_REPOSITORIES["almalinux"],
-        image=(
-            "docker.io/library/almalinux:9@sha256:"
-            "28db580abb508f7ccbc0ac6d53e1d8da9d42a26c77fa3dcc26ac2726673fbe3e"
-        ),
-        package_pattern=r"^syswarden-[0-9][0-9.]*-1\.x86_64\.rpm$",
-        bootstrap_command=RPM_BOOTSTRAP,
-        scenarios=("upgrade-rollback", "remove"),
-        purge_semantics=RPM_PURGE_SEMANTICS,
-    ),
-    PlatformSpec(
-        name="Alpine",
-        distribution="alpine",
-        family="apk",
-        architecture="amd64",
-        package_architecture="x86_64",
-        podman_platform="linux/amd64",
-        uname_architecture="x86_64",
-        official_repository=OFFICIAL_REPOSITORIES["alpine"],
-        image=(
-            "docker.io/library/alpine:3.22@sha256:"
-            "7c8cb692ae09657cbc4a3f3cbd0e8d5a2690ba38386aaaf252dbb060bf5eb2e6"
-        ),
-        package_pattern=r"^syswarden_[0-9][0-9.]*_x86_64\.apk$",
-        bootstrap_command=APK_BOOTSTRAP,
-        scenarios=("upgrade-rollback", "remove", "purge"),
-        purge_semantics=APK_PURGE_SEMANTICS,
-    ),
+QUALIFICATION_MATRIX_PATH = qualification_matrix.DEFAULT_MATRIX
+QUALIFICATION_MATRIX_DOCUMENT, QUALIFICATION_MATRIX_SHA256 = (
+    qualification_matrix.load_matrix_snapshot(QUALIFICATION_MATRIX_PATH)
 )
+QUALIFICATION_MATRIX_ID = str(QUALIFICATION_MATRIX_DOCUMENT["matrix_id"])
+
+_PLATFORM_NAMES = {
+    "debian": "Debian",
+    "ubuntu": "Ubuntu",
+    "fedora": "Fedora",
+    "almalinux": "AlmaLinux",
+    "alpine": "Alpine",
+}
+_BOOTSTRAP_COMMANDS = {
+    "deb": DEB_BOOTSTRAP,
+    "rpm": RPM_BOOTSTRAP,
+    "apk": APK_BOOTSTRAP,
+}
+_PURGE_SEMANTICS = {
+    "deb": DEB_PURGE_SEMANTICS,
+    "rpm": RPM_PURGE_SEMANTICS,
+    "apk": APK_PURGE_SEMANTICS,
+}
+
+
+def _platform_from_matrix_cell(cell: dict[str, object]) -> PlatformSpec:
+    distribution = str(cell["distribution"])
+    family = str(cell["family"])
+    architecture = "amd64"
+    return PlatformSpec(
+        cell_id=str(cell["id"]),
+        version=str(cell["version"]),
+        name=_PLATFORM_NAMES[distribution],
+        distribution=distribution,
+        family=family,
+        architecture=architecture,
+        package_architecture=EXPECTED_PACKAGE_ARCHITECTURES[
+            (family, architecture)
+        ],
+        podman_platform=str(
+            QUALIFICATION_MATRIX_DOCUMENT["architecture"]["oci_platform"]
+        ),
+        uname_architecture=str(
+            QUALIFICATION_MATRIX_DOCUMENT["architecture"]["kernel"]
+        ),
+        official_repository=OFFICIAL_REPOSITORIES[distribution],
+        image=str(cell["image"]),
+        package_pattern=EXPECTED_PACKAGE_PATTERNS[(family, architecture)],
+        bootstrap_command=_BOOTSTRAP_COMMANDS[family],
+        scenarios=tuple(str(item) for item in cell["container_scenarios"]),
+        purge_semantics=_PURGE_SEMANTICS[family],
+    )
+
+
+DEFAULT_PLATFORMS = tuple(
+    _platform_from_matrix_cell(cell)
+    for cell in QUALIFICATION_MATRIX_DOCUMENT["cells"]
+)
+if len(DEFAULT_PLATFORMS) != 8:
+    raise LifecycleLabError("frozen qualification matrix must contain exactly 8 cells")
 
 REQUIRED_PLATFORM_COORDINATES = frozenset(
-    (spec.distribution, spec.architecture) for spec in DEFAULT_PLATFORMS
+    (spec.cell_id, spec.architecture) for spec in DEFAULT_PLATFORMS
+)
+REQUIRED_PLATFORM_COORDINATE_ORDER = tuple(
+    (spec.cell_id, spec.architecture) for spec in DEFAULT_PLATFORMS
 )
 REQUIRED_PACKAGE_COORDINATES = frozenset(
     f"{spec.family}:{spec.package_architecture}" for spec in DEFAULT_PLATFORMS
@@ -520,6 +519,30 @@ PACKAGE_COORDINATE_PATTERNS = {
 }
 REQUIRED_FAMILIES = ("deb", "rpm", "apk")
 NATIVE_AGGREGATE_HOST = "native-shards:amd64"
+QUALIFICATION_MATRIX_KEYS = frozenset({"matrix_id", "sha256"})
+SCOPE_KEYS = frozenset(
+    {
+        "evidence_kind",
+        "coverage_kind",
+        "real_host_evidence_included",
+        "required_checks_complete",
+        "covered_scenarios",
+        "container_lab_complete",
+        "coordinate_classification",
+        "host_architecture",
+        "network_during_image_bootstrap",
+        "network_during_package_operations",
+        "host_mutation",
+        "architectures_completed",
+        "architectures_incomplete_or_failed",
+        "architecture_coverage",
+        "family_architecture_coverage",
+        "required_platform_coordinates",
+        "missing_platform_coordinates",
+        "architecture_coverage_policy",
+        "rollback_model",
+    }
+)
 QUALIFICATION_BINDING_KEYS = frozenset(
     {
         "schema_version",
@@ -548,6 +571,46 @@ NATIVE_SHARD_RECORD_KEYS = frozenset(
         "engine_version",
     }
 )
+
+
+def qualification_matrix_binding(path: Path) -> dict[str, str]:
+    """Load and byte-bind the exact frozen matrix used by this lab run."""
+
+    try:
+        document, digest = qualification_matrix.load_matrix_snapshot(path)
+    except qualification_matrix.QualificationMatrixError as exc:
+        raise LifecycleLabError(f"qualification matrix is invalid: {exc}") from exc
+    if document != QUALIFICATION_MATRIX_DOCUMENT:
+        raise LifecycleLabError(
+            "qualification matrix differs from the frozen lifecycle contract"
+        )
+    if digest != QUALIFICATION_MATRIX_SHA256:
+        raise LifecycleLabError(
+            "qualification matrix bytes differ from the frozen lifecycle contract"
+        )
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise LifecycleLabError("qualification matrix SHA-256 is invalid")
+    return {"matrix_id": QUALIFICATION_MATRIX_ID, "sha256": digest}
+
+
+def validate_qualification_matrix_binding(value: object) -> dict[str, str]:
+    if (
+        not isinstance(value, dict)
+        or set(value) != QUALIFICATION_MATRIX_KEYS
+        or value.get("matrix_id") != QUALIFICATION_MATRIX_ID
+        or not isinstance(value.get("sha256"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", str(value.get("sha256"))) is None
+        or value.get("sha256") != QUALIFICATION_MATRIX_SHA256
+    ):
+        raise LifecycleLabError("qualification matrix report binding is invalid")
+    return {"matrix_id": str(value["matrix_id"]), "sha256": str(value["sha256"])}
+
+
+def qualification_matrix_container_scenarios() -> list[dict[str, object]]:
+    return [
+        {"cell_id": spec.cell_id, "scenarios": list(spec.scenarios)}
+        for spec in DEFAULT_PLATFORMS
+    ]
 
 OPERATOR_STATE_KEYS = (
     "config",
@@ -1356,11 +1419,11 @@ def package_coordinate(spec: PlatformSpec) -> str:
 
 
 def platform_coordinate(spec: PlatformSpec) -> tuple[str, str]:
-    return spec.distribution, spec.architecture
+    return spec.cell_id, spec.architecture
 
 
 def platform_slug(spec: PlatformSpec) -> str:
-    slug = f"{spec.distribution}-{spec.architecture}"
+    slug = f"{spec.cell_id.casefold()}-{spec.architecture}"
     if re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug) is None:
         raise LifecycleLabError(f"unsafe platform coordinate: {slug!r}")
     return slug
@@ -1398,6 +1461,23 @@ def validate_platforms(platforms: Sequence[PlatformSpec]) -> None:
         if spec.architecture not in ARCHITECTURE_LABELS:
             raise LifecycleLabError(
                 f"unsupported package lifecycle architecture: {spec.architecture!r}"
+            )
+        expected_spec = next(
+            (
+                item
+                for item in DEFAULT_PLATFORMS
+                if platform_coordinate(item) == coordinate
+            ),
+            None,
+        )
+        if expected_spec is None:
+            raise LifecycleLabError(
+                f"unsupported package lifecycle matrix cell: {coordinate!r}"
+            )
+        if spec.version != expected_spec.version:
+            raise LifecycleLabError(
+                f"matrix cell version mismatch for {coordinate}: expected "
+                f"{expected_spec.version!r}, found {spec.version!r}"
             )
         expected_platform = f"linux/{spec.architecture}"
         if spec.podman_platform != expected_platform:
@@ -1444,10 +1524,24 @@ def validate_platforms(platforms: Sequence[PlatformSpec]) -> None:
                 f"platform {coordinate} must use official image repository "
                 f"{expected_repository!r}"
             )
+        if spec.image != expected_spec.image:
+            raise LifecycleLabError(
+                f"frozen image identity mismatch for {coordinate}: expected "
+                f"{expected_spec.image!r}, found {spec.image!r}"
+            )
         if not spec.bootstrap_command.strip() or "\n" in spec.bootstrap_command:
             raise LifecycleLabError(f"invalid bootstrap command for {coordinate}")
         if not spec.purge_semantics.strip():
             raise LifecycleLabError(f"missing purge semantics for {coordinate}")
+        if spec != expected_spec:
+            raise LifecycleLabError(
+                f"matrix cell runtime contract differs from the frozen "
+                f"definition for {coordinate}"
+            )
+        if spec != expected_spec:
+            raise LifecycleLabError(
+                f"platform specification differs from frozen matrix cell {coordinate}"
+            )
         platform_slug(spec)
 
 
@@ -1732,6 +1826,37 @@ set -u
 [ -r /lab/package-webtui-retirement.sh ] || exit 90
 # shellcheck source=package_webtui_retirement.sh
 . /lab/package-webtui-retirement.sh
+
+[ -r /etc/os-release ] || exit 92
+case "${EXPECTED_DISTRIBUTION_VERSION}" in
+    ''|*[!0-9.]*|.*|*..*|*.) exit 92 ;;
+esac
+ACTUAL_DISTRIBUTION_ID="$(
+    . /etc/os-release
+    printf '%s' "${ID-}"
+)" || exit 92
+ACTUAL_DISTRIBUTION_VERSION="$(
+    . /etc/os-release
+    printf '%s' "${VERSION_ID-}"
+)" || exit 92
+[ "${ACTUAL_DISTRIBUTION_ID}" = "${EXPECTED_DISTRIBUTION}" ] || exit 92
+case "${ACTUAL_DISTRIBUTION_VERSION}" in
+    ''|*[!0-9.]*|.*|*..*|*.) exit 92 ;;
+esac
+case "${EXPECTED_DISTRIBUTION}" in
+    debian|ubuntu|fedora)
+        [ "${ACTUAL_DISTRIBUTION_VERSION}" = "${EXPECTED_DISTRIBUTION_VERSION}" ] || exit 92
+        ;;
+    almalinux)
+        [ "${ACTUAL_DISTRIBUTION_VERSION%%.*}" = "${EXPECTED_DISTRIBUTION_VERSION}" ] || exit 92
+        ;;
+    alpine)
+        actual_distribution_tail="${ACTUAL_DISTRIBUTION_VERSION#*.}"
+        actual_distribution_major_minor="${ACTUAL_DISTRIBUTION_VERSION%%.*}.${actual_distribution_tail%%.*}"
+        [ "${actual_distribution_major_minor}" = "${EXPECTED_DISTRIBUTION_VERSION}" ] || exit 92
+        ;;
+    *) exit 92 ;;
+esac
 
 RESULT_FILE="/results/events.tsv"
 COMMAND_LOG="/results/commands.log"
@@ -6224,6 +6349,42 @@ def ensure_image(
         )
 
 
+def distribution_version_matches(
+    distribution: str,
+    expected_version: str,
+    actual_version: str,
+) -> bool:
+    """Match an os-release VERSION_ID against the frozen distribution line.
+
+    Debian, Ubuntu, and Fedora matrix cells identify an exact VERSION_ID.
+    AlmaLinux tags identify a major release line, while Alpine tags identify a
+    major.minor release line.  Both line-based forms still reject malformed
+    values and adjacent lines; the immutable image digest remains exact.
+    """
+
+    if (
+        OS_RELEASE_VERSION_PATTERN.fullmatch(expected_version) is None
+        or OS_RELEASE_VERSION_PATTERN.fullmatch(actual_version) is None
+    ):
+        return False
+    expected_components = expected_version.split(".")
+    actual_components = actual_version.split(".")
+    if distribution in EXACT_OS_RELEASE_VERSION_DISTRIBUTIONS:
+        return actual_version == expected_version
+    if distribution == "almalinux":
+        return (
+            len(expected_components) == 1
+            and actual_components[0] == expected_components[0]
+        )
+    if distribution == "alpine":
+        return (
+            len(expected_components) == 2
+            and len(actual_components) >= 2
+            and actual_components[:2] == expected_components
+        )
+    return False
+
+
 def architecture_probe_arguments(
     podman: str,
     spec: PlatformSpec,
@@ -6244,8 +6405,36 @@ def architecture_probe_arguments(
         "--pids-limit=64",
         "--memory=128m",
         "--tmpfs=/tmp:rw,nodev,nosuid,size=16m",
+        "--env",
+        f"EXPECTED_DISTRIBUTION={spec.distribution}",
+        "--env",
+        f"EXPECTED_DISTRIBUTION_VERSION={spec.version}",
     ]
-    arguments.extend((spec.image, "/bin/uname", "-m"))
+    probe = (
+        "set -eu\n"
+        ". /etc/os-release\n"
+        "actual_uname=\"$(uname -m)\"\n"
+        "actual_distribution=\"${ID-}\"\n"
+        "actual_version=\"${VERSION_ID-}\"\n"
+        "printf '%s\\t%s\\t%s\\n' \"${actual_uname}\" "
+        "\"${actual_distribution}\" \"${actual_version}\"\n"
+        "[ \"${actual_distribution}\" = \"${EXPECTED_DISTRIBUTION}\" ]\n"
+        "case \"${actual_version}\" in "
+        "''|*[!0-9.]*|.*|*..*|*.) exit 1 ;; esac\n"
+        "[ -n \"${actual_version}\" ]\n"
+        "case \"${EXPECTED_DISTRIBUTION}\" in\n"
+        "  debian|ubuntu|fedora) "
+        "[ \"${actual_version}\" = \"${EXPECTED_DISTRIBUTION_VERSION}\" ] ;;\n"
+        "  almalinux) "
+        "[ \"${actual_version%%.*}\" = \"${EXPECTED_DISTRIBUTION_VERSION}\" ] ;;\n"
+        "  alpine)\n"
+        "    actual_tail=\"${actual_version#*.}\"\n"
+        "    actual_major_minor=\"${actual_version%%.*}.${actual_tail%%.*}\"\n"
+        "    [ \"${actual_major_minor}\" = \"${EXPECTED_DISTRIBUTION_VERSION}\" ] ;;\n"
+        "  *) exit 1 ;;\n"
+        "esac\n"
+    )
+    arguments.extend((spec.image, "/bin/sh", "-ceu", probe))
     return tuple(arguments)
 
 
@@ -6298,18 +6487,35 @@ def probe_platform_execution(
             "expected_uname": spec.uname_architecture,
             "reason": str(exc),
         }
-    actual_uname = result.stdout.strip()
-    if result.returncode != 0 or actual_uname != spec.uname_architecture:
+    fields = result.stdout.rstrip("\n").split("\t")
+    actual_uname = fields[0] if len(fields) == 3 else ""
+    actual_distribution = fields[1] if len(fields) == 3 else ""
+    actual_distribution_version = fields[2] if len(fields) == 3 else ""
+    if (
+        result.returncode != 0
+        or len(fields) != 3
+        or actual_uname != spec.uname_architecture
+        or actual_distribution != spec.distribution
+        or not distribution_version_matches(
+            spec.distribution,
+            spec.version,
+            actual_distribution_version,
+        )
+    ):
         return {
             "status": "unavailable",
             "execution_mode": "native",
             "podman_platform": spec.podman_platform,
             "expected_uname": spec.uname_architecture,
             "actual_uname": actual_uname,
+            "expected_distribution": spec.distribution,
+            "actual_distribution": actual_distribution,
+            "expected_distribution_version": spec.version,
+            "actual_distribution_version": actual_distribution_version,
             "container_exit_code": result.returncode,
             "reason": (
-                "the pinned image did not execute with the requested architecture; "
-                "native AMD64 execution is required"
+                "the pinned image did not prove the requested native architecture "
+                "and closed /etc/os-release ID and VERSION_ID identity"
             ),
             "log_tail": command_log_tail(result),
         }
@@ -6319,10 +6525,46 @@ def probe_platform_execution(
         "podman_platform": spec.podman_platform,
         "expected_uname": spec.uname_architecture,
         "actual_uname": actual_uname,
+        "expected_distribution": spec.distribution,
+        "actual_distribution": actual_distribution,
+        "expected_distribution_version": spec.version,
+        "actual_distribution_version": actual_distribution_version,
         "container_exit_code": result.returncode,
         "network": "disabled",
         "filesystem": "read-only with bounded /tmp tmpfs",
     }
+
+
+def validate_available_architecture_probe(
+    value: object, spec: PlatformSpec
+) -> dict[str, object]:
+    if (
+        not isinstance(value, dict)
+        or set(value) != AVAILABLE_ARCHITECTURE_PROBE_KEYS
+        or value.get("status") != "available"
+        or value.get("execution_mode") != "native"
+        or value.get("podman_platform") != spec.podman_platform
+        or value.get("expected_uname") != spec.uname_architecture
+        or value.get("actual_uname") != spec.uname_architecture
+        or value.get("expected_distribution") != spec.distribution
+        or value.get("actual_distribution") != spec.distribution
+        or value.get("expected_distribution_version") != spec.version
+        or not isinstance(value.get("actual_distribution_version"), str)
+        or not distribution_version_matches(
+            spec.distribution,
+            spec.version,
+            value["actual_distribution_version"],
+        )
+        or type(value.get("container_exit_code")) is not int
+        or value.get("container_exit_code") != 0
+        or value.get("network") != "disabled"
+        or value.get("filesystem") != "read-only with bounded /tmp tmpfs"
+    ):
+        raise LifecycleLabError(
+            f"architecture and distribution-version evidence is invalid for "
+            f"{platform_coordinate(spec)}"
+        )
+    return value
 
 
 def _capability_has_bit(value: str, bit: int) -> bool:
@@ -6601,6 +6843,8 @@ def container_run_arguments(
         f"EXPECTED_UNAME_ARCHITECTURE={spec.uname_architecture}",
         "--env",
         f"EXPECTED_DISTRIBUTION={spec.distribution}",
+        "--env",
+        f"EXPECTED_DISTRIBUTION_VERSION={spec.version}",
         "--env",
         f"EXPECTED_CANDIDATE_VERSION={pair.candidate.version}",
         "--env",
@@ -8184,6 +8428,8 @@ def run_platform(
 ) -> dict[str, object]:
     slug = platform_slug(spec)
     platform_result: dict[str, object] = {
+        "cell_id": spec.cell_id,
+        "version": spec.version,
         "name": spec.name,
         "distribution": spec.distribution,
         "family": spec.family,
@@ -8818,7 +9064,9 @@ def _platform_spec_from_result(platform_result: dict[str, object]) -> PlatformSp
     matches = [
         spec
         for spec in DEFAULT_PLATFORMS
-        if spec.distribution == platform_result.get("distribution")
+        if spec.cell_id == platform_result.get("cell_id")
+        and spec.version == platform_result.get("version")
+        and spec.distribution == platform_result.get("distribution")
         and spec.architecture == platform_result.get("architecture_id")
         and spec.family == platform_result.get("family")
     ]
@@ -9559,7 +9807,7 @@ def classify_lifecycle_evidence(
     *,
     required_platform_coordinates: frozenset[tuple[str, str]] = REQUIRED_PLATFORM_COORDINATES,
 ) -> dict[str, object]:
-    """Recompute release readiness without a generic product waiver."""
+    """Recompute compatibility verdicts for container scenarios only."""
 
     if (
         not required_platform_coordinates
@@ -9569,34 +9817,52 @@ def classify_lifecycle_evidence(
 
     structural_failures: list[str] = []
     results_by_coordinate = {
-        (str(result.get("distribution")), str(result.get("architecture_id"))): result
+        (str(result.get("cell_id")), str(result.get("architecture_id"))): result
         for result in results
     }
     if len(results_by_coordinate) != len(results):
         structural_failures.append("matrix:duplicate-platform-coordinate")
-    for distribution, architecture in sorted(
+    for cell_id, architecture in sorted(
         set(results_by_coordinate) - required_platform_coordinates
     ):
         structural_failures.append(
-            f"matrix:unexpected-platform-coordinate:{distribution}/{architecture}"
+            f"matrix:unexpected-platform-coordinate:{cell_id}/{architecture}"
         )
     observed_failures: dict[str, str] = {}
     coordinate_classification: list[dict[str, object]] = []
 
-    for distribution, architecture in sorted(required_platform_coordinates):
-        coordinate_name = f"{distribution}/{architecture}"
-        platform_result = results_by_coordinate.get((distribution, architecture))
+    required_coordinate_order = [
+        coordinate
+        for coordinate in REQUIRED_PLATFORM_COORDINATE_ORDER
+        if coordinate in required_platform_coordinates
+    ]
+    for cell_id, architecture in required_coordinate_order:
+        coordinate_name = f"{cell_id}/{architecture}"
+        platform_result = results_by_coordinate.get((cell_id, architecture))
         coordinate_structural: list[str] = []
         coordinate_failures: dict[str, str] = {}
+        expected_spec = next(
+            spec
+            for spec in DEFAULT_PLATFORMS
+            if platform_coordinate(spec) == (cell_id, architecture)
+        )
         if platform_result is None:
             coordinate_structural.append(f"{coordinate_name}:platform-result-missing")
-            family = next(
-                spec.family
-                for spec in DEFAULT_PLATFORMS
-                if platform_coordinate(spec) == (distribution, architecture)
-            )
+            family = expected_spec.family
         else:
             family = str(platform_result.get("family"))
+            if any(
+                platform_result.get(key) != value
+                for key, value in {
+                    "cell_id": expected_spec.cell_id,
+                    "version": expected_spec.version,
+                    "distribution": expected_spec.distribution,
+                    "family": expected_spec.family,
+                }.items()
+            ):
+                coordinate_structural.append(
+                    f"{coordinate_name}:matrix-cell-identity-invalid"
+                )
             if platform_result.get("runtime_mode") != "active-real-init":
                 coordinate_structural.append(
                     f"{coordinate_name}:runtime-mode-not-active-real-init"
@@ -9745,7 +10011,7 @@ def classify_lifecycle_evidence(
             coordinate_status = "incomplete"
         coordinate_classification.append(
             {
-                "distribution": distribution,
+                "cell_id": cell_id,
                 "architecture_id": architecture,
                 "family": family,
                 "status": coordinate_status,
@@ -10025,6 +10291,7 @@ def validate_report_version_contract(
         raise LifecycleLabError(
             f"package lifecycle report schema must be {SCHEMA_VERSION}"
         )
+    validate_qualification_matrix_binding(report.get("qualification_matrix"))
     contract = report.get("package_version_contract")
     if not isinstance(contract, dict):
         raise LifecycleLabError("package lifecycle report lacks a version contract")
@@ -10072,6 +10339,26 @@ def validate_report_version_contract(
     for platform_result in platforms:
         if not isinstance(platform_result, dict):
             raise LifecycleLabError("package lifecycle platform result must be an object")
+        spec = _platform_spec_from_result(platform_result)
+        expected_platform_metadata = {
+            "cell_id": spec.cell_id,
+            "version": spec.version,
+            "distribution": spec.distribution,
+            "family": spec.family,
+            "architecture": ARCHITECTURE_LABELS[spec.architecture],
+            "architecture_id": spec.architecture,
+            "package_architecture": spec.package_architecture,
+            "podman_platform": spec.podman_platform,
+            "image": spec.image,
+        }
+        if any(
+            platform_result.get(key) != value
+            for key, value in expected_platform_metadata.items()
+        ):
+            raise LifecycleLabError(
+                f"package lifecycle matrix-cell evidence is invalid at "
+                f"{platform_coordinate(spec)}"
+            )
         family = platform_result.get("family")
         package_architecture = platform_result.get("package_architecture")
         if not isinstance(family, str) or not isinstance(package_architecture, str):
@@ -10104,6 +10391,9 @@ def validate_report_version_contract(
             expected_gid_map = native_gid_map
         scenarios = platform_result.get("scenarios")
         if platform_result.get("status") == "pass":
+            validate_available_architecture_probe(
+                platform_result.get("architecture_probe"), spec
+            )
             if not isinstance(scenarios, list) or [
                 item.get("name") if isinstance(item, dict) else None
                 for item in scenarios
@@ -10242,6 +10532,13 @@ def validate_report_version_contract(
     scope = report.get("scope")
     if (
         not isinstance(scope, dict)
+        or set(scope) != SCOPE_KEYS
+        or scope.get("evidence_kind") != "container-lifecycle"
+        or scope.get("coverage_kind") != "container_scenarios_only"
+        or scope.get("real_host_evidence_included") is not False
+        or scope.get("required_checks_complete") is not False
+        or scope.get("covered_scenarios")
+        != qualification_matrix_container_scenarios()
         or scope.get("coordinate_classification")
         != classification["coordinate_classification"]
         or scope.get("container_lab_complete")
@@ -10390,6 +10687,10 @@ def run_lab(
     host_architecture: str | None = None,
 ) -> dict[str, object]:
     active_runner = runner or CommandRunner()
+    matrix_path = Path(
+        getattr(args, "qualification_matrix", QUALIFICATION_MATRIX_PATH)
+    )
+    matrix_binding = qualification_matrix_binding(matrix_path)
     architecture_shard = getattr(args, "architecture_shard", None)
     required_platform_coordinates = (
         required_coordinates_for_architecture(architecture_shard)
@@ -10399,12 +10700,22 @@ def run_lab(
     observed_platform_coordinates = frozenset(
         platform_coordinate(spec) for spec in platforms
     )
+    observed_platform_coordinate_order = tuple(
+        platform_coordinate(spec) for spec in platforms
+    )
+    required_platform_coordinate_order = tuple(
+        coordinate
+        for coordinate in REQUIRED_PLATFORM_COORDINATE_ORDER
+        if coordinate in required_platform_coordinates
+    )
     if architecture_shard is not None and (
         observed_platform_coordinates != required_platform_coordinates
         or len(platforms) != len(required_platform_coordinates)
+        or observed_platform_coordinate_order != required_platform_coordinate_order
     ):
         raise LifecycleLabError(
-            f"{architecture_shard} shard must contain its exact five platform coordinates"
+            f"{architecture_shard} shard must contain its exact eight matrix cells "
+            f"in canonical order"
         )
     candidate_root, previous_root, pairs = validate_inputs(
         args.packages_dir, args.previous_packages_dir, platforms
@@ -10456,19 +10767,26 @@ def run_lab(
         )
 
     results_by_coordinate = {
-        (str(result["distribution"]), str(result["architecture_id"])): result
+        (str(result["cell_id"]), str(result["architecture_id"])): result
         for result in platform_results
     }
-    missing_coordinates = sorted(
-        required_platform_coordinates - set(results_by_coordinate)
-    )
+    required_coordinate_order = [
+        coordinate
+        for coordinate in REQUIRED_PLATFORM_COORDINATE_ORDER
+        if coordinate in required_platform_coordinates
+    ]
+    missing_coordinates = [
+        coordinate
+        for coordinate in required_coordinate_order
+        if coordinate not in results_by_coordinate
+    ]
     architecture_coverage: list[dict[str, object]] = []
     for architecture in sorted({item[1] for item in required_platform_coordinates}):
-        expected = sorted(
+        expected = [
             coordinate
-            for coordinate in required_platform_coordinates
+            for coordinate in required_coordinate_order
             if coordinate[1] == architecture
-        )
+        ]
         present = [
             results_by_coordinate[coordinate]
             for coordinate in expected
@@ -10480,17 +10798,23 @@ def run_lab(
                 "architecture": ARCHITECTURE_LABELS[architecture],
                 "architecture_id": architecture,
                 "status": status,
-                "required_distributions": [item[0] for item in expected],
-                "completed_distributions": sorted(
-                    str(result["distribution"])
-                    for result in present
-                    if result["status"] == "pass"
-                ),
-                "incomplete_or_failed_distributions": sorted(
-                    str(result["distribution"])
-                    for result in present
-                    if result["status"] != "pass"
-                ),
+                "required_cells": [item[0] for item in expected],
+                "completed_cells": [
+                    cell_id
+                    for cell_id, item_architecture in expected
+                    if results_by_coordinate.get((cell_id, item_architecture), {}).get(
+                        "status"
+                    )
+                    == "pass"
+                ],
+                "incomplete_or_failed_cells": [
+                    cell_id
+                    for cell_id, item_architecture in expected
+                    if results_by_coordinate.get((cell_id, item_architecture), {}).get(
+                        "status"
+                    )
+                    != "pass"
+                ],
             }
         )
 
@@ -10515,14 +10839,15 @@ def run_lab(
                     "architecture": ARCHITECTURE_LABELS[architecture],
                     "architecture_id": architecture,
                     "status": coverage_status(present, len(expected_specs)),
-                    "required_distributions": [
-                        spec.distribution for spec in expected_specs
+                    "required_cells": [spec.cell_id for spec in expected_specs],
+                    "completed_cells": [
+                        spec.cell_id
+                        for spec in expected_specs
+                        if results_by_coordinate.get(platform_coordinate(spec), {}).get(
+                            "status"
+                        )
+                        == "pass"
                     ],
-                    "completed_distributions": sorted(
-                        str(result["distribution"])
-                        for result in present
-                        if result["status"] == "pass"
-                    ),
                 }
             )
 
@@ -10550,7 +10875,7 @@ def run_lab(
         {
             "architecture": item["architecture"],
             "status": item["status"],
-            "reason": "not every required distribution completed every lifecycle scenario",
+            "reason": "not every required matrix cell completed every lifecycle scenario",
         }
         for item in architecture_coverage
         if item["status"] != "pass"
@@ -10570,8 +10895,14 @@ def run_lab(
         "unexpected_failed_checks": classification[
             "unexpected_failed_checks"
         ],
+        "qualification_matrix": matrix_binding,
         "package_version_contract": version_contract,
         "scope": {
+            "evidence_kind": "container-lifecycle",
+            "coverage_kind": "container_scenarios_only",
+            "real_host_evidence_included": False,
+            "required_checks_complete": False,
+            "covered_scenarios": qualification_matrix_container_scenarios(),
             "container_lab_complete": container_status == "pass",
             "coordinate_classification": classification[
                 "coordinate_classification"
@@ -10585,16 +10916,18 @@ def run_lab(
             "architecture_coverage": architecture_coverage,
             "family_architecture_coverage": family_architecture_coverage,
             "required_platform_coordinates": [
-                {"distribution": distribution, "architecture": architecture}
-                for distribution, architecture in sorted(required_platform_coordinates)
+                {"cell_id": cell_id, "architecture": architecture}
+                for cell_id, architecture in required_coordinate_order
             ],
             "missing_platform_coordinates": [
-                {"distribution": distribution, "architecture": architecture}
-                for distribution, architecture in missing_coordinates
+                {"cell_id": cell_id, "architecture": architecture}
+                for cell_id, architecture in missing_coordinates
             ],
             "architecture_coverage_policy": (
-                "qualification requires the exact five-platform AMD64 matrix "
-                "on a native AMD64 host; native execution is mandatory"
+                "container lifecycle qualification requires every declared "
+                "container_scenario in the exact eight-cell AMD64 matrix on a "
+                "native AMD64 host; it does not close real-host, updater, or "
+                "reboot obligations"
             ),
             "rollback_model": (
                 "external package-manager downgrade to the separately supplied, "
@@ -10657,6 +10990,7 @@ def validate_native_shard_report(
         "release_ready",
         "blocker_ids",
         "unexpected_failed_checks",
+        "qualification_matrix",
         "package_version_contract",
         "scope",
         "engine",
@@ -10667,6 +11001,7 @@ def validate_native_shard_report(
     }
     if set(report) != expected_top_keys:
         raise LifecycleLabError("native shard report top-level schema is not exact")
+    validate_qualification_matrix_binding(report.get("qualification_matrix"))
     required_coordinates = required_coordinates_for_architecture(architecture)
     validate_qualification_binding(
         report.get("qualification_binding"), expected=expected_binding
@@ -10686,8 +11021,9 @@ def validate_native_shard_report(
     ) != architecture:
         raise LifecycleLabError("native shard host architecture is inconsistent")
     expected_coordinates_json = [
-        {"distribution": distribution, "architecture": item_architecture}
-        for distribution, item_architecture in sorted(required_coordinates)
+        {"cell_id": cell_id, "architecture": item_architecture}
+        for cell_id, item_architecture in REQUIRED_PLATFORM_COORDINATE_ORDER
+        if (cell_id, item_architecture) in required_coordinates
     ]
     if (
         scope.get("required_platform_coordinates") != expected_coordinates_json
@@ -10743,7 +11079,7 @@ def validate_native_shard_report(
         if not isinstance(platform_result, dict):
             raise LifecycleLabError("native shard platform result is invalid")
         coordinate = (
-            str(platform_result.get("distribution")),
+            str(platform_result.get("cell_id")),
             str(platform_result.get("architecture_id")),
         )
         if coordinate in seen or coordinate not in required_coordinates:
@@ -10754,6 +11090,9 @@ def validate_native_shard_report(
         observed_order.append(coordinate)
         spec = specs[coordinate]
         expected_platform_metadata = {
+            "cell_id": spec.cell_id,
+            "version": spec.version,
+            "distribution": spec.distribution,
             "family": spec.family,
             "architecture": ARCHITECTURE_LABELS[spec.architecture],
             "package_architecture": spec.package_architecture,
@@ -10769,33 +11108,9 @@ def validate_native_shard_report(
             raise LifecycleLabError(
                 f"native shard platform metadata is invalid at {coordinate}"
             )
-        probe = platform_result.get("architecture_probe")
-        if (
-            not isinstance(probe, dict)
-            or set(probe)
-            != {
-                "status",
-                "execution_mode",
-                "podman_platform",
-                "expected_uname",
-                "actual_uname",
-                "container_exit_code",
-                "network",
-                "filesystem",
-            }
-            or probe.get("status") != "available"
-            or probe.get("execution_mode") != "native"
-            or probe.get("podman_platform") != spec.podman_platform
-            or probe.get("expected_uname") != spec.uname_architecture
-            or probe.get("actual_uname") != spec.uname_architecture
-            or type(probe.get("container_exit_code")) is not int
-            or probe.get("container_exit_code") != 0
-            or probe.get("network") != "disabled"
-            or probe.get("filesystem") != "read-only with bounded /tmp tmpfs"
-        ):
-            raise LifecycleLabError(
-                f"native shard execution evidence is invalid at {coordinate}"
-            )
+        validate_available_architecture_probe(
+            platform_result.get("architecture_probe"), spec
+        )
     if seen != required_coordinates:
         raise LifecycleLabError("native shard platform coordinate set is incomplete")
     expected_order = [
@@ -10861,7 +11176,7 @@ def _aggregate_matrix_summary(
     platform_results: Sequence[dict[str, object]],
 ) -> tuple[str, dict[str, object], dict[str, object]]:
     results_by_coordinate = {
-        (str(result.get("distribution")), str(result.get("architecture_id"))): result
+        (str(result.get("cell_id")), str(result.get("architecture_id"))): result
         for result in platform_results
     }
     if len(results_by_coordinate) != len(platform_results):
@@ -10871,28 +11186,30 @@ def _aggregate_matrix_summary(
     architecture_coverage: list[dict[str, object]] = []
     family_architecture_coverage: list[dict[str, object]] = []
     for architecture in ARCHITECTURE_LABELS:
-        expected = sorted(
+        expected = [
             coordinate
-            for coordinate in REQUIRED_PLATFORM_COORDINATES
+            for coordinate in REQUIRED_PLATFORM_COORDINATE_ORDER
             if coordinate[1] == architecture
-        )
+        ]
         present = [results_by_coordinate[coordinate] for coordinate in expected]
         architecture_coverage.append(
             {
                 "architecture": ARCHITECTURE_LABELS[architecture],
                 "architecture_id": architecture,
                 "status": coverage_status(present, len(expected)),
-                "required_distributions": [item[0] for item in expected],
-                "completed_distributions": sorted(
-                    str(result["distribution"])
-                    for result in present
-                    if result["status"] == "pass"
-                ),
-                "incomplete_or_failed_distributions": sorted(
-                    str(result["distribution"])
-                    for result in present
-                    if result["status"] != "pass"
-                ),
+                "required_cells": [item[0] for item in expected],
+                "completed_cells": [
+                    cell_id
+                    for cell_id, item_architecture in expected
+                    if results_by_coordinate[(cell_id, item_architecture)]["status"]
+                    == "pass"
+                ],
+                "incomplete_or_failed_cells": [
+                    cell_id
+                    for cell_id, item_architecture in expected
+                    if results_by_coordinate[(cell_id, item_architecture)]["status"]
+                    != "pass"
+                ],
             }
         )
         for family in REQUIRED_FAMILIES:
@@ -10910,12 +11227,13 @@ def _aggregate_matrix_summary(
                     "architecture": ARCHITECTURE_LABELS[architecture],
                     "architecture_id": architecture,
                     "status": coverage_status(family_results, len(specs)),
-                    "required_distributions": [spec.distribution for spec in specs],
-                    "completed_distributions": sorted(
-                        str(result["distribution"])
-                        for result in family_results
-                        if result["status"] == "pass"
-                    ),
+                    "required_cells": [spec.cell_id for spec in specs],
+                    "completed_cells": [
+                        spec.cell_id
+                        for spec in specs
+                        if results_by_coordinate[platform_coordinate(spec)]["status"]
+                        == "pass"
+                    ],
                 }
             )
     if any(result.get("status") == "fail" for result in platform_results):
@@ -10926,6 +11244,11 @@ def _aggregate_matrix_summary(
         status = "pass"
     classification = classify_lifecycle_evidence(platform_results)
     scope = {
+        "evidence_kind": "container-lifecycle",
+        "coverage_kind": "container_scenarios_only",
+        "real_host_evidence_included": False,
+        "required_checks_complete": False,
+        "covered_scenarios": qualification_matrix_container_scenarios(),
         "container_lab_complete": status == "pass",
         "coordinate_classification": classification["coordinate_classification"],
         "host_architecture": NATIVE_AGGREGATE_HOST,
@@ -10945,7 +11268,7 @@ def _aggregate_matrix_summary(
                 "architecture": item["architecture"],
                 "status": item["status"],
                 "reason": (
-                    "not every required distribution completed every lifecycle scenario"
+                    "not every required matrix cell completed every lifecycle scenario"
                 ),
             }
             for item in architecture_coverage
@@ -10954,13 +11277,15 @@ def _aggregate_matrix_summary(
         "architecture_coverage": architecture_coverage,
         "family_architecture_coverage": family_architecture_coverage,
         "required_platform_coordinates": [
-            {"distribution": distribution, "architecture": architecture}
-            for distribution, architecture in sorted(REQUIRED_PLATFORM_COORDINATES)
+            {"cell_id": cell_id, "architecture": architecture}
+            for cell_id, architecture in REQUIRED_PLATFORM_COORDINATE_ORDER
         ],
         "missing_platform_coordinates": [],
         "architecture_coverage_policy": (
-            "qualification requires the exact five-platform AMD64 matrix on the "
-            "native AMD64 shard; native execution is mandatory"
+            "container lifecycle qualification requires every declared "
+            "container_scenario in the exact eight-cell AMD64 matrix on the "
+            "native AMD64 shard; it does not close real-host, updater, or "
+            "reboot obligations"
         ),
         "rollback_model": (
             "external package-manager downgrade to the separately supplied, "
@@ -10972,6 +11297,10 @@ def _aggregate_matrix_summary(
 
 
 def aggregate_native_shard_reports(args: argparse.Namespace) -> dict[str, object]:
+    matrix_path = Path(
+        getattr(args, "qualification_matrix", QUALIFICATION_MATRIX_PATH)
+    )
+    matrix_binding = qualification_matrix_binding(matrix_path)
     candidate_root, previous_root, pairs = validate_inputs(
         args.packages_dir,
         args.previous_packages_dir,
@@ -11000,6 +11329,10 @@ def aggregate_native_shard_reports(args: argparse.Namespace) -> dict[str, object
             architecture=architecture,
             expected_binding=expected_binding,
         )
+        if report.get("qualification_matrix") != matrix_binding:
+            raise LifecycleLabError(
+                "native shard qualification matrix differs from aggregate inputs"
+            )
         shard_reports[architecture] = report
         shard_digests[architecture] = digest
 
@@ -11136,6 +11469,7 @@ def aggregate_native_shard_reports(args: argparse.Namespace) -> dict[str, object
         "release_ready": classification["release_ready"],
         "blocker_ids": classification["blocker_ids"],
         "unexpected_failed_checks": classification["unexpected_failed_checks"],
+        "qualification_matrix": matrix_binding,
         "package_version_contract": version_contract,
         "scope": scope,
         "engine": {
@@ -11212,6 +11546,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--podman", default="podman")
     parser.add_argument("--architecture-shard", choices=("amd64",))
     parser.add_argument("--aggregate-amd64-report", type=Path)
+    parser.add_argument(
+        "--qualification-matrix",
+        type=Path,
+        default=QUALIFICATION_MATRIX_PATH,
+    )
     parser.add_argument("--package-tmp-dir", type=Path)
     parser.add_argument("--qualification-repository")
     parser.add_argument("--qualification-release-sha")
@@ -11227,49 +11566,74 @@ def build_parser() -> argparse.ArgumentParser:
         "--pull-policy", choices=("never", "missing", "always"), default="missing"
     )
     parser.add_argument("--scenario-timeout", type=int, default=600)
-    defaults = {
-        platform_coordinate(spec): spec.image for spec in DEFAULT_PLATFORMS
-    }
+    defaults = {spec.cell_id: spec.image for spec in DEFAULT_PLATFORMS}
     parser.add_argument(
         "--debian-image",
         "--debian-amd64-image",
-        dest="debian_amd64_image",
-        default=defaults[("debian", "amd64")],
+        "--debian-13-image",
+        dest="deb_13_image",
+        default=defaults["DEB-13"],
     )
     parser.add_argument(
-        "--ubuntu-amd64-image", default=defaults[("ubuntu", "amd64")]
+        "--ubuntu-amd64-image",
+        "--ubuntu-2404-image",
+        dest="deb_u2404_image",
+        default=defaults["DEB-U2404"],
+    )
+    parser.add_argument(
+        "--ubuntu-2604-image",
+        dest="deb_u2604_image",
+        default=defaults["DEB-U2604"],
     )
     parser.add_argument(
         "--fedora-image",
         "--fedora-amd64-image",
-        dest="fedora_amd64_image",
-        default=defaults[("fedora", "amd64")],
+        "--fedora-44-image",
+        dest="rpm_f44_image",
+        default=defaults["RPM-F44"],
     )
     parser.add_argument(
-        "--almalinux-amd64-image", default=defaults[("almalinux", "amd64")]
+        "--almalinux-amd64-image",
+        "--almalinux-9-image",
+        dest="rpm_a9_image",
+        default=defaults["RPM-A9"],
+    )
+    parser.add_argument(
+        "--almalinux-10-image",
+        dest="rpm_a10_image",
+        default=defaults["RPM-A10"],
     )
     parser.add_argument(
         "--alpine-image",
         "--alpine-amd64-image",
-        dest="alpine_amd64_image",
-        default=defaults[("alpine", "amd64")],
+        "--alpine-322-image",
+        dest="apk_322_image",
+        default=defaults["APK-322"],
+    )
+    parser.add_argument(
+        "--alpine-324-image",
+        dest="apk_324_image",
+        default=defaults["APK-324"],
     )
     return parser
 
 
 def configured_platforms(args: argparse.Namespace) -> tuple[PlatformSpec, ...]:
     images = {
-        ("debian", "amd64"): args.debian_amd64_image,
-        ("ubuntu", "amd64"): args.ubuntu_amd64_image,
-        ("fedora", "amd64"): args.fedora_amd64_image,
-        ("almalinux", "amd64"): args.almalinux_amd64_image,
-        ("alpine", "amd64"): args.alpine_amd64_image,
+        "DEB-13": args.deb_13_image,
+        "DEB-U2404": args.deb_u2404_image,
+        "DEB-U2604": args.deb_u2604_image,
+        "RPM-F44": args.rpm_f44_image,
+        "RPM-A9": args.rpm_a9_image,
+        "RPM-A10": args.rpm_a10_image,
+        "APK-322": args.apk_322_image,
+        "APK-324": args.apk_324_image,
     }
     return tuple(
         PlatformSpec(
             **{
                 **asdict(spec),
-                "image": images[platform_coordinate(spec)],
+                "image": images[spec.cell_id],
             }
         )
         for spec in DEFAULT_PLATFORMS
@@ -11287,6 +11651,10 @@ def error_report(exc: Exception) -> dict[str, object]:
         "release_ready": False,
         "blocker_ids": [],
         "unexpected_failed_checks": [f"harness:{exc}"],
+        "qualification_matrix": {
+            "matrix_id": QUALIFICATION_MATRIX_ID,
+            "sha256": QUALIFICATION_MATRIX_SHA256,
+        },
         "error": str(exc),
     }
 

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -67,30 +67,28 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
 
     @staticmethod
     def write_inventory_evidence(
-        result_root: Path, family: str, scenario: str
+        result_root: Path,
+        family: str,
+        scenario: str,
+        previous_version: str,
+        candidate_version: str,
     ) -> None:
-        if family == "deb":
-            paths = sorted(package_lifecycle_lab.DEB_PACKAGE_PATHS)
-        elif family == "apk":
-            paths = sorted(package_lifecycle_lab.APK_PACKAGE_PATHS)
-        else:
-            paths = sorted(
-                set(package_lifecycle_lab.PACKAGE_PAYLOAD_PATHS)
-                | {
-                    "/usr/lib/.build-id",
-                    "/usr/lib/.build-id/11",
-                    "/usr/lib/.build-id/11/" + "1" * 38,
-                    "/usr/lib/.build-id/11/" + "2" * 38,
-                    "/usr/lib/.build-id/33",
-                    "/usr/lib/.build-id/33/" + "3" * 38,
-                }
-            )
         file_modes = {
             "/opt/syswarden/bin/syswarden-cli": "750",
             "/opt/syswarden/bin/syswarden-core": "750",
             "/opt/syswarden/bin/syswarden-tui": "750",
             "/opt/syswarden/signatures.json": "640",
             package_lifecycle_lab.BASH_COMPLETION_PATH: "644",
+            package_lifecycle_lab.GEOIP_DATA_LICENSE_PATH: "644",
+            package_lifecycle_lab.PROJECT_LICENSE_PATH: "644",
+        }
+        file_digests = {
+            package_lifecycle_lab.GEOIP_DATA_LICENSE_PATH: (
+                package_lifecycle_lab.GEOIP_DATA_LICENSE_SHA256
+            ),
+            package_lifecycle_lab.PROJECT_LICENSE_PATH: (
+                package_lifecycle_lab.PROJECT_LICENSE_SHA256
+            ),
         }
         link_targets = {
             "/usr/local/bin/syswarden": "/opt/syswarden/bin/syswarden-cli",
@@ -107,26 +105,76 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 "../../../../opt/syswarden/bin/syswarden-tui"
             ),
         }
-        filesystem = []
-        for path in paths:
-            if path in file_modes:
-                kind, mode, value = "file", file_modes[path], "a" * 64
-            elif path in link_targets:
-                kind, mode, value = "symlink", "777", link_targets[path]
-            elif path == "/usr/share/doc/syswarden/changelog.gz":
-                kind, mode, value = "file", "644", "b" * 64
-            elif path in build_targets:
-                kind, mode, value = "symlink", "777", build_targets[path]
-            else:
-                kind, mode, value = "directory", "755", "-"
-            filesystem.append(
-                f"{path}\t{kind}\t{mode}\t0\t0\t{value}\n"
+
+        def render(version: str) -> tuple[list[str], list[str]]:
+            licensed = (
+                package_lifecycle_lab.parse_syswarden_version(version)
+                >= package_lifecycle_lab.parse_syswarden_version("4.04.0")
             )
+            if family == "deb":
+                paths = sorted(
+                    package_lifecycle_lab.LICENSED_DEB_PACKAGE_PATHS
+                    if licensed
+                    else package_lifecycle_lab.DEB_PACKAGE_PATHS
+                )
+            elif family == "apk":
+                paths = sorted(
+                    package_lifecycle_lab.LICENSED_APK_PACKAGE_PATHS
+                    if licensed
+                    else package_lifecycle_lab.APK_PACKAGE_PATHS
+                )
+            else:
+                paths = sorted(
+                    set(
+                        package_lifecycle_lab.LICENSED_PACKAGE_PAYLOAD_PATHS
+                        if licensed
+                        else package_lifecycle_lab.PACKAGE_PAYLOAD_PATHS
+                    )
+                    | {
+                        "/usr/lib/.build-id",
+                        "/usr/lib/.build-id/11",
+                        "/usr/lib/.build-id/11/" + "1" * 38,
+                        "/usr/lib/.build-id/11/" + "2" * 38,
+                        "/usr/lib/.build-id/33",
+                        "/usr/lib/.build-id/33/" + "3" * 38,
+                    }
+                )
+            filesystem: list[str] = []
+            for path in paths:
+                if path in file_modes:
+                    kind, mode, value = (
+                        "file",
+                        file_modes[path],
+                        file_digests.get(path, "a" * 64),
+                    )
+                elif path in link_targets:
+                    kind, mode, value = "symlink", "777", link_targets[path]
+                elif path == "/usr/share/doc/syswarden/changelog.gz":
+                    kind, mode, value = "file", "644", "b" * 64
+                elif path in build_targets:
+                    kind, mode, value = "symlink", "777", build_targets[path]
+                else:
+                    kind, mode, value = "directory", "755", "-"
+                filesystem.append(
+                    f"{path}\t{kind}\t{mode}\t0\t0\t{value}\n"
+                )
+            return paths, filesystem
+
+        snapshots = {
+            "previous": render(previous_version),
+            "candidate": render(candidate_version),
+        }
         inventory_root = result_root / "inventories"
         inventory_root.mkdir()
         for label in package_lifecycle_lab.expected_inventory_phase_labels(
             scenario
         ):
+            role = (
+                "previous"
+                if label in {"previous", "rollback"}
+                else "candidate"
+            )
+            paths, filesystem = snapshots[role]
             inventory_root.joinpath(
                 f"{scenario}-{label}-manager.tsv"
             ).write_text("".join(f"{path}\n" for path in paths), encoding="utf-8")
@@ -221,9 +269,21 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 for value in environment
                 if value.startswith("SCENARIO=")
             )
+            candidate_version = next(
+                value.split("=", 1)[1]
+                for value in environment
+                if value.startswith("EXPECTED_CANDIDATE_VERSION=")
+            )
+            previous_version = next(
+                value.split("=", 1)[1]
+                for value in environment
+                if value.startswith("EXPECTED_PREVIOUS_VERSION=")
+            )
             self.containers[name] = {
                 "family": family,
                 "scenario": scenario,
+                "previous_version": previous_version,
+                "candidate_version": candidate_version,
                 "result_root": result_root,
                 "starts": 0,
             }
@@ -242,7 +302,9 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 family = str(container["family"])
                 scenario = str(container["scenario"])
                 checks = package_lifecycle_lab.expected_event_checks(
-                    family, scenario
+                    family,
+                    scenario,
+                    candidate_version=str(container["candidate_version"]),
                 )
                 result_root.joinpath("events.tsv").write_text(
                     "".join(
@@ -254,7 +316,13 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 result_root.joinpath("commands.log").write_text(
                     "fake lifecycle commands\n", encoding="utf-8"
                 )
-                self.write_inventory_evidence(result_root, family, scenario)
+                self.write_inventory_evidence(
+                    result_root,
+                    family,
+                    scenario,
+                    str(container["previous_version"]),
+                    str(container["candidate_version"]),
+                )
             if container["scenario"] == "upgrade-rollback":
                 result_root.joinpath("restart-state").write_text(
                     ("restart-one", "restart-two", "complete")[
@@ -279,13 +347,15 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
 
 
 class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
-    """Exact stateful Podman double for ACTIVE raw-v4 lifecycle evidence."""
+    """Exact stateful Podman double for ACTIVE raw-v5 lifecycle evidence."""
 
     def __init__(
         self,
         event_status: str = "pass",
         unavailable_architectures: set[str] | None = None,
         reported_architectures: dict[str, str] | None = None,
+        reported_distributions: dict[str, str] | None = None,
+        reported_distribution_versions: dict[str, str] | None = None,
         host_architecture: str = "amd64",
         namespace_failures: int = 0,
         namespace_failure_stderr: str = "runtime not ready\n",
@@ -300,6 +370,8 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
         self.event_status = event_status
         self.unavailable_architectures = unavailable_architectures or set()
         self.reported_architectures = reported_architectures or {}
+        self.reported_distributions = reported_distributions or {}
+        self.reported_distribution_versions = reported_distribution_versions or {}
         self.host_architecture = host_architecture
         self.namespace_failures = namespace_failures
         self.namespace_failure_stderr = namespace_failure_stderr
@@ -582,7 +654,11 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 else {"fresh"}
             )
             records: list[str] = []
-            for check in package_lifecycle_lab.expected_event_checks(family, scenario):
+            for check in package_lifecycle_lab.expected_event_checks(
+                family,
+                scenario,
+                candidate_version=str(container["candidate_version"]),
+            ):
                 detail = "fake verified evidence"
                 if self.event_status == "pass" and check.endswith(
                     ".postinstall_contract"
@@ -603,7 +679,13 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
             result_root.joinpath("commands.log").write_text(
                 "fake lifecycle commands\n", encoding="utf-8"
             )
-            self.write_inventory_evidence(result_root, family, scenario)
+            self.write_inventory_evidence(
+                result_root,
+                family,
+                scenario,
+                str(container["previous_version"]),
+                str(container["candidate_version"]),
+            )
         invocation_index = int(container["invocation_index"])
         if scenario == "upgrade-rollback":
             result_root.joinpath("restart-state").write_text(
@@ -665,14 +747,41 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
         elif command[1] == "run":
             platform_name = command[command.index("--platform") + 1]
             architecture = platform_name.split("/", 1)[1]
+            spec = self._spec_from_image(
+                next(
+                    value
+                    for value in command
+                    if value.startswith("docker.io/") and "@sha256:" in value
+                )
+            )
             if architecture in self.unavailable_architectures:
                 returncode = 126
                 stderr = "exec format error\n"
             else:
-                stdout = self.reported_architectures.get(
-                    architecture,
-                    "x86_64",
-                ) + "\n"
+                reported_version = self.reported_distribution_versions.get(
+                    spec.cell_id, spec.version
+                )
+                reported_distribution = self.reported_distributions.get(
+                    spec.cell_id, spec.distribution
+                )
+                stdout = (
+                    self.reported_architectures.get(architecture, "x86_64")
+                    + "\t"
+                    + reported_distribution
+                    + "\t"
+                    + reported_version
+                    + "\n"
+                )
+                if (
+                    reported_distribution != spec.distribution
+                    or not package_lifecycle_lab.distribution_version_matches(
+                        spec.distribution,
+                        spec.version,
+                        reported_version,
+                    )
+                ):
+                    returncode = 1
+                    stderr = "distribution os-release identity mismatch\n"
         elif command[1] == "create":
             volumes = self._volume_values(command)
             result_mount = next(
@@ -687,6 +796,12 @@ class FakePodmanRunner(package_lifecycle_lab.CommandRunner):
                 self.containers[name] = {
                     "family": environment["PACKAGE_FAMILY"],
                     "scenario": environment["SCENARIO"],
+                    "previous_version": environment[
+                        "EXPECTED_PREVIOUS_VERSION"
+                    ],
+                    "candidate_version": environment[
+                        "EXPECTED_CANDIDATE_VERSION"
+                    ],
                     "spec": self._spec_from_image(command[-1]),
                     "result_root": Path(result_mount.removesuffix(":/results:rw")),
                     "volumes": volumes,
@@ -1246,7 +1361,54 @@ class PackageLifecycleLabTests(unittest.TestCase):
 
     def test_default_matrix_is_official_digest_pinned_and_complete(self) -> None:
         platforms = package_lifecycle_lab.DEFAULT_PLATFORMS
-        self.assertEqual(len(platforms), 5)
+        self.assertEqual(len(platforms), 8)
+        self.assertEqual(
+            [spec.cell_id for spec in platforms],
+            [
+                "DEB-13",
+                "DEB-U2404",
+                "DEB-U2604",
+                "RPM-F44",
+                "RPM-A9",
+                "RPM-A10",
+                "APK-322",
+                "APK-324",
+            ],
+        )
+        self.assertEqual(
+            [(spec.distribution, spec.version) for spec in platforms],
+            [
+                ("debian", "13"),
+                ("ubuntu", "24.04"),
+                ("ubuntu", "26.04"),
+                ("fedora", "44"),
+                ("almalinux", "9"),
+                ("almalinux", "10"),
+                ("alpine", "3.22"),
+                ("alpine", "3.24"),
+            ],
+        )
+        self.assertEqual(
+            package_lifecycle_lab.QUALIFICATION_MATRIX_SHA256,
+            hashlib.sha256(
+                package_lifecycle_lab.QUALIFICATION_MATRIX_PATH.read_bytes()
+            ).hexdigest(),
+        )
+        for spec, cell in zip(
+            platforms,
+            package_lifecycle_lab.QUALIFICATION_MATRIX_DOCUMENT["cells"],
+            strict=True,
+        ):
+            with self.subTest(cell_id=spec.cell_id):
+                self.assertEqual(spec.cell_id, cell["id"])
+                self.assertEqual(spec.distribution, cell["distribution"])
+                self.assertEqual(spec.version, cell["version"])
+                self.assertEqual(spec.family, cell["family"])
+                self.assertEqual(spec.image, cell["image"])
+                self.assertEqual(
+                    spec.scenarios,
+                    tuple(cell["container_scenarios"]),
+                )
         self.assertEqual(
             {package_lifecycle_lab.platform_coordinate(spec) for spec in platforms},
             package_lifecycle_lab.REQUIRED_PLATFORM_COORDINATES,
@@ -1312,6 +1474,28 @@ class PackageLifecycleLabTests(unittest.TestCase):
             "lifecycle scenario contract mismatch",
         ):
             package_lifecycle_lab.validate_platforms((missing_scenario,))
+
+        altered_runtime = replace(
+            baseline,
+            bootstrap_command=baseline.bootstrap_command + " && true",
+        )
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "runtime contract differs from the frozen definition",
+        ):
+            package_lifecycle_lab.validate_platforms((altered_runtime,))
+
+    def test_matrix_binding_rejects_semantically_equal_but_different_bytes(self) -> None:
+        rewritten = self.root / "qualification-matrix.json"
+        rewritten.write_text(
+            json.dumps(package_lifecycle_lab.QUALIFICATION_MATRIX_DOCUMENT),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "matrix bytes differ",
+        ):
+            package_lifecycle_lab.qualification_matrix_binding(rewritten)
 
     def test_removed_arm64_architecture_is_rejected(self) -> None:
         removed = replace(
@@ -3453,6 +3637,15 @@ probe
         self.assertNotIn("--cap-add", probe)
         self.assertNotIn("--privileged", probe)
         self.assertNotIn("--volume", probe)
+        self.assertIn(
+            f"EXPECTED_DISTRIBUTION_VERSION={spec.version}", probe
+        )
+        self.assertIn(f"EXPECTED_DISTRIBUTION={spec.distribution}", probe)
+        self.assertEqual(probe[-3:-1], ("/bin/sh", "-ceu"))
+        self.assertIn("/etc/os-release", probe[-1])
+        self.assertIn("actual_distribution", probe[-1])
+        self.assertIn("almalinux)", probe[-1])
+        self.assertIn("alpine)", probe[-1])
 
         self.assertNotIn("--entrypoint", probe)
         pair = package_lifecycle_lab.PackagePair(
@@ -3485,6 +3678,9 @@ probe
         )
         self.assertIn("EXPECTED_PACKAGE_ARCHITECTURE=x86_64", lifecycle)
         self.assertIn("EXPECTED_UNAME_ARCHITECTURE=x86_64", lifecycle)
+        self.assertIn(
+            f"EXPECTED_DISTRIBUTION_VERSION={spec.version}", lifecycle
+        )
         self.assertIn("--cap-add=NET_ADMIN", lifecycle)
         self.assertIn("--cap-add=SYS_BOOT", lifecycle)
         self.assertNotIn("--cap-add=SYS_ADMIN", lifecycle)
@@ -3496,6 +3692,194 @@ probe
         )
 
         self.assertNotIn("--entrypoint", lifecycle)
+
+    def test_distribution_version_line_matching_is_closed(self) -> None:
+        accepted = (
+            ("debian", "13", "13"),
+            ("ubuntu", "24.04", "24.04"),
+            ("fedora", "44", "44"),
+            ("almalinux", "9", "9"),
+            ("almalinux", "9", "9.7"),
+            ("almalinux", "10", "10.1"),
+            ("alpine", "3.22", "3.22"),
+            ("alpine", "3.22", "3.22.5"),
+            ("alpine", "3.24", "3.24.1"),
+        )
+        rejected = (
+            ("debian", "13", "13.1"),
+            ("ubuntu", "24.04", "24.04.1"),
+            ("fedora", "44", "44.1"),
+            ("almalinux", "9", "10"),
+            ("almalinux", "9", "90.1"),
+            ("almalinux", "9.0", "9.0"),
+            ("alpine", "3.22", "3.23"),
+            ("alpine", "3.22", "3.220.1"),
+            ("alpine", "3.22", "3.22x"),
+            ("alpine", "3.22", "3.22."),
+            ("unknown", "1", "1"),
+        )
+        for distribution, expected, actual in accepted:
+            with self.subTest(
+                verdict="accepted",
+                distribution=distribution,
+                expected=expected,
+                actual=actual,
+            ):
+                self.assertTrue(
+                    package_lifecycle_lab.distribution_version_matches(
+                        distribution, expected, actual
+                    )
+                )
+        for distribution, expected, actual in rejected:
+            with self.subTest(
+                verdict="rejected",
+                distribution=distribution,
+                expected=expected,
+                actual=actual,
+            ):
+                self.assertFalse(
+                    package_lifecycle_lab.distribution_version_matches(
+                        distribution, expected, actual
+                    )
+                )
+
+    def test_runtime_distribution_line_patch_versions_are_accepted(self) -> None:
+        observed_versions = {
+            "RPM-A9": "9.7",
+            "RPM-A10": "10.1",
+            "APK-322": "3.22.5",
+            "APK-324": "3.24.1",
+        }
+        for spec in package_lifecycle_lab.DEFAULT_PLATFORMS:
+            if spec.cell_id not in observed_versions:
+                continue
+            observed = observed_versions[spec.cell_id]
+            with self.subTest(cell_id=spec.cell_id, observed=observed):
+                report = package_lifecycle_lab.run_lab(
+                    self.args(),
+                    runner=FakePodmanRunner(
+                        reported_distribution_versions={spec.cell_id: observed}
+                    ),
+                    platforms=(spec,),
+                    host_architecture="x86_64",
+                )
+                platform = report["platforms"][0]
+                self.assertEqual(platform["status"], "pass")
+                probe = platform["architecture_probe"]
+                self.assertEqual(probe["status"], "available")
+                self.assertEqual(probe["actual_distribution"], spec.distribution)
+                self.assertEqual(probe["actual_distribution_version"], observed)
+
+    def test_runtime_probe_shell_enforces_distribution_line_boundaries(self) -> None:
+        cases = (
+            ("RPM-A9", "almalinux", "9.8", 0),
+            ("RPM-A9", "almalinux", "10.0", 1),
+            ("RPM-A9", "alpine", "9.8", 1),
+            ("APK-322", "alpine", "3.22.5", 0),
+            ("APK-322", "alpine", "3.23.0", 1),
+            ("DEB-U2404", "ubuntu", "24.04", 0),
+            ("DEB-U2404", "ubuntu", "24.04.1", 1),
+        )
+        specs = {
+            spec.cell_id: spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+        }
+        for index, (cell_id, actual_id, actual_version, expected_rc) in enumerate(
+            cases
+        ):
+            with self.subTest(
+                cell_id=cell_id,
+                actual_id=actual_id,
+                actual_version=actual_version,
+            ):
+                spec = specs[cell_id]
+                os_release = self.root / f"probe-os-release-{index}"
+                os_release.write_text(
+                    f"ID={actual_id}\nVERSION_ID={actual_version}\n",
+                    encoding="ascii",
+                )
+                probe = package_lifecycle_lab.architecture_probe_arguments(
+                    "podman", spec
+                )[-1].replace('. /etc/os-release', '. "$1"', 1)
+                lifecycle_source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+                lifecycle_guard = lifecycle_source[
+                    lifecycle_source.index("[ -r /etc/os-release ]") :
+                    lifecycle_source.index('\nRESULT_FILE="/results/events.tsv"')
+                ]
+                lifecycle_guard = lifecycle_guard.replace(
+                    "[ -r /etc/os-release ]", '[ -r "$1" ]'
+                ).replace(". /etc/os-release", '. "$1"')
+                environment = {
+                    **os.environ,
+                    "EXPECTED_DISTRIBUTION": spec.distribution,
+                    "EXPECTED_DISTRIBUTION_VERSION": spec.version,
+                }
+                for script_kind, script in (
+                    ("architecture-probe", probe),
+                    ("lifecycle-guard", lifecycle_guard),
+                ):
+                    result = subprocess.run(
+                        (
+                            shutil.which("dash") or "/bin/sh",
+                            "-ceu",
+                            script,
+                            "distribution-probe",
+                            str(os_release),
+                        ),
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+                    self.assertEqual(
+                        result.returncode == 0,
+                        expected_rc == 0,
+                        f"{script_kind}: {result.stderr}",
+                    )
+
+    def test_runtime_distribution_version_mismatch_is_fail_closed(self) -> None:
+        for spec in package_lifecycle_lab.DEFAULT_PLATFORMS:
+            with self.subTest(cell_id=spec.cell_id):
+                report = package_lifecycle_lab.run_lab(
+                    self.args(),
+                    runner=FakePodmanRunner(
+                        reported_distribution_versions={spec.cell_id: "0"}
+                    ),
+                    platforms=(spec,),
+                    host_architecture="x86_64",
+                )
+                platform = report["platforms"][0]
+                self.assertEqual(platform["status"], "incomplete")
+                probe = platform["architecture_probe"]
+                self.assertEqual(probe["status"], "unavailable")
+                self.assertEqual(
+                    probe["expected_distribution_version"], spec.version
+                )
+                self.assertEqual(probe["actual_distribution_version"], "0")
+                self.assertIn("VERSION_ID", probe["reason"])
+
+    def test_runtime_distribution_id_mismatch_is_fail_closed(self) -> None:
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.cell_id == "RPM-A9"
+        )
+        report = package_lifecycle_lab.run_lab(
+            self.args(),
+            runner=FakePodmanRunner(
+                reported_distributions={spec.cell_id: "alpine"}
+            ),
+            platforms=(spec,),
+            host_architecture="x86_64",
+        )
+        platform = report["platforms"][0]
+        self.assertEqual(platform["status"], "incomplete")
+        probe = platform["architecture_probe"]
+        self.assertEqual(probe["status"], "unavailable")
+        self.assertEqual(probe["expected_distribution"], "almalinux")
+        self.assertEqual(probe["actual_distribution"], "alpine")
+        self.assertIn("ID", probe["reason"])
+
     def test_amd64_pull_is_explicitly_platform_selected_and_digest_checked(self) -> None:
         spec = next(
             item
@@ -3582,6 +3966,20 @@ probe
             [script.index(fragment) for fragment in lifecycle_order],
             sorted(script.index(fragment) for fragment in lifecycle_order),
         )
+
+    def test_lifecycle_shell_is_syntactically_valid(self) -> None:
+        script = self.root / "package-lifecycle-syntax.sh"
+        script.write_text(
+            package_lifecycle_lab.LIFECYCLE_SCRIPT,
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            (shutil.which("dash") or "/bin/sh", "-n", str(script)),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_candidate_native_license_metadata_is_versioned_and_exact(self) -> None:
         check = "upgrade-rollback.metadata.candidate.license"
@@ -5038,6 +5436,13 @@ probe
         self.assertEqual(
             report["schema_version"], package_lifecycle_lab.SCHEMA_VERSION
         )
+        self.assertEqual(
+            report["qualification_matrix"],
+            {
+                "matrix_id": package_lifecycle_lab.QUALIFICATION_MATRIX_ID,
+                "sha256": package_lifecycle_lab.QUALIFICATION_MATRIX_SHA256,
+            },
+        )
         version_contract = report["package_version_contract"]
         self.assertEqual(version_contract["previous_version"], "4.02.7")
         self.assertEqual(version_contract["candidate_version"], "4.02.8")
@@ -5062,7 +5467,25 @@ probe
             {item["distribution"] for item in report["platforms"]},
             {"debian", "ubuntu", "fedora", "almalinux", "alpine"},
         )
-        self.assertEqual(len(report["platforms"]), 5)
+        self.assertEqual(len(report["platforms"]), 8)
+        self.assertEqual(
+            [item["cell_id"] for item in report["platforms"]],
+            [spec.cell_id for spec in package_lifecycle_lab.DEFAULT_PLATFORMS],
+        )
+        self.assertTrue(
+            all(
+                item["version"]
+                == item["architecture_probe"]["actual_distribution_version"]
+                for item in report["platforms"]
+            )
+        )
+        self.assertTrue(
+            all(
+                item["distribution"]
+                == item["architecture_probe"]["actual_distribution"]
+                for item in report["platforms"]
+            )
+        )
         self.assertTrue(all(item["status"] == "pass" for item in report["platforms"]))
         deb_upgrade = next(
             scenario
@@ -5092,6 +5515,20 @@ probe
             ["amd64/x86_64"],
         )
         self.assertEqual(report["scope"]["missing_platform_coordinates"], [])
+        self.assertEqual(report["scope"]["evidence_kind"], "container-lifecycle")
+        self.assertEqual(
+            report["scope"]["coverage_kind"], "container_scenarios_only"
+        )
+        self.assertIs(report["scope"]["real_host_evidence_included"], False)
+        self.assertIs(report["scope"]["required_checks_complete"], False)
+        self.assertEqual(
+            report["scope"]["covered_scenarios"],
+            package_lifecycle_lab.qualification_matrix_container_scenarios(),
+        )
+        self.assertEqual(
+            report["scope"]["architecture_coverage"][0]["required_cells"],
+            [spec.cell_id for spec in package_lifecycle_lab.DEFAULT_PLATFORMS],
+        )
         family_coverage = {
             item["family"]: item["status"]
             for item in report["scope"]["family_architecture_coverage"]
@@ -5102,7 +5539,7 @@ probe
         )
         self.assertIn("not a SysWarden product rollback", report["scope"]["rollback_model"])
         run_calls = [call for call in runner.calls if call[1] == "run"]
-        self.assertEqual(len(run_calls), 5)
+        self.assertEqual(len(run_calls), 8)
         lifecycle_creates = [
             call
             for call in runner.calls
@@ -5110,7 +5547,7 @@ probe
                 value.endswith(":/results:rw") for value in call
             )
         ]
-        self.assertEqual(len(lifecycle_creates), 13)
+        self.assertEqual(len(lifecycle_creates), 21)
         self.assertTrue(all("--network=none" in call for call in lifecycle_creates))
         bootstrap_creates = [
             call
@@ -5126,16 +5563,51 @@ probe
             if call[1] == "exec"
             and "exec /bin/sh /lab/package-lifecycle.sh" in call[-1]
         ]
-        self.assertEqual(len(start_calls), 13)
-        self.assertEqual(len(restart_calls), 10)
-        self.assertEqual(len(lifecycle_execs), 23)
+        self.assertEqual(len(start_calls), 21)
+        self.assertEqual(len(restart_calls), 16)
+        self.assertEqual(len(lifecycle_execs), 37)
         self.assertEqual(
             len([call for call in runner.calls if call[1] == "commit"]), 0
         )
         build_calls = [call for call in runner.calls if call[1] == "build"]
-        self.assertEqual(len(build_calls), 5)
+        self.assertEqual(len(build_calls), 8)
         self.assertTrue(all("--platform" in call for call in build_calls))
         self.assertTrue(all("--network=host" not in call for call in build_calls))
+
+    def test_v4040_fake_matrix_distinguishes_previous_and_licensed_candidate(self) -> None:
+        candidate = self.root / "candidate-v4040"
+        previous = self.root / "previous-v4033"
+        candidate.mkdir()
+        previous.mkdir()
+        self.create_package_set(candidate, b"candidate-v4040", "4.04.0")
+        self.create_package_set(previous, b"previous-v4033", "4.03.3")
+        report = package_lifecycle_lab.run_lab(
+            self.args(
+                packages_dir=candidate,
+                previous_packages_dir=previous,
+            ),
+            runner=FakePodmanRunner(),
+        )
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(len(report["platforms"]), 8)
+        for platform in report["platforms"]:
+            upgrade = next(
+                item
+                for item in platform["scenarios"]
+                if item["name"] == "upgrade-rollback"
+            )
+            previous_paths = upgrade["inventory_evidence"]["previous"][
+                "manager_paths"
+            ]
+            candidate_paths = upgrade["inventory_evidence"]["candidate"][
+                "manager_paths"
+            ]
+            self.assertNotIn(
+                package_lifecycle_lab.PROJECT_LICENSE_PATH, previous_paths
+            )
+            self.assertIn(
+                package_lifecycle_lab.PROJECT_LICENSE_PATH, candidate_paths
+            )
 
     def test_native_shard_covers_exact_amd64_architecture(self) -> None:
         report = self.native_shard_report()
@@ -5148,13 +5620,33 @@ probe
             {item["architecture_id"] for item in report["platforms"]},
             {"amd64"},
         )
-        self.assertEqual(len(report["platforms"]), 5)
+        self.assertEqual(len(report["platforms"]), 8)
         self.assertTrue(
             all(
                 item["architecture_probe"]["execution_mode"] == "native"
                 for item in report["platforms"]
             )
         )
+
+    def test_native_shard_rejects_missing_duplicate_or_reordered_cells(self) -> None:
+        platforms = package_lifecycle_lab.DEFAULT_PLATFORMS
+        invalid_matrices = {
+            "missing": platforms[:-1],
+            "duplicate": platforms[:-1] + (platforms[0],),
+            "reordered": tuple(reversed(platforms)),
+        }
+        for name, matrix in invalid_matrices.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    package_lifecycle_lab.LifecycleLabError,
+                    "exact eight matrix cells in canonical order",
+                ):
+                    package_lifecycle_lab.run_lab(
+                        self.qualification_args("amd64"),
+                        runner=FakePodmanRunner(),
+                        platforms=matrix,
+                        host_architecture="x86_64",
+                    )
 
     def test_native_shard_rejects_non_amd64_host(self) -> None:
         amd64_platforms = tuple(
@@ -5190,7 +5682,7 @@ probe
             aggregate["scope"]["host_architecture"],
             package_lifecycle_lab.NATIVE_AGGREGATE_HOST,
         )
-        self.assertEqual(len(aggregate["platforms"]), 5)
+        self.assertEqual(len(aggregate["platforms"]), 8)
         self.assertEqual(
             [item["architecture"] for item in aggregate["native_shards"]["reports"]],
             ["amd64"],
@@ -5250,6 +5742,15 @@ probe
             "wrong native uname": lambda report: report["platforms"][0][
                 "architecture_probe"
             ].__setitem__("actual_uname", "unsupported"),
+            "wrong distribution version": lambda report: report["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("actual_distribution_version", "12"),
+            "wrong distribution id": lambda report: report["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("actual_distribution", "alpine"),
+            "matrix digest mismatch": lambda report: report[
+                "qualification_matrix"
+            ].__setitem__("sha256", "0" * 64),
             "missing coordinate": lambda report: report["platforms"].pop(),
             "duplicate coordinate": lambda report: report["platforms"].__setitem__(
                 -1, dict(report["platforms"][0])
@@ -5326,7 +5827,7 @@ probe
             self.assertEqual(package_lifecycle_lab.main(arguments), 0)
         written = json.loads(output.read_text(encoding="utf-8"))
         self.assertEqual(written["status"], "pass")
-        self.assertEqual(len(written["platforms"]), 5)
+        self.assertEqual(len(written["platforms"]), 8)
         stdout.write.assert_called_once()
 
     def test_report_version_contract_rejects_schema_order_and_platform_tampering(
@@ -5337,12 +5838,45 @@ probe
         )
         mutations = {
             "schema": lambda item: item.update(schema_version=2),
+            "matrix_id": lambda item: item["qualification_matrix"].update(
+                matrix_id="syswarden-package-qualification/v2"
+            ),
+            "matrix_sha256": lambda item: item["qualification_matrix"].update(
+                sha256="0" * 64
+            ),
+            "coverage_kind": lambda item: item["scope"].update(
+                coverage_kind="full-qualification"
+            ),
+            "real_host_scope": lambda item: item["scope"].update(
+                real_host_evidence_included=True
+            ),
+            "required_checks_scope": lambda item: item["scope"].update(
+                required_checks_complete=True
+            ),
+            "scope_extra_key": lambda item: item["scope"].update(
+                global_qualification_complete=True
+            ),
+            "covered_scenarios": lambda item: item["scope"][
+                "covered_scenarios"
+            ].reverse(),
             "order": lambda item: item["package_version_contract"].update(
                 candidate_version="4.02.7", candidate_numeric=[4, 2, 7]
             ),
             "platform": lambda item: item["platforms"][0].update(
                 candidate_version="4.02.9"
             ),
+            "cell_id": lambda item: item["platforms"][0].update(
+                cell_id="DEB-U2404"
+            ),
+            "distribution_version": lambda item: item["platforms"][0].update(
+                version="12"
+            ),
+            "runtime_distribution_version": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].update(actual_distribution_version="12"),
+            "runtime_distribution_id": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].update(actual_distribution="alpine"),
             "coordinate": lambda item: item["package_version_contract"][
                 "coordinates"
             ][0].update(candidate_numeric=[4, 2, 9]),
@@ -5825,7 +6359,7 @@ probe
         alpine_coordinates = [
             item
             for item in classification["coordinate_classification"]
-            if item["distribution"] == "alpine"
+            if item["cell_id"] in {"APK-322", "APK-324"}
         ]
         self.assertTrue(
             all(item["status"] == "incomplete" for item in alpine_coordinates)
@@ -6195,7 +6729,7 @@ probe
         self.assertFalse(rejected["harness_complete"])
         self.assertEqual(rejected["blocker_ids"], [])
         self.assertIn(
-            f"ubuntu/amd64:{drifted['check']}",
+            f"DEB-U2404/amd64:{drifted['check']}",
             rejected["unexpected_failed_checks"],
         )
 
@@ -9765,7 +10299,7 @@ seed_live_legacy_webtui_process
         )
         self.assertEqual(report["status"], "incomplete")
         self.assertFalse(report["scope"]["container_lab_complete"])
-        self.assertEqual(len(report["scope"]["missing_platform_coordinates"]), 3)
+        self.assertEqual(len(report["scope"]["missing_platform_coordinates"]), 6)
         self.assertEqual(report["scope"]["architectures_completed"], [])
 
     def test_image_inspection_architecture_mismatch_is_rejected(self) -> None:
@@ -9891,7 +10425,11 @@ seed_live_legacy_webtui_process
             )
         )
         configured = package_lifecycle_lab.configured_platforms(args)
-        self.assertEqual(len(configured), 5)
+        self.assertEqual(
+            args.qualification_matrix,
+            package_lifecycle_lab.QUALIFICATION_MATRIX_PATH,
+        )
+        self.assertEqual(len(configured), 8)
         self.assertEqual(
             {package_lifecycle_lab.platform_coordinate(spec) for spec in configured},
             package_lifecycle_lab.REQUIRED_PLATFORM_COORDINATES,
@@ -9909,7 +10447,7 @@ seed_live_legacy_webtui_process
             )
         )
         shard_configured = package_lifecycle_lab.configured_platforms(amd64_shard)
-        self.assertEqual(len(shard_configured), 5)
+        self.assertEqual(len(shard_configured), 8)
         self.assertEqual(
             {spec.architecture for spec in shard_configured},
             {"amd64"},
@@ -9932,9 +10470,16 @@ seed_live_legacy_webtui_process
             spec
             for spec in package_lifecycle_lab.configured_platforms(overridden)
             if package_lifecycle_lab.platform_coordinate(spec)
-            == ("ubuntu", "amd64")
+            == ("DEB-U2404", "amd64")
         )
         self.assertEqual(ubuntu_amd64.image, replacement_image)
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "frozen image identity mismatch",
+        ):
+            package_lifecycle_lab.validate_platforms(
+                package_lifecycle_lab.configured_platforms(overridden)
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/release_qualification_adapter.py
+++ b/scripts/ci/release_qualification_adapter.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 import package_lifecycle_lab as package_lab
+import package_qualification_matrix as qualification_matrix
 import release_qualification_gate as gate
 
 
@@ -73,6 +74,7 @@ RAW_TOP_KEYS = {
             "package_roots",
             "platforms",
             "qualification_binding",
+            "qualification_matrix",
             "native_shards",
         }
     ),
@@ -123,12 +125,21 @@ class RawReport:
 
 
 @dataclass(frozen=True)
+class QualificationMatrix:
+    snapshot: gate.FileSnapshot
+    document: dict[str, Any]
+    matrix_id: str
+    sha256: str
+
+
+@dataclass(frozen=True)
 class ValidatedInputs:
     binding: gate.RepositoryBinding
     candidate: gate.PackageManifest
     previous: gate.PackageManifest
     raws: dict[str, RawReport]
     package_shards: dict[str, RawReport]
+    qualification_matrix: QualificationMatrix
     envelopes: dict[str, dict[str, Any]]
 
 
@@ -601,6 +612,11 @@ PACKAGE_CONTRACT_COORDINATE_KEYS = frozenset(
 )
 PACKAGE_SCOPE_KEYS = frozenset(
     {
+        "evidence_kind",
+        "coverage_kind",
+        "real_host_evidence_included",
+        "required_checks_complete",
+        "covered_scenarios",
         "container_lab_complete",
         "coordinate_classification",
         "host_architecture",
@@ -634,6 +650,8 @@ PACKAGE_QUALIFICATION_BINDING_KEYS = frozenset(
         "previous_manifest_sha256",
     }
 )
+PACKAGE_QUALIFICATION_MATRIX_KEYS = frozenset({"matrix_id", "sha256"})
+PACKAGE_QUALIFICATION_MATRIX_PATH = "scripts/ci/package_qualification_matrix.json"
 PACKAGE_NATIVE_SHARDS_KEYS = frozenset({"schema_version", "mode", "reports"})
 PACKAGE_NATIVE_SHARD_RECORD_KEYS = frozenset(
     {
@@ -694,8 +712,10 @@ PACKAGE_NATIVE_SHARD_NAMES = {
 PACKAGE_NATIVE_AGGREGATE_HOST = "native-shards:amd64"
 PACKAGE_PLATFORM_KEYS = frozenset(
     {
+        "cell_id",
         "name",
         "distribution",
+        "version",
         "family",
         "architecture",
         "architecture_id",
@@ -883,8 +903,8 @@ LIFECYCLE_CLAIM_KEYS = (
 
 def _package_versions(document: dict[str, Any], expected_version: str) -> tuple[str, str]:
     _exact_keys(document, RAW_TOP_KEYS["package"], "package raw report")
-    if _integer(document["schema_version"], "package.schema_version") != 4:
-        _fail("package raw report schema version must be 4")
+    if _integer(document["schema_version"], "package.schema_version") != 5:
+        _fail("package raw report schema version must be 5")
     contract = _exact_keys(
         document["package_version_contract"], PACKAGE_CONTRACT_KEYS, "package.version_contract"
     )
@@ -939,6 +959,58 @@ def _validate_package_qualification_binding(
     for key in ("candidate_manifest_sha256", "previous_manifest_sha256"):
         _sha256(binding[key], f"package.qualification_binding.{key}")
     return binding
+
+
+def _load_qualification_matrix(
+    path: Path,
+    binding: gate.RepositoryBinding,
+) -> QualificationMatrix:
+    expected_path = gate._absolute_without_symlinks(
+        binding.root / PACKAGE_QUALIFICATION_MATRIX_PATH,
+        "repository package qualification matrix",
+    )
+    supplied_path = gate._absolute_without_symlinks(
+        path,
+        "package qualification matrix",
+    )
+    if supplied_path != expected_path:
+        _fail(
+            "package qualification matrix must be the exact repository contract "
+            f"at {PACKAGE_QUALIFICATION_MATRIX_PATH}"
+        )
+    snapshot = gate.read_snapshot(supplied_path, "package qualification matrix")
+    committed_payload = _git_blob_bytes(binding, PACKAGE_QUALIFICATION_MATRIX_PATH)
+    if snapshot.payload != committed_payload:
+        _fail("package qualification matrix bytes differ from the exact Git commit")
+    try:
+        document = qualification_matrix.validate_document(
+            gate.strict_json(snapshot.payload, "package qualification matrix")
+        )
+    except (qualification_matrix.QualificationMatrixError, gate.EvidenceError) as exc:
+        raise AdapterError(f"invalid package qualification matrix: {exc}") from exc
+    digest = hashlib.sha256(snapshot.payload).hexdigest()
+    matrix_id = _string(document["matrix_id"], "package qualification matrix id")
+    if document["target_release"] != binding.version:
+        _fail("package qualification matrix target differs from the exact release")
+    return QualificationMatrix(snapshot, document, matrix_id, digest)
+
+
+def _validate_package_qualification_matrix_binding(
+    value: Any,
+    expected: QualificationMatrix,
+    *,
+    label: str = "package.qualification_matrix",
+) -> dict[str, Any]:
+    matrix_binding = _exact_keys(
+        value,
+        PACKAGE_QUALIFICATION_MATRIX_KEYS,
+        label,
+    )
+    matrix_id = _string(matrix_binding["matrix_id"], f"{label}.matrix_id")
+    digest = _sha256(matrix_binding["sha256"], f"{label}.sha256")
+    if matrix_id != expected.matrix_id or digest != expected.sha256:
+        _fail(f"{label} differs from the exact Git-bound qualification matrix")
+    return matrix_binding
 
 
 def _validate_lifecycle_helper(
@@ -1144,18 +1216,28 @@ def _validate_package_shard_binding(
     document: dict[str, Any],
     package_shards: dict[str, RawReport],
     expected_binding: dict[str, Any],
+    expected_matrix: QualificationMatrix,
 ) -> None:
     binding = _validate_package_qualification_binding(
         document["qualification_binding"]
     )
     if binding != expected_binding:
         _fail("package qualification binding differs from the exact workflow inputs")
+    _validate_package_qualification_matrix_binding(
+        document["qualification_matrix"],
+        expected_matrix,
+    )
     records = _validate_package_native_shards(document["native_shards"])
     if set(package_shards) != {"amd64"}:
         _fail("package native shard file inventory is incomplete")
     for architecture in ("amd64",):
         raw = package_shards[architecture]
         record = records[architecture]
+        _validate_package_qualification_matrix_binding(
+            raw.document["qualification_matrix"],
+            expected_matrix,
+            label=f"package.{architecture}.qualification_matrix",
+        )
         if raw.snapshot.path.name != PACKAGE_NATIVE_SHARD_NAMES[architecture]:
             _fail(f"package {architecture} shard basename is invalid")
         if raw.snapshot.sha256 != record["report_sha256"]:
@@ -1903,9 +1985,11 @@ def _validate_runtime_scenario(
     scenario: str,
     label: str,
     *,
+    candidate_version: str,
     expected_uid_map: list[dict[str, Any]] | None = None,
     expected_gid_map: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    candidate_version = _string(candidate_version, f"{label}.candidate_version")
     result = _exact_keys(value, PACKAGE_SCENARIO_KEYS, label)
     required_boots = 3 if scenario == "upgrade-rollback" else 1
     exec_exit_codes = _list(
@@ -1954,7 +2038,12 @@ def _validate_runtime_scenario(
             event["detail"], f"{label}.events[{event_index}].detail", empty=True
         )
     try:
-        package_lab.validate_event_contract(events, spec.family, scenario)
+        package_lab.validate_event_contract(
+            events,
+            spec.family,
+            scenario,
+            candidate_version=candidate_version,
+        )
     except package_lab.LifecycleLabError as exc:
         raise AdapterError(f"{label} event contract is invalid: {exc}") from exc
     _string(result["log_tail"], f"{label}.log_tail", empty=True)
@@ -2186,8 +2275,15 @@ def _derive_platform_lifecycle_claims(
     }
 
 
-def _validate_package_schema(document: dict[str, Any]) -> None:
+def _validate_package_schema(
+    document: dict[str, Any],
+    expected_matrix: QualificationMatrix,
+) -> None:
     _validate_package_qualification_binding(document["qualification_binding"])
+    _validate_package_qualification_matrix_binding(
+        document["qualification_matrix"],
+        expected_matrix,
+    )
     native_records = _validate_package_native_shards(document["native_shards"])
     contract = _exact_keys(
         document["package_version_contract"], PACKAGE_CONTRACT_KEYS, "package.version_contract"
@@ -2213,7 +2309,54 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
                 _fail("package coordinate numeric version is invalid")
 
     scope = _exact_keys(document["scope"], PACKAGE_SCOPE_KEYS, "package.scope")
-    _boolean(scope["container_lab_complete"], "package.scope.container_lab_complete")
+    if (
+        _boolean(
+            scope["container_lab_complete"],
+            "package.scope.container_lab_complete",
+        )
+        is not True
+    ):
+        _fail("package container lifecycle scope is not complete")
+    if scope["evidence_kind"] != "container-lifecycle":
+        _fail("package scope must be limited to container-lifecycle evidence")
+    if scope["coverage_kind"] != "container_scenarios_only":
+        _fail("package scope must cover container scenarios only")
+    if (
+        _boolean(
+            scope["real_host_evidence_included"],
+            "package.scope.real_host_evidence_included",
+        )
+        is not False
+        or _boolean(
+            scope["required_checks_complete"],
+            "package.scope.required_checks_complete",
+        )
+        is not False
+    ):
+        _fail("package scope may not claim real-host or complete required-check evidence")
+    covered_scenarios = _list(
+        scope["covered_scenarios"], "package.scope.covered_scenarios"
+    )
+    expected_covered_scenarios = [
+        {
+            "cell_id": cell["id"],
+            "scenarios": list(cell["container_scenarios"]),
+        }
+        for cell in expected_matrix.document["cells"]
+    ]
+    for index, value in enumerate(covered_scenarios):
+        entry = _exact_keys(
+            value,
+            {"cell_id", "scenarios"},
+            f"package.scope.covered_scenarios[{index}]",
+        )
+        _string(entry["cell_id"], f"package.scope.covered_scenarios[{index}].cell_id")
+        _string_list(
+            entry["scenarios"],
+            f"package.scope.covered_scenarios[{index}].scenarios",
+        )
+    if covered_scenarios != expected_covered_scenarios:
+        _fail("package covered scenarios differ from the exact ordered matrix contract")
     for key in (
         "host_architecture",
         "network_during_image_bootstrap",
@@ -2231,18 +2374,37 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
         _fail("package report must identify the exact AMD64 native shard model")
     if scope["network_during_package_operations"] != "disabled":
         _fail("package operations were not network-isolated")
+    if scope["architecture_coverage_policy"] != (
+        "container lifecycle qualification requires every declared "
+        "container_scenario in the exact eight-cell AMD64 matrix on the native "
+        "AMD64 shard; it does not close real-host, updater, or reboot obligations"
+    ):
+        _fail("package architecture coverage policy is not the exact scoped contract")
     classification = _list(scope["coordinate_classification"], "package.scope.coordinate_classification")
-    if len(classification) != 5:
-        _fail("package coordinate classification must contain exactly five coordinates")
+    expected_cell_ids = [cell["id"] for cell in expected_matrix.document["cells"]]
+    if len(classification) != len(expected_cell_ids):
+        _fail("package coordinate classification must contain exactly eight cells")
     for index, item in enumerate(classification):
         entry = _exact_keys(
             item,
-            {"distribution", "architecture_id", "family", "status", "blocker_ids"},
+            {"cell_id", "architecture_id", "family", "status", "blocker_ids"},
             f"package.scope.coordinate_classification[{index}]",
         )
-        for key in ("distribution", "architecture_id", "family", "status"):
+        for key in ("cell_id", "architecture_id", "family", "status"):
             _string(entry[key], f"package.scope.coordinate_classification[{index}].{key}")
         _string_list(entry["blocker_ids"], f"package.scope.coordinate_classification[{index}].blocker_ids", sorted_unique=True)
+        expected_cell = expected_matrix.document["cells"][index]
+        if (
+            entry["cell_id"] != expected_cell_ids[index]
+            or entry["architecture_id"] != "amd64"
+            or entry["family"] != expected_cell["family"]
+            or entry["status"] != "pass"
+            or entry["blocker_ids"] != []
+        ):
+            _fail(
+                "package coordinate classification differs from the frozen "
+                f"cell at index {index}"
+            )
     for key in ("architectures_completed",):
         _string_list(scope[key], f"package.scope.{key}")
     incomplete = _list(scope["architectures_incomplete_or_failed"], "package.scope.architectures_incomplete_or_failed")
@@ -2250,30 +2412,63 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
         entry = _exact_keys(item, {"architecture", "status", "reason"}, f"package.scope.architectures_incomplete_or_failed[{index}]")
         for key in entry:
             _string(entry[key], f"package.scope.architectures_incomplete_or_failed[{index}].{key}")
+    if scope["architectures_completed"] != [
+        package_lab.ARCHITECTURE_LABELS["amd64"]
+    ] or incomplete != []:
+        _fail("package completed architecture scope is not exact")
     architecture_coverage = _list(scope["architecture_coverage"], "package.scope.architecture_coverage")
     if len(architecture_coverage) != 1:
         _fail("package architecture coverage must contain AMD64 only")
     for index, item in enumerate(architecture_coverage):
-        entry = _exact_keys(item, {"architecture", "architecture_id", "status", "required_distributions", "completed_distributions", "incomplete_or_failed_distributions"}, f"package.scope.architecture_coverage[{index}]")
+        entry = _exact_keys(item, {"architecture", "architecture_id", "status", "required_cells", "completed_cells", "incomplete_or_failed_cells"}, f"package.scope.architecture_coverage[{index}]")
         for key in ("architecture", "architecture_id", "status"):
             _string(entry[key], f"package.scope.architecture_coverage[{index}].{key}")
-        for key in ("required_distributions", "completed_distributions", "incomplete_or_failed_distributions"):
+        for key in ("required_cells", "completed_cells", "incomplete_or_failed_cells"):
             _string_list(entry[key], f"package.scope.architecture_coverage[{index}].{key}")
+        if (
+            entry["architecture"] != package_lab.ARCHITECTURE_LABELS["amd64"]
+            or entry["architecture_id"] != "amd64"
+            or entry["status"] != "pass"
+            or entry["required_cells"] != expected_cell_ids
+            or entry["completed_cells"] != expected_cell_ids
+            or entry["incomplete_or_failed_cells"] != []
+        ):
+            _fail("package AMD64 coverage is not the exact eight-cell matrix")
     family_coverage = _list(scope["family_architecture_coverage"], "package.scope.family_architecture_coverage")
     if len(family_coverage) != 3:
         _fail("package family/architecture coverage must contain three coordinates")
     for index, item in enumerate(family_coverage):
-        entry = _exact_keys(item, {"family", "architecture", "architecture_id", "status", "required_distributions", "completed_distributions"}, f"package.scope.family_architecture_coverage[{index}]")
+        entry = _exact_keys(item, {"family", "architecture", "architecture_id", "status", "required_cells", "completed_cells"}, f"package.scope.family_architecture_coverage[{index}]")
         for key in ("family", "architecture", "architecture_id", "status"):
             _string(entry[key], f"package.scope.family_architecture_coverage[{index}].{key}")
-        for key in ("required_distributions", "completed_distributions"):
+        for key in ("required_cells", "completed_cells"):
             _string_list(entry[key], f"package.scope.family_architecture_coverage[{index}].{key}")
+        expected_family = package_lab.REQUIRED_FAMILIES[index]
+        expected_family_cells = [
+            cell["id"]
+            for cell in expected_matrix.document["cells"]
+            if cell["family"] == expected_family
+        ]
+        if (
+            entry["family"] != expected_family
+            or entry["architecture"] != package_lab.ARCHITECTURE_LABELS["amd64"]
+            or entry["architecture_id"] != "amd64"
+            or entry["status"] != "pass"
+            or entry["required_cells"] != expected_family_cells
+            or entry["completed_cells"] != expected_family_cells
+        ):
+            _fail(f"package {expected_family} coverage is not matrix-exact")
     for key in ("required_platform_coordinates", "missing_platform_coordinates"):
         entries = _list(scope[key], f"package.scope.{key}")
         for index, item in enumerate(entries):
-            entry = _exact_keys(item, {"distribution", "architecture"}, f"package.scope.{key}[{index}]")
-            _string(entry["distribution"], f"package.scope.{key}[{index}].distribution")
+            entry = _exact_keys(item, {"cell_id", "architecture"}, f"package.scope.{key}[{index}]")
+            _string(entry["cell_id"], f"package.scope.{key}[{index}].cell_id")
             _string(entry["architecture"], f"package.scope.{key}[{index}].architecture")
+    if scope["required_platform_coordinates"] != [
+        {"cell_id": cell_id, "architecture": "amd64"}
+        for cell_id in expected_cell_ids
+    ] or scope["missing_platform_coordinates"] != []:
+        _fail("package scope does not prove the exact complete eight-cell inventory")
 
     engine = _validate_package_engine(
         document["engine"], "package.engine", architecture="native-shards"
@@ -2307,30 +2502,51 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
         _fail("package roots were not mounted read-only")
 
     platforms = _list(document["platforms"], "package.platforms")
-    if len(platforms) != 5:
-        _fail("package report must contain exactly five platform results")
-    seen: set[tuple[str, str]] = set()
-    specs = {(item.distribution, item.architecture): item for item in package_lab.DEFAULT_PLATFORMS}
+    matrix_cells = expected_matrix.document["cells"]
+    expected_cell_ids = [cell["id"] for cell in matrix_cells]
+    if len(platforms) != len(expected_cell_ids):
+        _fail(
+            "package report must contain exactly one result for each of the "
+            f"{len(expected_cell_ids)} qualification cells"
+        )
+    seen_cell_ids: set[str] = set()
+    specs = {item.cell_id: item for item in package_lab.DEFAULT_PLATFORMS}
+    if list(specs) != expected_cell_ids:
+        _fail("package laboratory platform order differs from the frozen matrix")
     for index, item in enumerate(platforms):
         platform = _exact_keys(item, PACKAGE_PLATFORM_KEYS, f"package.platforms[{index}]")
-        for key in ("name", "distribution", "family", "architecture", "architecture_id", "package_architecture", "podman_platform", "image", "purge_semantics", "candidate_version", "previous_version", "bootstrap_execution", "lifecycle_network", "runtime_mode", "restart_contract", "status"):
+        for key in ("cell_id", "name", "distribution", "version", "family", "architecture", "architecture_id", "package_architecture", "podman_platform", "image", "purge_semantics", "candidate_version", "previous_version", "bootstrap_execution", "lifecycle_network", "runtime_mode", "restart_contract", "status"):
             _string(platform[key], f"package.platforms[{index}].{key}")
-        coordinate = (platform["distribution"], platform["architecture_id"])
-        if coordinate in seen or coordinate not in specs:
-            _fail(f"package platform coordinate is duplicate or unsupported: {coordinate}")
-        seen.add(coordinate)
-        spec = specs[coordinate]
+        cell_id = platform["cell_id"]
+        if cell_id in seen_cell_ids or cell_id != expected_cell_ids[index]:
+            _fail(
+                "package platform cell identity is duplicate, missing, or out of "
+                f"frozen order at index {index}: {cell_id!r}"
+            )
+        seen_cell_ids.add(cell_id)
+        spec = specs[cell_id]
+        cell = matrix_cells[index]
+        coordinate = (cell_id, platform["architecture_id"])
         expected = {
             "name": spec.name,
+            "distribution": cell["distribution"],
+            "version": cell["version"],
             "family": spec.family,
             "architecture": package_lab.ARCHITECTURE_LABELS[spec.architecture],
+            "architecture_id": spec.architecture,
             "package_architecture": spec.package_architecture,
             "podman_platform": spec.podman_platform,
-            "image": spec.image,
+            "image": cell["image"],
             "purge_semantics": spec.purge_semantics,
         }
         if any(platform[key] != value for key, value in expected.items()):
             _fail(f"package platform metadata differs from the pinned matrix at {coordinate}")
+        if (
+            tuple(spec.scenarios) != tuple(cell["container_scenarios"])
+            or tuple(package_lab.EXPECTED_SCENARIOS[spec.family])
+            != tuple(cell["container_scenarios"])
+        ):
+            _fail(f"package platform scenario contract differs from the matrix at {coordinate}")
         if (
             platform["lifecycle_network"] != "disabled"
             or platform["runtime_mode"] != "active-real-init"
@@ -2351,9 +2567,15 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
             _string(artifact["filename"], f"package.platforms[{index}].{artifact_key}.filename")
             _string(artifact["version"], f"package.platforms[{index}].{artifact_key}.version")
             _sha256(artifact["sha256"], f"package.platforms[{index}].{artifact_key}.sha256")
-        probe = _exact_keys(platform["architecture_probe"], {"status", "execution_mode", "podman_platform", "expected_uname", "actual_uname", "container_exit_code", "network", "filesystem"}, f"package.platforms[{index}].architecture_probe")
-        for key in ("status", "execution_mode", "podman_platform", "expected_uname", "actual_uname", "network", "filesystem"):
+        probe = _exact_keys(platform["architecture_probe"], {"status", "execution_mode", "podman_platform", "expected_uname", "actual_uname", "expected_distribution", "actual_distribution", "expected_distribution_version", "actual_distribution_version", "container_exit_code", "network", "filesystem"}, f"package.platforms[{index}].architecture_probe")
+        for key in ("status", "execution_mode", "podman_platform", "expected_uname", "actual_uname", "expected_distribution", "actual_distribution", "expected_distribution_version", "actual_distribution_version", "network", "filesystem"):
             _string(probe[key], f"package.platforms[{index}].architecture_probe.{key}")
+        try:
+            package_lab.validate_available_architecture_probe(probe, spec)
+        except package_lab.LifecycleLabError as exc:
+            raise AdapterError(
+                f"package architecture execution probe is invalid at {coordinate}: {exc}"
+            ) from exc
         if (
             probe["status"] != "available"
             or probe["network"] != "disabled"
@@ -2365,6 +2587,9 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
             or probe["podman_platform"] != spec.podman_platform
             or probe["expected_uname"] != spec.uname_architecture
             or probe["actual_uname"] != spec.uname_architecture
+            or probe["expected_distribution"] != cell["distribution"]
+            or probe["actual_distribution"] != cell["distribution"]
+            or probe["expected_distribution_version"] != cell["version"]
             or probe["execution_mode"] != "native"
             or platform["bootstrap_execution"] != "native_container_build"
         ):
@@ -2385,6 +2610,7 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
                 spec,
                 expected_scenarios[scenario_index],
                 scenario_label,
+                candidate_version=platform["candidate_version"],
                 expected_uid_map=native_records[spec.architecture]["uid_map"],
                 expected_gid_map=native_records[spec.architecture]["gid_map"],
             )
@@ -2403,8 +2629,8 @@ def _validate_package_schema(document: dict[str, Any]) -> None:
                         _string(entry[key], f"package inventory filesystem.{key}", empty=key == "value")
                     for key in ("uid", "gid"):
                         _integer(entry[key], f"package inventory filesystem.{key}")
-    if seen != package_lab.REQUIRED_PLATFORM_COORDINATES:
-        _fail("package platform matrix is incomplete")
+    if seen_cell_ids != set(expected_cell_ids):
+        _fail("package platform matrix cell inventory is incomplete")
 
 
 def _validate_package(
@@ -2414,12 +2640,14 @@ def _validate_package(
     previous: gate.PackageManifest,
     package_shards: dict[str, RawReport],
     expected_qualification_binding: dict[str, Any],
+    expected_matrix: QualificationMatrix,
 ) -> dict[str, Any]:
-    _validate_package_schema(document)
+    _validate_package_schema(document, expected_matrix)
     _validate_package_shard_binding(
         document,
         package_shards,
         expected_qualification_binding,
+        expected_matrix,
     )
     try:
         package_lab.validate_report_version_contract(document)
@@ -2472,14 +2700,11 @@ def _validate_package(
                 _fail(f"package platform artifact binding is invalid at index {index}/{side}")
         if platform["candidate"]["sha256"] == platform["previous"]["sha256"]:
             _fail("package previous and candidate bytes are identical")
-    specs = {
-        (item.distribution, item.architecture): item
-        for item in package_lab.DEFAULT_PLATFORMS
-    }
+    specs = {item.cell_id: item for item in package_lab.DEFAULT_PLATFORMS}
     coordinate_claims = [
         _derive_platform_lifecycle_claims(
             platform,
-            specs[(platform["distribution"], platform["architecture_id"])],
+            specs[platform["cell_id"]],
         )
         for platform in document["platforms"]
     ]
@@ -2497,17 +2722,24 @@ def _validate_package(
         _fail("package lifecycle evidence is not exclusively ACTIVE real-init")
     coordinates = [
         {
-            "platform": item["distribution"],
+            "cell_id": item["cell_id"],
             "architecture": item["architecture_id"],
             "status": item["status"],
         }
         for item in classification["coordinate_classification"]
     ]
+    lifecycle_claims = {
+        key: value
+        for key, value in derived_claims.items()
+        if key != "second_restart"
+    }
     lifecycle = {
         "previous_version": "v" + previous_version,
         "candidate_version": "v" + candidate_version,
-        "runtime_mode": next(iter(runtime_modes)),
-        **derived_claims,
+        "runtime_mode": "active-container-init",
+        **lifecycle_claims,
+        "second_container_restart": derived_claims["second_restart"],
+        "previous_manifest_sha256": previous.sha256,
         "previous_package_checksums": {
             name: digest
             for name, digest in previous.checksums.items()
@@ -2518,6 +2750,23 @@ def _validate_package(
         "release_ready": classification["release_ready"],
         "blocker_ids": blockers,
         "coordinates": coordinates,
+        "evidence_kind": "container-lifecycle",
+        "evidence_scope": {
+            "coverage_kind": "container_scenarios_only",
+            "real_host_evidence_included": False,
+            "required_checks_complete": False,
+            "covered_scenarios": [
+                {
+                    "cell_id": cell["id"],
+                    "scenarios": list(cell["container_scenarios"]),
+                }
+                for cell in expected_matrix.document["cells"]
+            ],
+        },
+        "qualification_matrix_binding": {
+            "matrix_id": expected_matrix.matrix_id,
+            "sha256": expected_matrix.sha256,
+        },
         "lifecycle": lifecycle,
     }
 
@@ -2526,13 +2775,57 @@ def _package_identity_set(*manifests: gate.PackageManifest) -> set[tuple[int, in
     return {(item.device, item.inode) for manifest in manifests for item in manifest.snapshots}
 
 
+def _validate_baseline_package_assets(
+    previous: gate.PackageManifest,
+    baseline: dict[str, Any],
+) -> None:
+    expected_assets = _list(baseline["assets"], "qualification matrix baseline.assets")
+    expected_by_name: dict[str, dict[str, Any]] = {}
+    for index, value in enumerate(expected_assets):
+        asset = _exact_keys(
+            value,
+            {"name", "id", "size", "architecture", "sha256"},
+            f"qualification matrix baseline.assets[{index}]",
+        )
+        name = _string(asset["name"], f"qualification matrix baseline.assets[{index}].name")
+        if name in expected_by_name:
+            _fail(f"qualification matrix baseline asset is duplicated: {name!r}")
+        _integer(asset["id"], f"qualification matrix baseline.assets[{index}].id")
+        _integer(asset["size"], f"qualification matrix baseline.assets[{index}].size")
+        _string(
+            asset["architecture"],
+            f"qualification matrix baseline.assets[{index}].architecture",
+        )
+        _sha256(asset["sha256"], f"qualification matrix baseline.assets[{index}].sha256")
+        expected_by_name[name] = asset
+    actual_by_name = {snapshot.path.name: snapshot for snapshot in previous.snapshots}
+    if set(actual_by_name) != set(expected_by_name):
+        _fail("previous package asset inventory differs from the frozen baseline")
+    for name, expected in expected_by_name.items():
+        snapshot = actual_by_name[name]
+        if snapshot.size != expected["size"] or snapshot.sha256 != expected["sha256"]:
+            _fail(
+                f"previous package asset {name!r} size/SHA256 differs from the frozen baseline"
+            )
+    manifest = expected_by_name.get("SHA256SUMS.txt")
+    if manifest is None or previous.sha256 != manifest["sha256"]:
+        _fail("previous package manifest digest differs from the frozen baseline")
+
+
 def _revalidate_all(
     binding: gate.RepositoryBinding,
     candidate: gate.PackageManifest,
     previous: gate.PackageManifest,
     raws: dict[str, RawReport],
     package_shards: dict[str, RawReport],
+    matrix: QualificationMatrix,
 ) -> None:
+    gate.revalidate(matrix.snapshot, "package qualification matrix")
+    if (
+        matrix.snapshot.payload
+        != _git_blob_bytes(binding, PACKAGE_QUALIFICATION_MATRIX_PATH)
+    ):
+        _fail("package qualification matrix changed after validation")
     for raw in (*raws.values(), *package_shards.values()):
         gate.revalidate(raw.snapshot, f"{raw.label} raw report")
     for manifest, label in ((candidate, "candidate package evidence"), (previous, "previous package evidence")):
@@ -2556,6 +2849,10 @@ def _revalidate_all(
     )
     if current_candidate != candidate or current_previous != previous:
         _fail("package directory inventory changed after validation")
+    _validate_baseline_package_assets(
+        current_previous,
+        matrix.document["package_sources"]["baseline"],
+    )
     current = gate.verify_repository(binding.root, binding.commit_sha, binding.version)
     if current != binding:
         _fail("Git binding changed during adapter validation")
@@ -2568,6 +2865,7 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         _fail("max report skew must be between 0 and 3600 seconds")
     current = (now or datetime.now(UTC)).astimezone(UTC)
     binding = gate.verify_repository(args.repo_root, args.expected_sha, args.expected_version)
+    matrix = _load_qualification_matrix(args.qualification_matrix, binding)
     candidate = gate.verify_packages(args.candidate_packages_dir, binding)
     raw_paths = {"nft": args.nft_raw, "package": args.package_raw}
     raws = {key: _load_raw(path, key, binding.root, current, args.max_age_seconds) for key, path in raw_paths.items()}
@@ -2614,6 +2912,15 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         "previous_manifest_sha256": previous.sha256,
     }
     _validate_package_qualification_binding(expected_qualification_binding)
+    baseline = matrix.document["package_sources"]["baseline"]
+    if (
+        baseline["release"] != previous_binding.version
+        or baseline["release_id"] != args.expected_previous_release_id
+    ):
+        _fail(
+            "previous package release inputs differ from the frozen qualification matrix"
+        )
+    _validate_baseline_package_assets(previous, baseline)
     if args.expected_candidate_artifact_name != (
         "syswarden-packages-" + binding.version.removeprefix("v")
     ):
@@ -2658,6 +2965,7 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         previous,
         package_shards,
         expected_qualification_binding,
+        matrix,
     )
     generated_at = min(timestamps).isoformat()
     bindings = {
@@ -2672,13 +2980,14 @@ def build_expected(args: argparse.Namespace, *, now: datetime | None = None) -> 
         "nft": gate.build_bound_report(kind="nftables_kernel", generated_at=generated_at, raw_report_sha256=raws["nft"].snapshot.sha256, bindings=bindings, **nft),
         "package": gate.build_bound_report(kind="linux_package_lifecycle", generated_at=generated_at, raw_report_sha256=raws["package"].snapshot.sha256, bindings=bindings, **package),
     }
-    _revalidate_all(binding, candidate, previous, raws, package_shards)
+    _revalidate_all(binding, candidate, previous, raws, package_shards, matrix)
     return ValidatedInputs(
         binding,
         candidate,
         previous,
         raws,
         package_shards,
+        matrix,
         envelopes,
     )
 
@@ -2694,7 +3003,12 @@ def _validate_destinations(paths: dict[str, Path], state: ValidatedInputs, *, mu
     protected = {
         (item.snapshot.device, item.snapshot.inode)
         for item in (*state.raws.values(), *state.package_shards.values())
-    } | _package_identity_set(state.candidate, state.previous)
+    } | _package_identity_set(state.candidate, state.previous) | {
+        (
+            state.qualification_matrix.snapshot.device,
+            state.qualification_matrix.snapshot.inode,
+        )
+    }
     existing: set[tuple[int, int]] = set()
     for key, path in paths.items():
         if path.name != OUTPUT_NAMES[key]:
@@ -2738,6 +3052,7 @@ def run_build(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
         state.previous,
         state.raws,
         state.package_shards,
+        state.qualification_matrix,
     )
     return state.envelopes
 
@@ -2760,6 +3075,7 @@ def run_verify(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
         state.previous,
         state.raws,
         state.package_shards,
+        state.qualification_matrix,
     )
     return state.envelopes
 
@@ -2773,6 +3089,7 @@ def _common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--nft-raw", type=Path, required=True)
     parser.add_argument("--package-raw", type=Path, required=True)
     parser.add_argument("--package-amd64-shard", type=Path, required=True)
+    parser.add_argument("--qualification-matrix", type=Path, required=True)
     parser.add_argument("--expected-repository", required=True)
     parser.add_argument("--expected-workflow-run-id", type=int, required=True)
     parser.add_argument("--expected-workflow-run-attempt", type=int, required=True)

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -60,15 +61,15 @@ def replace_snapshot_identity_maps(
 
 
 class AdapterFixture:
-    version = "v4.02.8"
-    previous_version = "v4.02.7"
+    version = "v4.04.0"
+    previous_version = "v4.03.3"
     repository = "duggytuxy/syswarden"
     workflow_run_id = 1001
     workflow_run_attempt = 1
     candidate_run_id = 900
     candidate_artifact_id = 901
-    candidate_artifact_name = "syswarden-packages-4.02.8"
-    previous_release_id = 800
+    candidate_artifact_name = "syswarden-packages-4.04.0"
+    previous_release_id = 377680978
 
     def __init__(self, root: Path) -> None:
         self.root = root
@@ -92,8 +93,8 @@ class AdapterFixture:
         self.now = datetime.now(UTC).replace(microsecond=0)
         self._make_repository()
         self.commit = self._git("rev-parse", "HEAD")
-        self._make_package_set(self.candidate, "4.02.8", b"candidate")
-        self._make_package_set(self.previous, "4.02.7", b"previous")
+        self._make_package_set(self.candidate, "4.04.0", b"candidate")
+        self._make_package_set(self.previous, "4.03.3", b"previous")
         self._make_raw_reports()
 
     def _run(self, *arguments: str, cwd: Path | None = None) -> str:
@@ -184,6 +185,9 @@ class AdapterFixture:
                 continue
             source.parent.mkdir(parents=True, exist_ok=True)
             source.write_text(f"fixture for {relative}\n", encoding="utf-8")
+        matrix_path = self.repo / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH
+        matrix_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(adapter.qualification_matrix.DEFAULT_MATRIX, matrix_path)
         self._git("add", ".")
         self._git("commit", "-qm", "fixture")
 
@@ -212,6 +216,8 @@ class AdapterFixture:
             "pull_policy": "never",
             "scenario_timeout": 60,
             "package_tmp_dir": self.package_tmp,
+            "qualification_matrix": self.repo
+            / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH,
             "qualification_repository": self.repository,
             "qualification_release_sha": self.commit,
             "qualification_release_tag": self.version,
@@ -401,6 +407,8 @@ class AdapterFixture:
             "nft_raw": self.raw / "nftables-raw.json",
             "package_raw": self.raw / "package-lifecycle-raw.json",
             "package_amd64_shard": self.raw / "package-lifecycle-amd64.json",
+            "qualification_matrix": self.repo
+            / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH,
             "expected_repository": self.repository,
             "expected_workflow_run_id": self.workflow_run_id,
             "expected_workflow_run_attempt": self.workflow_run_attempt,
@@ -426,12 +434,27 @@ class AdapterFixture:
             json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
 
+    def matrix_binding(self) -> adapter.QualificationMatrix:
+        binding = gate.verify_repository(self.repo, self.commit, self.version)
+        return adapter._load_qualification_matrix(
+            self.repo / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH,
+            binding,
+        )
+
 
 class ReleaseQualificationAdapterTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
         self.fixture = AdapterFixture(Path(self.temporary.name))
+        self.baseline_validator = adapter._validate_baseline_package_assets
+        baseline_patcher = mock.patch.object(
+            adapter,
+            "_validate_baseline_package_assets",
+            return_value=None,
+        )
+        baseline_patcher.start()
+        self.addCleanup(baseline_patcher.stop)
 
     def assertAdapterError(self, args: argparse.Namespace) -> None:
         with self.assertRaises(gate.EvidenceError):
@@ -464,11 +487,186 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         envelopes = adapter.run_build(self.fixture.args())
         expected_time = self.fixture.now.isoformat()
         self.assertEqual({item["generated_at"] for item in envelopes.values()}, {expected_time})
+        self.assertEqual(
+            envelopes["package"]["lifecycle"]["runtime_mode"],
+            "active-container-init",
+        )
         verified = adapter.run_verify(self.fixture.args("verify"))
         self.assertEqual(verified, envelopes)
         for key, name in adapter.OUTPUT_NAMES.items():
             payload = (self.fixture.bound / name).read_bytes()
             self.assertEqual(payload, adapter._canonical(envelopes[key]))
+
+    def test_matrix_binding_scope_and_exact_eight_cells_are_fail_closed(self) -> None:
+        original = self.fixture.load_raw("package-lifecycle-raw.json")
+        expected_binding = self.fixture.matrix_binding()
+        self.assertEqual(
+            original["qualification_matrix"],
+            {
+                "matrix_id": expected_binding.matrix_id,
+                "sha256": expected_binding.sha256,
+            },
+        )
+        self.assertEqual(
+            [item["cell_id"] for item in original["platforms"]],
+            [cell.identifier for cell in adapter.qualification_matrix.EXPECTED_CELLS],
+        )
+        self.assertEqual(original["scope"]["evidence_kind"], "container-lifecycle")
+        self.assertEqual(
+            original["scope"]["coverage_kind"], "container_scenarios_only"
+        )
+        self.assertIs(original["scope"]["real_host_evidence_included"], False)
+        self.assertIs(original["scope"]["required_checks_complete"], False)
+        mutations = {
+            "matrix-id": lambda item: item["qualification_matrix"].__setitem__(
+                "matrix_id", "syswarden-package-qualification/forged"
+            ),
+            "matrix-sha": lambda item: item["qualification_matrix"].__setitem__(
+                "sha256", "0" * 64
+            ),
+            "host-scope": lambda item: item["scope"].__setitem__(
+                "evidence_kind", "real-host-lifecycle"
+            ),
+            "host-evidence": lambda item: item["scope"].__setitem__(
+                "real_host_evidence_included", True
+            ),
+            "required-checks": lambda item: item["scope"].__setitem__(
+                "required_checks_complete", True
+            ),
+            "coverage-kind": lambda item: item["scope"].__setitem__(
+                "coverage_kind", "all-required-checks"
+            ),
+            "container-lab-incomplete": lambda item: item["scope"].__setitem__(
+                "container_lab_complete", False
+            ),
+            "covered-scenario": lambda item: item["scope"][
+                "covered_scenarios"
+            ][0]["scenarios"].pop(),
+            "coordinate-incomplete": lambda item: item["scope"][
+                "coordinate_classification"
+            ][0].__setitem__("status", "incomplete"),
+            "completed-architectures": lambda item: item["scope"].__setitem__(
+                "architectures_completed", []
+            ),
+            "architecture-status": lambda item: item["scope"][
+                "architecture_coverage"
+            ][0].__setitem__("status", "incomplete"),
+            "family-status": lambda item: item["scope"][
+                "family_architecture_coverage"
+            ][0].__setitem__("status", "incomplete"),
+            "missing-cell": lambda item: item["platforms"].pop(),
+            "duplicate-cell": lambda item: item["platforms"][1].__setitem__(
+                "cell_id", item["platforms"][0]["cell_id"]
+            ),
+            "reordered-cells": lambda item: item["platforms"].reverse(),
+            "cell-version": lambda item: item["platforms"][0].__setitem__(
+                "version", "forged"
+            ),
+            "expected-runtime-distribution": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("expected_distribution", "forged"),
+            "actual-runtime-distribution": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("actual_distribution", "forged"),
+            "expected-runtime-version": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("expected_distribution_version", "forged"),
+            "actual-runtime-version": lambda item: item["platforms"][0][
+                "architecture_probe"
+            ].__setitem__("actual_distribution_version", "forged"),
+        }
+        for name, mutation in mutations.items():
+            with self.subTest(mutation=name):
+                report = copy.deepcopy(original)
+                mutation(report)
+                with self.assertRaises(adapter.AdapterError):
+                    adapter._validate_package_schema(report, expected_binding)
+
+    def test_matrix_path_and_raw_bytes_must_match_the_exact_commit(self) -> None:
+        args = self.fixture.args()
+        canonical_path = self.fixture.repo / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH
+        original = canonical_path.read_bytes()
+        try:
+            canonical_path.write_bytes(original + b"\n")
+            self.assertAdapterError(args)
+        finally:
+            canonical_path.write_bytes(original)
+
+        alternate = self.fixture.root / "package_qualification_matrix.json"
+        alternate.write_bytes(original)
+        args.qualification_matrix = alternate
+        self.assertAdapterError(args)
+
+    def test_frozen_baseline_assets_reject_size_digest_and_coherent_replacement(self) -> None:
+        baseline = self.fixture.matrix_binding().document["package_sources"][
+            "baseline"
+        ]
+        snapshots = tuple(
+            gate.FileSnapshot(
+                Path(asset["name"]),
+                1,
+                index + 1,
+                asset["size"],
+                1,
+                asset["sha256"],
+                b"",
+            )
+            for index, asset in enumerate(baseline["assets"])
+        )
+        manifest_sha256 = next(
+            item["sha256"]
+            for item in baseline["assets"]
+            if item["name"] == "SHA256SUMS.txt"
+        )
+        previous = gate.PackageManifest(
+            Path("baseline"),
+            manifest_sha256,
+            {
+                item["name"]: item["sha256"]
+                for item in baseline["assets"]
+                if item["name"] != "SHA256SUMS.txt"
+            },
+            snapshots,
+        )
+        self.baseline_validator(previous, baseline)
+
+        size_drift = replace(
+            previous,
+            snapshots=(replace(snapshots[0], size=snapshots[0].size + 1),)
+            + snapshots[1:],
+        )
+        digest_drift = replace(
+            previous,
+            snapshots=(replace(snapshots[0], sha256="0" * 64),) + snapshots[1:],
+            sha256="0" * 64,
+        )
+        replacement_snapshots = tuple(
+            replace(
+                snapshot,
+                size=snapshot.size + index + 1,
+                sha256=f"{index + 1:x}" * 64,
+            )
+            for index, snapshot in enumerate(snapshots)
+        )
+        coherent_replacement = replace(
+            previous,
+            sha256=replacement_snapshots[0].sha256,
+            checksums={
+                snapshot.path.name: snapshot.sha256
+                for snapshot in replacement_snapshots
+                if snapshot.path.name != "SHA256SUMS.txt"
+            },
+            snapshots=replacement_snapshots,
+        )
+        for name, changed in (
+            ("size", size_drift),
+            ("digest", digest_drift),
+            ("coherent-replacement", coherent_replacement),
+        ):
+            with self.subTest(mutation=name), self.assertRaises(
+                adapter.AdapterError
+            ):
+                self.baseline_validator(changed, baseline)
 
     def test_evidence_bundle_can_be_relocated_before_verify(self) -> None:
         adapter.run_build(self.fixture.args())
@@ -617,12 +815,16 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         spec = next(
             item
             for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-            if item.distribution == platform["distribution"]
+            if item.cell_id == platform["cell_id"]
             and item.architecture == platform["architecture_id"]
         )
         original = platform["scenarios"][0]
         adapter._validate_runtime_scenario(
-            original, spec, original["name"], "fixture.scenario"
+            original,
+            spec,
+            original["name"],
+            "fixture.scenario",
+            candidate_version=platform["candidate_version"],
         )
         restarted_rsyslog = copy.deepcopy(original)
         restarted_rsyslog["boots"][0]["post_exec"]["rsyslog_main_pid"] += 1
@@ -631,6 +833,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             spec,
             restarted_rsyslog["name"],
             "fixture.rsyslog-restart",
+            candidate_version=platform["candidate_version"],
         )
         debian_lib_fragment = copy.deepcopy(original)
         for boot in debian_lib_fragment["boots"]:
@@ -643,6 +846,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             spec,
             debian_lib_fragment["name"],
             "fixture.debian-lib-fragment",
+            candidate_version=platform["candidate_version"],
         )
 
         def change_identity_mode(
@@ -658,7 +862,11 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             mutator(scenario)
             with self.assertRaises(adapter.AdapterError):
                 adapter._validate_runtime_scenario(
-                    scenario, spec, original["name"], "fixture.scenario"
+                    scenario,
+                    spec,
+                    original["name"],
+                    "fixture.scenario",
+                    candidate_version=platform["candidate_version"],
                 )
 
         mutations = {
@@ -999,13 +1207,18 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                             spec,
                             original["name"],
                             "fixture.scenario",
+                            candidate_version=platform["candidate_version"],
                         )
             with self.subTest(schema=object_name, extra="unknown"):
                 scenario = copy.deepcopy(original)
                 locate(scenario)["unknown"] = True
                 with self.assertRaises(adapter.AdapterError):
                     adapter._validate_runtime_scenario(
-                        scenario, spec, original["name"], "fixture.scenario"
+                        scenario,
+                        spec,
+                        original["name"],
+                        "fixture.scenario",
+                        candidate_version=platform["candidate_version"],
                     )
 
     def test_adapter_rejects_every_capability_process_boundary_bit(self) -> None:
@@ -1014,7 +1227,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         spec = next(
             item
             for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-            if item.distribution == platform["distribution"]
+            if item.cell_id == platform["cell_id"]
             and item.architecture == platform["architecture_id"]
         )
         original = platform["scenarios"][0]
@@ -1082,6 +1295,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                                 spec,
                                 original["name"],
                                 "fixture.scenario",
+                                candidate_version=platform["candidate_version"],
                             )
 
     def test_alpine_cron_fragment_mode_is_family_bound(self) -> None:
@@ -1092,13 +1306,17 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         spec = next(
             item
             for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-            if item.distribution == platform["distribution"]
+            if item.cell_id == platform["cell_id"]
             and item.architecture == platform["architecture_id"]
         )
         original = copy.deepcopy(platform["scenarios"][0])
         scenario = copy.deepcopy(original)
         adapter._validate_runtime_scenario(
-            scenario, spec, scenario["name"], "fixture.alpine"
+            scenario,
+            spec,
+            scenario["name"],
+            "fixture.alpine",
+            candidate_version=platform["candidate_version"],
         )
         snapshot = scenario["boots"][0]["pre_exec"]
         self.assertIn(":81ed:0:0|", snapshot["cron_fragment_identity"])
@@ -1107,7 +1325,11 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         ].replace(":81ed:0:0|", ":81a4:0:0|")
         with self.assertRaises(adapter.AdapterError):
             adapter._validate_runtime_scenario(
-                scenario, spec, scenario["name"], "fixture.alpine"
+                scenario,
+                spec,
+                scenario["name"],
+                "fixture.alpine",
+                candidate_version=platform["candidate_version"],
             )
 
         systemd_platform = next(
@@ -1181,7 +1403,11 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                 mutation(changed)
                 with self.assertRaises(adapter.AdapterError):
                     adapter._validate_runtime_scenario(
-                        changed, spec, changed["name"], "fixture.alpine"
+                        changed,
+                        spec,
+                        changed["name"],
+                        "fixture.alpine",
+                        candidate_version=platform["candidate_version"],
                     )
 
     def test_lifecycle_claims_are_derived_from_active_event_evidence(self) -> None:
@@ -1190,11 +1416,11 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             coordinate_spec = next(
                 item
                 for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-                if item.distribution == coordinate_platform["distribution"]
+                if item.cell_id == coordinate_platform["cell_id"]
                 and item.architecture == coordinate_platform["architecture_id"]
             )
             with self.subTest(
-                distribution=coordinate_platform["distribution"],
+                cell_id=coordinate_platform["cell_id"],
                 architecture=coordinate_platform["architecture_id"],
             ):
                 coordinate_claims = adapter._derive_platform_lifecycle_claims(
@@ -1205,7 +1431,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         spec = next(
             item
             for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-            if item.distribution == platform["distribution"]
+            if item.cell_id == platform["cell_id"]
             and item.architecture == platform["architecture_id"]
         )
         claims = adapter._derive_platform_lifecycle_claims(platform, spec)
@@ -1320,10 +1546,10 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                 )
                 self.assertFalse(changed[claim])
 
-    def test_raw_v4_engine_helper_cleanup_and_native_records_are_exact(self) -> None:
+    def test_raw_v5_matrix_engine_helper_cleanup_and_native_records_are_exact(self) -> None:
         original = self.fixture.load_raw("package-lifecycle-raw.json")
-        adapter._validate_package_schema(original)
-        self.assertEqual(len(original["platforms"]), 5)
+        adapter._validate_package_schema(original, self.fixture.matrix_binding())
+        self.assertEqual(len(original["platforms"]), 8)
         native_records = {
             record["architecture"]: record
             for record in original["native_shards"]["reports"]
@@ -1333,7 +1559,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.assertEqual(len(native_records["amd64"]["gid_map"]), 2)
         self.assertEqual(
             {
-                (item["distribution"], item["architecture_id"])
+                (item["cell_id"], item["architecture_id"])
                 for item in original["platforms"]
             },
             package_lifecycle_lab.REQUIRED_PLATFORM_COORDINATES,
@@ -1347,7 +1573,9 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             report = copy.deepcopy(original)
             mutator(report)
             with self.assertRaises(adapter.AdapterError):
-                adapter._validate_package_schema(report)
+                adapter._validate_package_schema(
+                    report, self.fixture.matrix_binding()
+                )
 
         def mismatch_native_effective_uid_map(item: dict[str, Any]) -> None:
             record = item["native_shards"]["reports"][0]
@@ -1472,15 +1700,15 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self,
     ) -> None:
         original = self.fixture.load_raw("package-lifecycle-raw.json")
-        adapter._validate_package_schema(original)
+        adapter._validate_package_schema(original, self.fixture.matrix_binding())
 
         def platform(
-            report: dict[str, Any], distribution: str, architecture: str
+            report: dict[str, Any], cell_id: str, architecture: str
         ) -> dict[str, Any]:
             return next(
                 item
                 for item in report["platforms"]
-                if item["distribution"] == distribution
+                if item["cell_id"] == cell_id
                 and item["architecture_id"] == architecture
             )
 
@@ -1493,7 +1721,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             ]
 
         expected = [package_lifecycle_lab.FEDORA_CRON_DROPIN_PATH]
-        fedora_snapshots = snapshots(platform(original, "fedora", "amd64"))
+        fedora_snapshots = snapshots(platform(original, "RPM-F44", "amd64"))
         self.assertTrue(
             all(
                 snapshot["cron_dropin_paths"] == expected
@@ -1506,40 +1734,51 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                 for snapshot in fedora_snapshots
             )
         )
-        alma_snapshots = snapshots(platform(original, "almalinux", "amd64"))
-        self.assertTrue(
-            all(
-                snapshot["cron_executable_path"] == "/usr/sbin/crond"
-                for snapshot in alma_snapshots
+        for cell_id in ("RPM-A9", "RPM-A10"):
+            alma_snapshots = snapshots(platform(original, cell_id, "amd64"))
+            self.assertTrue(
+                all(
+                    snapshot["cron_executable_path"] == "/usr/sbin/crond"
+                    for snapshot in alma_snapshots
+                )
             )
-        )
-        for distribution in ("debian", "ubuntu", "almalinux", "alpine"):
+        for cell_id in (
+            "DEB-13",
+            "DEB-U2404",
+            "DEB-U2604",
+            "RPM-A9",
+            "RPM-A10",
+            "APK-322",
+            "APK-324",
+        ):
             self.assertTrue(
                 all(
                     snapshot["cron_dropin_paths"] == []
                     for snapshot in snapshots(
-                        platform(original, distribution, "amd64")
+                        platform(original, cell_id, "amd64")
                     )
                 )
             )
 
         def assert_rejected(
-            distribution: str,
+            cell_id: str,
             architecture: str,
             value: list[str],
         ) -> None:
             report = copy.deepcopy(original)
-            snapshots(platform(report, distribution, architecture))[0][
+            snapshots(platform(report, cell_id, architecture))[0][
                 "cron_dropin_paths"
             ] = value
             with self.assertRaises(adapter.AdapterError):
-                adapter._validate_package_schema(report)
+                adapter._validate_package_schema(
+                    report, self.fixture.matrix_binding()
+                )
 
-        for name, distribution, architecture, value in (
-            ("missing", "fedora", "amd64", []),
+        for name, cell_id, architecture, value in (
+            ("missing", "RPM-F44", "amd64", []),
             (
                 "extra",
-                "fedora",
+                "RPM-F44",
                 "amd64",
                 [
                     package_lifecycle_lab.FEDORA_CRON_DROPIN_PATH,
@@ -1548,7 +1787,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             ),
             (
                 "duplicate",
-                "fedora",
+                "RPM-F44",
                 "amd64",
                 [
                     package_lifecycle_lab.FEDORA_CRON_DROPIN_PATH,
@@ -1557,31 +1796,33 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
             ),
             (
                 "wrong",
-                "fedora",
+                "RPM-F44",
                 "amd64",
                 ["/etc/systemd/system/crond.service.d/operator.conf"],
             ),
             (
                 "cross_distribution",
-                "almalinux",
+                "RPM-A9",
                 "amd64",
                 [package_lifecycle_lab.FEDORA_CRON_DROPIN_PATH],
             ),
         ):
             with self.subTest(mutation=name):
-                assert_rejected(distribution, architecture, value)
+                assert_rejected(cell_id, architecture, value)
 
-        for name, distribution, architecture, value in (
-            ("fedora_alias", "fedora", "amd64", "/usr/sbin/crond"),
-            ("alma_fedora_path", "almalinux", "amd64", "/usr/bin/crond"),
+        for name, cell_id, architecture, value in (
+            ("fedora_alias", "RPM-F44", "amd64", "/usr/sbin/crond"),
+            ("alma_fedora_path", "RPM-A9", "amd64", "/usr/bin/crond"),
         ):
             with self.subTest(mutation=name):
                 report = copy.deepcopy(original)
-                snapshots(platform(report, distribution, architecture))[0][
+                snapshots(platform(report, cell_id, architecture))[0][
                     "cron_executable_path"
                 ] = value
                 with self.assertRaises(adapter.AdapterError):
-                    adapter._validate_package_schema(report)
+                    adapter._validate_package_schema(
+                        report, self.fixture.matrix_binding()
+                    )
 
     def test_amd64_probe_must_report_the_native_uname(self) -> None:
         report = self.fixture.load_raw("package-lifecycle-raw.json")
@@ -1640,7 +1881,7 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         self.fixture._make_raw_reports()
         report = self.fixture.load_raw("package-lifecycle-raw.json")
         report["scope"]["architecture_coverage"][0][
-            "completed_distributions"
+            "completed_cells"
         ].reverse()
         self.fixture.save_raw("package-lifecycle-raw.json", report)
         self.assertAdapterError(self.fixture.args())
@@ -1685,6 +1926,13 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
         os.link(original, alias)
         self.assertAdapterError(self.fixture.args())
         alias.unlink()
+        matrix_alias = self.fixture.bound / "package-lifecycle-bound.json"
+        os.link(
+            self.fixture.repo / adapter.PACKAGE_QUALIFICATION_MATRIX_PATH,
+            matrix_alias,
+        )
+        self.assertAdapterError(self.fixture.args())
+        matrix_alias.unlink()
         self.assertAdapterError(
             self.fixture.args(nft_output=self.fixture.repo / "nftables-bound.json")
         )

--- a/scripts/ci/release_qualification_gate.py
+++ b/scripts/ci/release_qualification_gate.py
@@ -25,11 +25,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Sequence
 
+import package_qualification_matrix as qualification_matrix
 
-SCHEMA_VERSION = 1
+
+SCHEMA_VERSION = 2
 REPORT_SCHEMA_VERSIONS = {
     "nftables_kernel": 1,
-    "linux_package_lifecycle": 4,
+    "linux_package_lifecycle": 5,
 }
 REPORT_LIMIT = 8 * 1024 * 1024
 PACKAGE_LIMIT = 128 * 1024 * 1024
@@ -246,6 +248,22 @@ def _git(root: Path, *arguments: str) -> str:
     return process.stdout.strip()
 
 
+def _git_bytes(root: Path, *arguments: str) -> bytes:
+    try:
+        process = subprocess.run(
+            ("git", "-c", "core.fsmonitor=false", "-C", str(root), *arguments),
+            check=False,
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EvidenceError(f"cannot execute Git: {exc}") from exc
+    if process.returncode != 0:
+        detail = process.stderr.decode("utf-8", errors="replace").strip()
+        raise EvidenceError(f"Git {' '.join(arguments)} failed: {detail}")
+    return process.stdout
+
+
 SOURCE_TARGETS = (
     ("src/core/syswarden-cli/pkg/system/upgrade.go", 1),
     ("src/core/syswarden-tui/main.go", 1),
@@ -304,6 +322,33 @@ def verify_repository(repo_root: Path, expected_sha: str, expected_version: str)
         raise EvidenceError(f"Git returned an invalid tree SHA: {tree!r}")
     verify_source_version(root, expected_version)
     return RepositoryBinding(root, head, tree, expected_version)
+
+
+def qualification_matrix_binding(
+    binding: RepositoryBinding,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    payload = _git_bytes(
+        binding.root,
+        "show",
+        f"{binding.commit_sha}:{QUALIFICATION_MATRIX_PATH}",
+    )
+    try:
+        document = qualification_matrix.validate_document(
+            strict_json(payload, "committed package qualification matrix")
+        )
+    except qualification_matrix.QualificationMatrixError as exc:
+        raise EvidenceError(f"committed package qualification matrix is invalid: {exc}") from exc
+    if document["target_release"] != binding.version:
+        raise EvidenceError(
+            "committed package qualification matrix target differs from the release"
+        )
+    return (
+        {
+            "matrix_id": str(document["matrix_id"]),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        },
+        document,
+    )
 
 
 def package_names(version: str) -> tuple[str, ...]:
@@ -388,7 +433,14 @@ COMMON_REPORT_KEYS = frozenset(
 REPORT_KEYS = {
     "nftables_kernel": COMMON_REPORT_KEYS
     | {"conditions", "network_namespaces"},
-    "linux_package_lifecycle": COMMON_REPORT_KEYS | {"coverage", "lifecycle"},
+    "linux_package_lifecycle": COMMON_REPORT_KEYS
+    | {
+        "coverage",
+        "lifecycle",
+        "evidence_kind",
+        "evidence_scope",
+        "qualification_matrix",
+    },
 }
 BINDING_KEYS = frozenset(
     {
@@ -401,7 +453,18 @@ BINDING_KEYS = frozenset(
     }
 )
 COVERAGE_KEYS = frozenset({"coordinates"})
-COORDINATE_KEYS = frozenset({"platform", "architecture", "status"})
+COORDINATE_KEYS = frozenset({"cell_id", "architecture", "status"})
+QUALIFICATION_MATRIX_BINDING_KEYS = frozenset({"matrix_id", "sha256"})
+QUALIFICATION_MATRIX_PATH = "scripts/ci/package_qualification_matrix.json"
+EVIDENCE_SCOPE_KEYS = frozenset(
+    {
+        "coverage_kind",
+        "real_host_evidence_included",
+        "required_checks_complete",
+        "covered_scenarios",
+    }
+)
+COVERED_SCENARIO_KEYS = frozenset({"cell_id", "scenarios"})
 NFT_CONDITION_KEYS = frozenset(
     {
         "network_namespace_isolated",
@@ -425,7 +488,8 @@ LIFECYCLE_KEYS = frozenset(
         "rollback",
         "remove",
         "purge",
-        "second_restart",
+        "second_container_restart",
+        "previous_manifest_sha256",
         "previous_package_checksums",
     }
 )
@@ -454,6 +518,9 @@ def build_bound_report(
     blocker_ids: Sequence[str],
     coordinates: Sequence[dict[str, str]] = (),
     lifecycle: dict[str, Any] | None = None,
+    evidence_kind: str | None = None,
+    evidence_scope: dict[str, Any] | None = None,
+    qualification_matrix_binding: dict[str, str] | None = None,
     conditions: dict[str, bool] | None = None,
     network_namespaces: dict[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -483,16 +550,35 @@ def build_bound_report(
             raise EvidenceError(
                 "nftables envelope requires conditions and network namespaces"
             )
-        if lifecycle is not None or coordinates:
-            raise EvidenceError("nftables envelope cannot claim package lifecycle or VM coverage")
+        if (
+            lifecycle is not None
+            or coordinates
+            or evidence_kind is not None
+            or evidence_scope is not None
+            or qualification_matrix_binding is not None
+        ):
+            raise EvidenceError(
+                "nftables envelope cannot claim package lifecycle or container scenario coverage"
+            )
         envelope["conditions"] = conditions
         envelope["network_namespaces"] = network_namespaces
     else:
         if lifecycle is None:
             raise EvidenceError(f"{kind} envelope requires package lifecycle evidence")
+        if (
+            evidence_kind != "container-lifecycle"
+            or evidence_scope is None
+            or qualification_matrix_binding is None
+        ):
+            raise EvidenceError(
+                f"{kind} envelope requires an exact container-lifecycle matrix binding"
+            )
         if conditions is not None or network_namespaces is not None:
             raise EvidenceError(f"{kind} envelope cannot contain nftables namespace evidence")
         envelope["coverage"] = {"coordinates": list(coordinates)}
+        envelope["evidence_kind"] = evidence_kind
+        envelope["evidence_scope"] = evidence_scope
+        envelope["qualification_matrix"] = qualification_matrix_binding
         envelope["lifecycle"] = lifecycle
     return envelope
 
@@ -525,7 +611,88 @@ def _validate_nft_evidence(document: dict[str, Any]) -> None:
         raise EvidenceError("nftables laboratory did not use a separate network namespace")
 
 
-def _validate_coverage(kind: str, document: dict[str, Any]) -> None:
+def _validate_package_matrix_evidence(
+    kind: str,
+    document: dict[str, Any],
+    binding: RepositoryBinding,
+) -> dict[str, Any]:
+    if document["evidence_kind"] != "container-lifecycle":
+        raise EvidenceError(
+            f"{kind}.evidence_kind must be exactly container-lifecycle"
+        )
+    report_matrix = document["qualification_matrix"]
+    if not isinstance(report_matrix, dict):
+        raise EvidenceError(f"{kind}.qualification_matrix must be an object")
+    _exact_keys(
+        report_matrix,
+        QUALIFICATION_MATRIX_BINDING_KEYS,
+        f"{kind}.qualification_matrix",
+    )
+    if (
+        not isinstance(report_matrix["matrix_id"], str)
+        or not isinstance(report_matrix["sha256"], str)
+        or SHA256_RE.fullmatch(report_matrix["sha256"]) is None
+    ):
+        raise EvidenceError(f"{kind}.qualification_matrix is not canonical")
+    expected, matrix_document = qualification_matrix_binding(binding)
+    if report_matrix != expected:
+        raise EvidenceError(
+            f"{kind}.qualification_matrix differs from the exact committed bytes"
+        )
+    evidence_scope = document["evidence_scope"]
+    if not isinstance(evidence_scope, dict):
+        raise EvidenceError(f"{kind}.evidence_scope must be an object")
+    _exact_keys(evidence_scope, EVIDENCE_SCOPE_KEYS, f"{kind}.evidence_scope")
+    if (
+        evidence_scope["coverage_kind"] != "container_scenarios_only"
+        or type(evidence_scope["real_host_evidence_included"]) is not bool
+        or evidence_scope["real_host_evidence_included"] is not False
+        or type(evidence_scope["required_checks_complete"]) is not bool
+        or evidence_scope["required_checks_complete"] is not False
+    ):
+        raise EvidenceError(
+            f"{kind}.evidence_scope overstates container lifecycle coverage"
+        )
+    covered = evidence_scope["covered_scenarios"]
+    if not isinstance(covered, list):
+        raise EvidenceError(f"{kind}.evidence_scope.covered_scenarios must be an array")
+    expected_covered = [
+        {
+            "cell_id": str(cell["id"]),
+            "scenarios": list(cell["container_scenarios"]),
+        }
+        for cell in matrix_document["cells"]
+    ]
+    for index, record in enumerate(covered):
+        if not isinstance(record, dict):
+            raise EvidenceError(
+                f"{kind}.evidence_scope.covered_scenarios[{index}] must be an object"
+            )
+        _exact_keys(
+            record,
+            COVERED_SCENARIO_KEYS,
+            f"{kind}.evidence_scope.covered_scenarios[{index}]",
+        )
+        if (
+            not isinstance(record["cell_id"], str)
+            or not isinstance(record["scenarios"], list)
+            or any(not isinstance(item, str) for item in record["scenarios"])
+        ):
+            raise EvidenceError(
+                f"{kind}.evidence_scope.covered_scenarios[{index}] has invalid types"
+            )
+    if covered != expected_covered:
+        raise EvidenceError(
+            f"{kind}.evidence_scope.covered_scenarios differs from the ordered matrix"
+        )
+    return matrix_document
+
+
+def _validate_coverage(
+    kind: str,
+    document: dict[str, Any],
+    matrix_document: dict[str, Any],
+) -> None:
     coverage = document["coverage"]
     if not isinstance(coverage, dict):
         raise EvidenceError(f"{kind}.coverage must be an object")
@@ -533,6 +700,11 @@ def _validate_coverage(kind: str, document: dict[str, Any]) -> None:
     if not isinstance(coverage["coordinates"], list):
         raise EvidenceError(f"{kind}.coverage has invalid types")
     seen: set[tuple[str, str]] = set()
+    expected_cell_ids = [str(cell["id"]) for cell in matrix_document["cells"]]
+    if len(coverage["coordinates"]) != len(expected_cell_ids):
+        raise EvidenceError(
+            f"{kind}.coverage must contain exactly {len(expected_cell_ids)} matrix cells"
+        )
     for index, coordinate in enumerate(coverage["coordinates"]):
         if not isinstance(coordinate, dict):
             raise EvidenceError(
@@ -547,10 +719,15 @@ def _validate_coverage(kind: str, document: dict[str, Any]) -> None:
             raise EvidenceError(
                 f"{kind}.coverage.coordinates[{index}] values must be strings"
             )
-        key = (coordinate["platform"], coordinate["architecture"])
+        key = (coordinate["cell_id"], coordinate["architecture"])
         if key in seen:
             raise EvidenceError(f"duplicate {kind} coverage coordinate: {key}")
         seen.add(key)
+        if key != (expected_cell_ids[index], "amd64"):
+            raise EvidenceError(
+                f"{kind}.coverage coordinate at index {index} differs from the "
+                "frozen matrix cell order"
+            )
         if coordinate["status"] not in {"pass", "blocker"}:
             raise EvidenceError(f"{kind} coverage status cannot be skipped/unknown")
 
@@ -560,6 +737,7 @@ def _validate_lifecycle(
     document: dict[str, Any],
     binding: RepositoryBinding,
     packages: PackageManifest,
+    matrix_document: dict[str, Any],
 ) -> tuple[str, dict[str, str]]:
     lifecycle = document["lifecycle"]
     if not isinstance(lifecycle, dict):
@@ -569,6 +747,7 @@ def _validate_lifecycle(
         "previous_version",
         "candidate_version",
         "runtime_mode",
+        "previous_manifest_sha256",
         "previous_package_checksums",
     }
     for key in boolean_keys:
@@ -580,9 +759,9 @@ def _validate_lifecycle(
         raise EvidenceError(f"{kind} lifecycle versions must be strings")
     if candidate != binding.version or version_tuple(previous) >= version_tuple(candidate):
         raise EvidenceError(f"{kind} lifecycle must prove previous_version < candidate_version")
-    if lifecycle["runtime_mode"] != "active-real-init":
+    if lifecycle["runtime_mode"] != "active-container-init":
         raise EvidenceError(
-            f"{kind} lifecycle runtime_mode must be active-real-init"
+            f"{kind} lifecycle runtime_mode must be active-container-init"
         )
     previous_checksums = lifecycle["previous_package_checksums"]
     if not isinstance(previous_checksums, dict):
@@ -598,6 +777,36 @@ def _validate_lifecycle(
         for digest in previous_checksums.values()
     ):
         raise EvidenceError(f"{kind} previous package checksums are invalid")
+    previous_manifest_sha256 = lifecycle["previous_manifest_sha256"]
+    if (
+        not isinstance(previous_manifest_sha256, str)
+        or SHA256_RE.fullmatch(previous_manifest_sha256) is None
+    ):
+        raise EvidenceError(f"{kind} previous package manifest SHA256 is invalid")
+    baseline = matrix_document["package_sources"]["baseline"]
+    if previous != baseline["release"]:
+        raise EvidenceError(
+            f"{kind} previous version differs from the frozen baseline release"
+        )
+    baseline_assets = {
+        asset["name"]: asset for asset in baseline["assets"]
+    }
+    expected_baseline_names = expected_previous_names | {"SHA256SUMS.txt"}
+    if set(baseline_assets) != expected_baseline_names:
+        raise EvidenceError(
+            f"{kind} qualification matrix baseline asset inventory is incomplete"
+        )
+    expected_previous_checksums = {
+        name: baseline_assets[name]["sha256"] for name in expected_previous_names
+    }
+    if previous_checksums != expected_previous_checksums:
+        raise EvidenceError(
+            f"{kind} previous package checksums differ from the frozen baseline assets"
+        )
+    if previous_manifest_sha256 != baseline_assets["SHA256SUMS.txt"]["sha256"]:
+        raise EvidenceError(
+            f"{kind} previous package manifest differs from the frozen baseline asset"
+        )
     for previous_name, candidate_name in pairs:
         if previous_checksums[previous_name] == packages.checksums[candidate_name]:
             raise EvidenceError(
@@ -664,9 +873,12 @@ def parse_report(
         previous: str | None = None
         previous_checksums: dict[str, str] = {}
     else:
-        _validate_coverage(kind, document)
+        matrix_document = _validate_package_matrix_evidence(
+            kind, document, binding
+        )
+        _validate_coverage(kind, document, matrix_document)
         previous, previous_checksums = _validate_lifecycle(
-            kind, document, binding, packages
+            kind, document, binding, packages, matrix_document
         )
     return ReportEvidence(
         kind,
@@ -681,9 +893,15 @@ def parse_report(
     )
 
 
-LINUX_BASE_PLATFORMS = frozenset({"debian", "ubuntu", "fedora", "alpine"})
-RHEL_PLATFORMS = frozenset({"rhel", "almalinux", "rocky"})
 ARCHITECTURES = frozenset({"amd64"})
+QUALIFICATION_CELL_IDS = tuple(
+    cell.identifier for cell in qualification_matrix.EXPECTED_CELLS
+)
+ALPINE_CELL_IDS = frozenset(
+    cell.identifier
+    for cell in qualification_matrix.EXPECTED_CELLS
+    if cell.family == "apk"
+)
 
 
 def policy_reasons(profile: str, reports: tuple[ReportEvidence, ...]) -> list[str]:
@@ -710,29 +928,23 @@ def policy_reasons(profile: str, reports: tuple[ReportEvidence, ...]) -> list[st
             reasons.append("combined previous package checksum inventory is incomplete")
     linux = by_kind["linux_package_lifecycle"].document["coverage"]
     linux_coordinates = {
-        (item["platform"], item["architecture"]): item["status"]
+        (item["cell_id"], item["architecture"]): item["status"]
         for item in linux["coordinates"]
     }
-    required_base = {(platform, architecture) for platform in LINUX_BASE_PLATFORMS for architecture in ARCHITECTURES}
-    if not required_base.issubset(linux_coordinates):
-        reasons.append("Linux coverage is missing Debian, Ubuntu, Fedora, or Alpine architecture coordinates")
-    chosen_rhel = {
-        platform for platform in RHEL_PLATFORMS if all((platform, arch) in linux_coordinates for arch in ARCHITECTURES)
+    expected_linux_coordinates = {
+        (cell_id, architecture)
+        for cell_id in QUALIFICATION_CELL_IDS
+        for architecture in ARCHITECTURES
     }
-    if len(chosen_rhel) != 1:
+    if set(linux_coordinates) != expected_linux_coordinates:
         reasons.append(
-            "Linux coverage must contain exactly one complete RHEL-compatible AMD64 target"
+            "Linux container coverage must contain exactly the eight frozen AMD64 cells"
         )
-    allowed_linux = LINUX_BASE_PLATFORMS | RHEL_PLATFORMS
-    if any(platform not in allowed_linux or architecture not in ARCHITECTURES for platform, architecture in linux_coordinates):
-        reasons.append("Linux coverage contains an unknown platform or architecture")
-    if len(linux_coordinates) != 5:
-        reasons.append("Linux coverage must contain exactly five required coordinates")
     package_blockers = set(by_kind["linux_package_lifecycle"].blockers)
     alpine_statuses = {
         status
-        for (platform, _), status in linux_coordinates.items()
-        if platform == "alpine"
+        for (cell_id, _), status in linux_coordinates.items()
+        if cell_id in ALPINE_CELL_IDS
     }
     if "SW-PKG-001" in package_blockers and alpine_statuses != {"blocker"}:
         reasons.append("SW-PKG-001 must be bound to the Alpine AMD64 blocker")
@@ -740,8 +952,8 @@ def policy_reasons(profile: str, reports: tuple[ReportEvidence, ...]) -> list[st
         reasons.append("Alpine blocker coverage lacks canonical SW-PKG-001")
     config_statuses = {
         status
-        for (platform, _), status in linux_coordinates.items()
-        if platform != "alpine"
+        for (cell_id, _), status in linux_coordinates.items()
+        if cell_id not in ALPINE_CELL_IDS
     }
     if "SW-CFG-001" in package_blockers and config_statuses != {"blocker"}:
         reasons.append(
@@ -764,6 +976,7 @@ def policy_reasons(profile: str, reports: tuple[ReportEvidence, ...]) -> list[st
                     "previous_version",
                     "candidate_version",
                     "runtime_mode",
+                    "previous_manifest_sha256",
                     "previous_package_checksums",
                 }
             ):
@@ -884,6 +1097,9 @@ def evaluate_gate(
     for report in lifecycle_reports:
         previous_checksums.update(report.previous_checksums)
     passed = not reasons
+    package_report = next(
+        report for report in reports if report.kind == "linux_package_lifecycle"
+    )
     aggregate = {
         "schema_version": SCHEMA_VERSION,
         "profile": args.profile,
@@ -897,7 +1113,13 @@ def evaluate_gate(
             "package_manifest_sha256": packages.sha256,
             "package_checksums": packages.checksums,
             "previous_version": previous_version,
+            "previous_manifest_sha256": package_report.document["lifecycle"][
+                "previous_manifest_sha256"
+            ],
             "previous_package_checksums": previous_checksums,
+            "qualification_matrix": package_report.document[
+                "qualification_matrix"
+            ],
         },
         "reports": {
             report.kind: {
@@ -907,6 +1129,17 @@ def evaluate_gate(
                 "generated_at": report.generated_at.isoformat(),
                 "harness_complete": report.harness_complete,
                 "release_ready": report.release_ready,
+                **(
+                    {
+                        "evidence_kind": report.document["evidence_kind"],
+                        "evidence_scope": report.document["evidence_scope"],
+                        "qualification_matrix": report.document[
+                            "qualification_matrix"
+                        ],
+                    }
+                    if report.kind == "linux_package_lifecycle"
+                    else {}
+                ),
             }
             for report in reports
         },
@@ -959,7 +1192,9 @@ def verify_aggregate(
         or document["reasons"] != []
         or document["allowlisted_findings"] != []
     ):
-        raise EvidenceError("aggregate is not an unqualified release PASS verdict")
+        raise EvidenceError(
+            "aggregate is not an exact container-lifecycle-scoped release gate PASS verdict"
+        )
     generated_at = parse_timestamp(document["generated_at"], "aggregate.generated_at")
     expires_at = parse_timestamp(document["expires_at"], "aggregate.expires_at")
     if generated_at > current + timedelta(seconds=FUTURE_SKEW_SECONDS):

--- a/scripts/ci/release_qualification_gate_test.py
+++ b/scripts/ci/release_qualification_gate_test.py
@@ -9,6 +9,7 @@ import hashlib
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -19,11 +20,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import release_qualification_gate as gate
+import package_qualification_matrix as qualification_matrix
 
 
 class QualificationFixture:
-    version = "v4.02.8"
-    previous_version = "v4.02.7"
+    version = "v4.04.0"
+    previous_version = "v4.03.3"
 
     def __init__(self, root: Path, *, profile: str = "release") -> None:
         self.root = root
@@ -78,6 +80,9 @@ class QualificationFixture:
             f"# Release {self.version}\n\n### TEST\n- qualification\n\n---\n",
             encoding="utf-8",
         )
+        matrix_path = self.repo / gate.QUALIFICATION_MATRIX_PATH
+        matrix_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(qualification_matrix.DEFAULT_MATRIX, matrix_path)
         self._git("add", ".")
         self._git("commit", "-qm", "fixture")
 
@@ -113,13 +118,19 @@ class QualificationFixture:
 
     def lifecycle(self, kind: str) -> dict[str, object]:
         previous_checksums = {
-            name: hashlib.sha256(f"previous:{name}\n".encode()).hexdigest()
-            for name in gate.package_names(self.previous_version)
+            asset.name: asset.sha256
+            for asset in qualification_matrix.EXPECTED_BASELINE_ASSETS
+            if asset.name != "SHA256SUMS.txt"
         }
+        previous_manifest_sha256 = next(
+            asset.sha256
+            for asset in qualification_matrix.EXPECTED_BASELINE_ASSETS
+            if asset.name == "SHA256SUMS.txt"
+        )
         return {
             "previous_version": self.previous_version,
             "candidate_version": self.version,
-            "runtime_mode": "active-real-init",
+            "runtime_mode": "active-container-init",
             "active_service_manager": True,
             "active_postinstall": True,
             "legacy_runtime_retirement": True,
@@ -129,18 +140,43 @@ class QualificationFixture:
             "rollback": True,
             "remove": True,
             "purge": True,
-            "second_restart": True,
+            "second_container_restart": True,
+            "previous_manifest_sha256": previous_manifest_sha256,
             "previous_package_checksums": previous_checksums,
         }
 
     def linux_coordinates(self, *, blocker: bool = False) -> list[dict[str, str]]:
         result = []
-        for platform in ("almalinux", "alpine", "debian", "fedora", "ubuntu"):
+        for cell_id in gate.QUALIFICATION_CELL_IDS:
             status = "blocker" if blocker else "pass"
             result.append(
-                {"platform": platform, "architecture": "amd64", "status": status}
+                {"cell_id": cell_id, "architecture": "amd64", "status": status}
             )
         return result
+
+    def qualification_matrix_binding(self) -> dict[str, str]:
+        payload = (self.repo / gate.QUALIFICATION_MATRIX_PATH).read_bytes()
+        document = qualification_matrix.validate_document(
+            gate.strict_json(payload, "fixture qualification matrix")
+        )
+        return {
+            "matrix_id": str(document["matrix_id"]),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+
+    def evidence_scope(self) -> dict[str, object]:
+        return {
+            "coverage_kind": "container_scenarios_only",
+            "real_host_evidence_included": False,
+            "required_checks_complete": False,
+            "covered_scenarios": [
+                {
+                    "cell_id": cell.identifier,
+                    "scenarios": list(cell.container_scenarios),
+                }
+                for cell in qualification_matrix.EXPECTED_CELLS
+            ],
+        }
 
     def report(self, kind: str, profile: str) -> dict[str, object]:
         blockers = {
@@ -178,6 +214,9 @@ class QualificationFixture:
         return gate.build_bound_report(
             **common,
             coordinates=coordinates,
+            evidence_kind="container-lifecycle",
+            evidence_scope=self.evidence_scope(),
+            qualification_matrix_binding=self.qualification_matrix_binding(),
             lifecycle=self.lifecycle(kind),
         )
 
@@ -234,7 +273,90 @@ class ReleaseQualificationGateTests(unittest.TestCase):
         self.assertTrue(aggregate["release_ready"])
         self.assertEqual(aggregate["bindings"]["commit_sha"], self.fixture.commit)
         self.assertEqual(set(aggregate["reports"]), set(self.fixture.reports))
+        self.assertEqual(
+            aggregate["bindings"]["qualification_matrix"],
+            self.fixture.qualification_matrix_binding(),
+        )
+        self.assertEqual(
+            aggregate["reports"]["linux_package_lifecycle"]["evidence_kind"],
+            "container-lifecycle",
+        )
+        self.assertEqual(
+            aggregate["reports"]["linux_package_lifecycle"]["evidence_scope"],
+            self.fixture.evidence_scope(),
+        )
+        self.assertEqual(
+            aggregate["bindings"]["previous_manifest_sha256"],
+            self.fixture.lifecycle("linux_package_lifecycle")[
+                "previous_manifest_sha256"
+            ],
+        )
         self.assertTrue(self.fixture.args().output.is_file())
+
+    def test_matrix_binding_scope_and_exact_eight_cell_order_are_fail_closed(self) -> None:
+        original = self.fixture.load_report("linux_package_lifecycle")
+        self.assertEqual(
+            [item["cell_id"] for item in original["coverage"]["coordinates"]],
+            list(gate.QUALIFICATION_CELL_IDS),
+        )
+        mutations = {
+            "matrix-id": lambda item: item["qualification_matrix"].__setitem__(
+                "matrix_id", "syswarden-package-qualification/forged"
+            ),
+            "matrix-sha": lambda item: item["qualification_matrix"].__setitem__(
+                "sha256", "0" * 64
+            ),
+            "host-scope": lambda item: item.__setitem__(
+                "evidence_kind", "real-host-lifecycle"
+            ),
+            "host-evidence": lambda item: item["evidence_scope"].__setitem__(
+                "real_host_evidence_included", True
+            ),
+            "required-checks": lambda item: item["evidence_scope"].__setitem__(
+                "required_checks_complete", True
+            ),
+            "coverage-kind": lambda item: item["evidence_scope"].__setitem__(
+                "coverage_kind", "all-required-checks"
+            ),
+            "covered-scenario": lambda item: item["evidence_scope"][
+                "covered_scenarios"
+            ][0]["scenarios"].pop(),
+            "missing-cell": lambda item: item["coverage"]["coordinates"].pop(),
+            "duplicate-cell": lambda item: item["coverage"]["coordinates"][1].__setitem__(
+                "cell_id", item["coverage"]["coordinates"][0]["cell_id"]
+            ),
+            "reordered-cells": lambda item: item["coverage"]["coordinates"].reverse(),
+            "baseline-manifest-digest": lambda item: item["lifecycle"].__setitem__(
+                "previous_manifest_sha256", "0" * 64
+            ),
+            "baseline-package-digest": lambda item: item["lifecycle"][
+                "previous_package_checksums"
+            ].__setitem__(
+                next(iter(item["lifecycle"]["previous_package_checksums"])),
+                "0" * 64,
+            ),
+            "coherent-baseline-replacement": lambda item: (
+                item["lifecycle"].__setitem__(
+                    "previous_manifest_sha256", "1" * 64
+                ),
+                item["lifecycle"].__setitem__(
+                    "previous_package_checksums",
+                    {
+                        name: f"{index + 2:x}" * 64
+                        for index, name in enumerate(
+                            item["lifecycle"]["previous_package_checksums"]
+                        )
+                    },
+                ),
+            ),
+        }
+        for name, mutation in mutations.items():
+            with self.subTest(mutation=name):
+                document = json.loads(json.dumps(original))
+                mutation(document)
+                self.fixture.save_report("linux_package_lifecycle", document)
+                self.assertEvidenceError(self.fixture.args())
+        self.fixture.save_report("linux_package_lifecycle", original)
 
     def test_characterization_accepts_only_the_exact_canonical_allowlist(self) -> None:
         self.fixture.write_reports("characterization")
@@ -414,7 +536,7 @@ class ReleaseQualificationGateTests(unittest.TestCase):
         args.expected_sha = self.fixture._git("rev-parse", "HEAD")
         self.assertEvidenceError(args)
 
-    def test_incomplete_harness_platform_architecture_vm_and_unknown_blocker_block(self) -> None:
+    def test_incomplete_harness_matrix_cell_and_unknown_blocker_block(self) -> None:
         document = self.fixture.load_report("nftables_kernel")
         document["harness_complete"] = False
         self.fixture.save_report("nftables_kernel", document)
@@ -426,8 +548,7 @@ class ReleaseQualificationGateTests(unittest.TestCase):
         document = self.fixture.load_report("linux_package_lifecycle")
         document["coverage"]["coordinates"].pop()
         self.fixture.save_report("linux_package_lifecycle", document)
-        code, _ = gate.run_gate(self.fixture.args(), now=self.fixture.now)
-        self.assertEqual(code, 1)
+        self.assertEvidenceError(self.fixture.args())
 
         self.fixture.write_reports("characterization")
         document = self.fixture.load_report("nftables_kernel")
@@ -459,7 +580,7 @@ class ReleaseQualificationGateTests(unittest.TestCase):
 
     def test_active_runtime_mode_and_every_derived_claim_are_mandatory(self) -> None:
         package = self.fixture.load_report("linux_package_lifecycle")
-        package["lifecycle"]["runtime_mode"] = "offline"
+        package["lifecycle"]["runtime_mode"] = "active-real-init"
         self.fixture.save_report("linux_package_lifecycle", package)
         self.assertEvidenceError(self.fixture.args())
 
@@ -467,6 +588,7 @@ class ReleaseQualificationGateTests(unittest.TestCase):
             "previous_version",
             "candidate_version",
             "runtime_mode",
+            "previous_manifest_sha256",
             "previous_package_checksums",
         }
         for claim in sorted(boolean_claims):

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -899,7 +899,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             with self.subTest(mutation=old), self.assertRaises(AssertionError):
                 assert_contract(self.workflow.replace(old, new, 1))
 
-    def test_three_packages_and_five_native_platforms_are_exact(self) -> None:
+    def test_three_packages_and_eight_native_matrix_cells_are_exact(self) -> None:
         catalog = self.package_qualification_matrix
         cells = catalog["cells"]
         self.assertEqual(catalog["target_release"], "v4.04.0")
@@ -924,10 +924,18 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         )
 
         runtime_platforms = package_lifecycle_lab.DEFAULT_PLATFORMS
-        self.assertEqual(len(runtime_platforms), 5)
+        self.assertEqual(len(runtime_platforms), 8)
         self.assertEqual(
-            tuple(platform.name for platform in runtime_platforms),
-            ("Debian", "Ubuntu", "Fedora", "AlmaLinux", "Alpine"),
+            tuple(platform.cell_id for platform in runtime_platforms),
+            tuple(cell["id"] for cell in cells),
+        )
+        self.assertEqual(
+            tuple(platform.version for platform in runtime_platforms),
+            tuple(cell["version"] for cell in cells),
+        )
+        self.assertEqual(
+            tuple(platform.image for platform in runtime_platforms),
+            tuple(cell["image"] for cell in cells),
         )
         self.assertEqual(
             {platform.distribution for platform in runtime_platforms},
@@ -971,7 +979,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_inventories(self.workflow.replace(removed, "", 1))
 
-    def test_previous_v4028_release_transition_and_asset_ids_are_fail_closed(self) -> None:
+    def test_frozen_previous_release_assets_and_transition_are_fail_closed(self) -> None:
         script = workflow_step_script(
             self.workflow, "Download Latest Public Previous Packages by Asset ID"
         )
@@ -991,6 +999,15 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '"repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"',
             "-H 'Accept: application/octet-stream'",
             '"${asset_state}" != "uploaded"',
+            'baseline_commit="$(jq -er \'.package_sources.baseline.commit\'',
+            'previous_commit="$(git rev-parse --verify "refs/tags/${PREVIOUS_TAG}^{commit}")"',
+            '"${previous_commit}" != "${baseline_commit}"',
+            '"${asset_id}" != "${expected_asset_id}"',
+            '"${asset_size}" != "${expected_asset_size}"',
+            '"${expected_asset_sha256}"',
+            "sha256sum \"${destination}\"",
+            "stat -c '%s' \"${destination}\"",
+            "printf 'commit_sha=%s\\n'",
             'verify-packages',
         ):
             self.assertIn(contract, script)
@@ -1006,6 +1023,21 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             self.assertEqual(expected_assets.count(asset), 1, asset)
         self.assertEqual(script.count("normalize-v4028-linux-packages"), 1)
         self.assertEqual(script.count("verify-packages"), 1)
+        for contract in (
+            '"${previous_commit}" != "${baseline_commit}"',
+            '"${asset_id}" != "${expected_asset_id}"',
+            '"${asset_size}" != "${expected_asset_size}"',
+            '"$(sha256sum "${destination}" | awk \'{print $1}\')" !=',
+        ):
+            with self.subTest(fail_closed_contract=contract), self.assertRaises(
+                AssertionError
+            ):
+                mutated = self.workflow.replace(contract, "false", 1)
+                mutated_script = workflow_step_script(
+                    mutated,
+                    "Download Latest Public Previous Packages by Asset ID",
+                )
+                self.assertIn(contract, mutated_script)
 
     def test_native_runtime_is_isolated_and_has_no_pull_fallback(self) -> None:
         for contract in (
@@ -1074,14 +1106,32 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             "--expected-previous-release-id",
         ):
             self.assertEqual(self.workflow.count(argument), 3, argument)
+        matrix_argument = (
+            '--qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/'
+            'package_qualification_matrix.json"'
+        )
+        self.assertEqual(lifecycle.count(matrix_argument), 2)
+        self.assertEqual(self.workflow.count(matrix_argument), 5)
+        for step_name in (
+            "Build and Verify Bound Laboratory Envelopes",
+            "Enforce Final Release Qualification Verdict",
+            "Require Successful Qualification Before Release Signing",
+        ):
+            self.assertIn(
+                matrix_argument,
+                workflow_step_script(self.workflow, step_name),
+                step_name,
+            )
         provenance = workflow_step_script(
             self.workflow, "Record Qualification Provenance Context"
         )
+        self.assertIn("schema_version: 2", provenance)
         for key in (
             "repository",
             "release_tag",
             "release_sha",
             "previous_tag",
+            "previous_commit_sha",
             "candidate_package_run_id",
             "candidate_package_artifact_id",
             "candidate_package_artifact_name",
@@ -1102,6 +1152,29 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             '("syswarden_" + ($previous_tag | ltrimstr("v")) + "_x86_64.apk")',
         ):
             self.assertIn(exact_name, self.workflow)
+        for matrix_binding in (
+            "$qualification_matrix[0].package_sources.baseline.commit",
+            "$qualification_matrix[0].package_sources.baseline.release_id",
+            "map({name, id}) | sort_by(.name)",
+        ):
+            self.assertIn(matrix_binding, self.workflow)
+        self.assertEqual(self.workflow.count(".schema_version == 2"), 1)
+
+    def test_raw_package_failure_summary_never_claims_global_release_readiness(self) -> None:
+        script = workflow_step_script(
+            self.workflow, "Enforce Final Release Qualification Verdict"
+        )
+        for contract in (
+            'if $label == "package-lifecycle" then null',
+            "container_lifecycle_release_ready",
+            '$report.scope.evidence_kind == "container-lifecycle"',
+            '$report.scope.coverage_kind == "container_scenarios_only"',
+            "$report.scope.real_host_evidence_included == false",
+            "$report.scope.required_checks_complete == false",
+            "$report.scope.covered_scenarios ==",
+            "sha256: $qualification_matrix_sha256",
+        ):
+            self.assertIn(contract, script)
 
     def test_premerge_package_workflow_runs_every_qualification_validator(self) -> None:
         step = workflow_step(


### PR DESCRIPTION
## Summary

- execute the frozen eight-cell AMD64 package qualification matrix in canonical order
- bind raw reports, architecture shards, adapter envelopes and the final gate to the exact matrix ID and Git-blob SHA-256
- attest container distribution ID and bounded VERSION_ID rules while retaining exact OCI repository and digest checks
- bind the v4.03.3 baseline to its tag commit, release ID and four exact GitHub assets by ID, name, size and SHA-256
- expose package lifecycle evidence only as container-lifecycle coverage and prevent a container result from becoming a generic release GO claim
- update the durable qualification schemas and hosted-signing validation fail-closed

## Security boundary

This PR qualifies only the container scenarios declared by each matrix cell. It explicitly records that real-host evidence is not included and that the overall required checks are not complete. VPS installation, upgrade, rollback, reboot and recovery evidence remains a separate post-merge qualification stage.

## Validation

- 255 coordinator, matrix, lab, adapter, gate and workflow tests passed; 2 expected skips
- 102 additional lifecycle and required-check contract tests passed; 6 expected skips
- 56 release-gate tests passed
- independent contract review: GO, no blocker
- Python compilation, workflow YAML parsing, embedded Bash syntax and git diff checks passed
- versionctl confirms this is a non-versioning commit and source remains v4.04.0
- commit efecbc6d0d133033fff66f9636b5a473c9cac2c4 is SSH signed

## Merge condition

Merge only after every required GitHub check is green. After merge, use the new main package artifact for all remaining real-host and updater labs; do not reuse the PR132 artifact because its embedded source identity is older.
