### PR TITLE
Fix : drop query strings from AbuseIPDB report comments

### DIFF
--- a/src/core/syswarden-core/telemetry/abuse.go
+++ b/src/core/syswarden-core/telemetry/abuse.go
@@ -55,6 +55,18 @@ func isKnownIP(ip string) bool {
 	return false
 }
 
+// maxReportedURIPathLength bounds the request path published in an AbuseIPDB comment.
+const maxReportedURIPathLength = 120
+
+// reportedURIPath keeps only the path of a matched request, because the query string
+// carries data belonging to whoever sent it and AbuseIPDB comments are public.
+func reportedURIPath(uri string) string {
+	if idx := strings.IndexByte(uri, '?'); idx != -1 {
+		uri = uri[:idx]
+	}
+	return boundedOSINTText(uri, maxReportedURIPathLength, "/")
+}
+
 // ReportAbuseAsync asynchronously reports a banned IP to AbuseIPDB
 func ReportAbuseAsync(ip, jail, payload string) {
 	abuseOnce.Do(initAbuse)
@@ -116,7 +128,7 @@ func ReportAbuseAsync(ip, jail, payload string) {
 					uri = parts[0]
 				}
 			}
-			comment = fmt.Sprintf("[%s] Attempted Web exploit (%s) on URI '%s' by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), uri, ip)
+			comment = fmt.Sprintf("[%s] Attempted Web exploit (%s) on URI '%s' by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), reportedURIPath(uri), ip)
 		} else {
 			comment = fmt.Sprintf("[%s] Attempted attack (%s) by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), ip)
 		}

--- a/src/core/syswarden-core/telemetry/abuse_test.go
+++ b/src/core/syswarden-core/telemetry/abuse_test.go
@@ -1,0 +1,21 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReportedURIPathDropsQueryAndBoundsLength_SW_KPI_001(t *testing.T) {
+	if got := reportedURIPath("/reset-password?token=RESET-TOKEN&email=jane%40example.com"); got != "/reset-password" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+	if got := reportedURIPath("/" + strings.Repeat("a", 200)); len([]rune(got)) != maxReportedURIPathLength {
+		t.Fatalf("reported URI path length = %d", len([]rune(got)))
+	}
+	if got := reportedURIPath("?q=SELECT+*+FROM+orders"); got != "/" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+	if got := reportedURIPath("/a%3Fb"); got != "/a%3Fb" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+}


### PR DESCRIPTION
With `integrations.abuseipdb` on, an L7 ban publishes a comment like this one, and AbuseIPDB comments are public and permanent:

```
[2026-08-29 10:00:02] Attempted Web exploit (SQLI) on URI '/reset-password?token=RESET-TOKEN&email=jane%40example.com' by IP 203.0.113.7 (Reported by SysWarden ...)
```

Query strings carry session and reset tokens, and the rules match anywhere in the log line - the referer included - so the person whose data gets published isnt always the attacker. After this change the same ban reads:

```
[2026-08-29 10:00:02] Attempted Web exploit (SQLI) on URI '/reset-password' by IP 203.0.113.7 (Reported by SysWarden ...)
```

The path still says what was hit, and it lines the L7 comments up with the SSH and port-scan ones, which only ever publish a port number. Length is capped too, reusing the bounder already in the telemetry package.

AbuseIPDB is the only place the raw log line leaves the box as far as I can see - the webhooks only get IP, jail and action - so I think thats all of it.

The test came out longer than the fix. `gofmt`, `go vet`, `go test` and `go test -race` are all green on `syswarden-core`.

Fixes #134
