### PR TITLE
Fix : scope HTTP exploit detection and redact AbuseIPDB reports

### DIFF
--- a/src/core/syswarden-core/engine/ahocorasick.go
+++ b/src/core/syswarden-core/engine/ahocorasick.go
@@ -24,6 +24,7 @@ type RuleDef struct {
 	Pattern            string   `json:"pattern,omitempty"`
 	Patterns           []string `json:"patterns,omitempty"`
 	Service            string   `json:"service"`
+	MatchScope         string   `json:"match_scope,omitempty"`
 	Action             string   `json:"action,omitempty"` // "ban" (default), "detect", or "track"
 	Threshold          int      `json:"threshold,omitempty"`
 	Window             int      `json:"window,omitempty"`
@@ -41,9 +42,10 @@ type Config struct {
 }
 
 type Engine struct {
-	ahoMachine    *goahocorasick.Automaton
-	patternToRule map[string][]RuleDef
-	regexRules    []compiledRegex
+	ahoMachine         *goahocorasick.Automaton
+	patternToRule      map[string][]RuleDef
+	regexRules         []compiledRegex
+	requestTargetRules bool
 
 	ahoCount             int
 	defaultThreshold     int
@@ -61,6 +63,13 @@ type Engine struct {
 	catalogDigest        string
 	riskModelVersion     string
 }
+
+const (
+	matchScopeRecord        = "record"
+	matchScopeRequestTarget = "request-target"
+	maxRequestTargetBytes   = 16 * 1024
+	maxScopedRecordBytes    = 1 << 20
+)
 
 // IngressSource identifies an independent delivery path for the same physical
 // log record. It is intentionally limited to the two collectors owned by the
@@ -222,6 +231,17 @@ func normalizeAndValidateRules(config *Config, defaultThreshold, defaultWindow i
 			return fmt.Errorf("rule ID %q is duplicated", rule.ID)
 		}
 		seen[rule.ID] = struct{}{}
+		if rule.MatchScope == "" {
+			rule.MatchScope = matchScopeRecord
+		}
+		switch rule.MatchScope {
+		case matchScopeRecord, matchScopeRequestTarget:
+		default:
+			return fmt.Errorf("rule %q has unsupported match scope %q", rule.ID, rule.MatchScope)
+		}
+		if rule.MatchScope == matchScopeRequestTarget && rule.TrustedHostCapture {
+			return fmt.Errorf("request-target rule %q cannot trust a host capture", rule.ID)
+		}
 		switch rule.Type {
 		case "regex", "aho-corasick":
 		default:
@@ -313,6 +333,9 @@ func NewEngine(configFile string, defaultThreshold, defaultWindow int) (*Engine,
 	ahoBuilder := goahocorasick.NewBuilder()
 
 	for _, rule := range config.Rules {
+		if rule.MatchScope == matchScopeRequestTarget {
+			e.requestTargetRules = true
+		}
 		switch rule.Type {
 		case "aho-corasick":
 			if rule.TrustedHostCapture {
@@ -368,41 +391,61 @@ func (e *Engine) RuleCount() int {
 
 func (e *Engine) Scan(logLine string) *Match {
 	structuralHost := authoritativeRecordHost(logLine)
+	requestTarget, hasRequestTarget := "", false
+	if e.requestTargetRules {
+		requestTarget, hasRequestTarget = extractRequestTarget(logLine)
+	}
 	type regexCandidate struct {
 		match *Match
 		start int
 	}
 	regexCandidates := make([]regexCandidate, 0, len(e.regexRules))
-	for _, rr := range e.regexRules {
-		if indexes := rr.re.FindStringSubmatchIndex(logLine); indexes != nil {
-			hostIdx := rr.re.SubexpIndex("host")
-			host := structuralHost
-			if !host.IsValid() && hostIdx >= 0 && rr.def.TrustedHostCapture {
-				indexOffset := 2 * hostIdx
-				if indexOffset+1 >= len(indexes) || indexes[indexOffset] < 0 || indexes[indexOffset+1] < 0 {
-					continue
-				}
-				var ok bool
-				host, ok = canonicalSourceAddr(logLine[indexes[indexOffset]:indexes[indexOffset+1]])
-				if !ok {
-					continue
-				}
+	addRegexCandidate := func(rr compiledRegex, content string) {
+		indexes := rr.re.FindStringSubmatchIndex(content)
+		if indexes == nil {
+			return
+		}
+		hostIdx := rr.re.SubexpIndex("host")
+		host := structuralHost
+		if !host.IsValid() && hostIdx >= 0 && rr.def.TrustedHostCapture {
+			indexOffset := 2 * hostIdx
+			if indexOffset+1 >= len(indexes) || indexes[indexOffset] < 0 || indexes[indexOffset+1] < 0 {
+				return
 			}
+			var ok bool
+			host, ok = canonicalSourceAddr(content[indexes[indexOffset]:indexes[indexOffset+1]])
+			if !ok {
+				return
+			}
+		}
 
-			regexCandidates = append(regexCandidates, regexCandidate{match: &Match{
-				RuleID:           rr.def.ID,
-				Payload:          logLine,
-				Service:          rr.def.Service,
-				Action:           rr.def.Action,
-				Threshold:        rr.def.Threshold,
-				Window:           rr.def.Window,
-				RiskCategory:     rr.def.RiskCategory,
-				CatalogVersion:   e.catalogVersion,
-				CatalogDigest:    e.catalogDigest,
-				RiskModelVersion: e.riskModelVersion,
-				MetricEligible:   rr.def.MetricEligible,
-				Host:             host,
-			}, start: indexes[0]})
+		regexCandidates = append(regexCandidates, regexCandidate{match: &Match{
+			RuleID:           rr.def.ID,
+			Payload:          logLine,
+			Service:          rr.def.Service,
+			Action:           rr.def.Action,
+			Threshold:        rr.def.Threshold,
+			Window:           rr.def.Window,
+			RiskCategory:     rr.def.RiskCategory,
+			CatalogVersion:   e.catalogVersion,
+			CatalogDigest:    e.catalogDigest,
+			RiskModelVersion: e.riskModelVersion,
+			MetricEligible:   rr.def.MetricEligible,
+			Host:             host,
+		}, start: indexes[0]})
+	}
+	for _, rr := range e.regexRules {
+		if rr.def.MatchScope == matchScopeRecord {
+			addRegexCandidate(rr, logLine)
+			continue
+		}
+		if !hasRequestTarget {
+			continue
+		}
+		addRegexCandidate(rr, requestTarget)
+		decodedTarget, err := url.QueryUnescape(requestTarget)
+		if err == nil && decodedTarget != requestTarget {
+			addRegexCandidate(rr, decodedTarget)
 		}
 	}
 
@@ -435,9 +478,12 @@ func (e *Engine) Scan(logLine string) *Match {
 	}
 
 	if e.ahoMachine != nil {
-		addMatches := func(content []byte) {
+		addMatches := func(content []byte, scope string) {
 			for _, ahoMatch := range e.ahoMachine.FindAllOverlapping(content) {
 				for _, rule := range e.patternToRule[string(e.ahoMachine.Pattern(ahoMatch.PatternID))] {
+					if rule.MatchScope != scope {
+						continue
+					}
 					consider(&Match{
 						RuleID:           rule.ID,
 						Payload:          logLine,
@@ -456,10 +502,17 @@ func (e *Engine) Scan(logLine string) *Match {
 			}
 		}
 
-		addMatches([]byte(logLine))
+		addMatches([]byte(logLine), matchScopeRecord)
 		decodedLine, err := url.QueryUnescape(logLine)
 		if err == nil && decodedLine != logLine {
-			addMatches([]byte(decodedLine))
+			addMatches([]byte(decodedLine), matchScopeRecord)
+		}
+		if hasRequestTarget {
+			addMatches([]byte(requestTarget), matchScopeRequestTarget)
+			decodedTarget, err := url.QueryUnescape(requestTarget)
+			if err == nil && decodedTarget != requestTarget {
+				addMatches([]byte(decodedTarget), matchScopeRequestTarget)
+			}
 		}
 	}
 	if best != nil && riskAttribution != nil && riskAttribution.RuleID != best.RuleID {
@@ -727,6 +780,289 @@ func authoritativeRecordHost(logLine string) netip.Addr {
 		return netip.Addr{}
 	}
 	return address.Unmap()
+}
+
+var jsonRequestTargetFieldNames = map[string]struct{}{
+	"path":           {},
+	"uri":            {},
+	"request_uri":    {},
+	"requestURI":     {},
+	"RequestURI":     {},
+	"RequestPath":    {},
+	"request_target": {},
+	"requestTarget":  {},
+	"RequestTarget":  {},
+}
+
+var jsonRequestLineFieldNames = map[string]struct{}{
+	"request":      {},
+	"request_line": {},
+	"RequestLine":  {},
+}
+
+// extractRequestTarget returns only an unambiguous HTTP request-target. It is
+// intentionally strict: scoped immediate-ban rules must not fall back to the
+// complete record when a supported access-log record is malformed or lacks a
+// target.
+func extractRequestTarget(logLine string) (string, bool) {
+	if len(logLine) == 0 || len(logLine) > maxScopedRecordBytes {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(logLine)
+	if trimmed == "" {
+		return "", false
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		return extractTopLevelJSONRequestTarget(trimmed)
+	}
+	if target, ok := extractCommonAccessLogRequestTarget(trimmed); ok {
+		return target, true
+	}
+	return extractPrefixedRequestTarget(trimmed)
+}
+
+// extractCommonAccessLogRequestTarget accepts the Apache/Nginx common and
+// combined access-log prefix:
+//
+//	host ident user [timestamp] "METHOD request-target HTTP/version" status bytes
+//
+// The request field is consumed at its structural position, so later quoted
+// Referer and User-Agent fields can never be mistaken for request data.
+func extractCommonAccessLogRequestTarget(logLine string) (string, bool) {
+	position := 0
+	host, ok := consumeAccessLogToken(logLine, &position)
+	if !ok {
+		return "", false
+	}
+	if _, valid := canonicalSourceAddr(host); !valid {
+		return "", false
+	}
+	if _, ok := consumeAccessLogToken(logLine, &position); !ok {
+		return "", false
+	}
+	if _, ok := consumeAccessLogToken(logLine, &position); !ok {
+		return "", false
+	}
+	consumeAccessLogWhitespace(logLine, &position)
+	if position >= len(logLine) || logLine[position] != '[' {
+		return "", false
+	}
+	timestampEnd := strings.IndexByte(logLine[position+1:], ']')
+	if timestampEnd < 0 || timestampEnd > 128 {
+		return "", false
+	}
+	position += timestampEnd + 2
+	if !consumeAccessLogWhitespace(logLine, &position) || position >= len(logLine) || logLine[position] != '"' {
+		return "", false
+	}
+	position++
+	requestEnd := strings.IndexByte(logLine[position:], '"')
+	if requestEnd < 0 || requestEnd > maxRequestTargetBytes+64 {
+		return "", false
+	}
+	requestLine := logLine[position : position+requestEnd]
+	position += requestEnd + 1
+	target, ok := parseHTTPRequestLine(requestLine)
+	if !ok {
+		return "", false
+	}
+	if !consumeAccessLogWhitespace(logLine, &position) {
+		return "", false
+	}
+	status, ok := consumeAccessLogToken(logLine, &position)
+	if !ok || len(status) != 3 || !allASCIIDigits(status) {
+		return "", false
+	}
+	size, ok := consumeAccessLogToken(logLine, &position)
+	if !ok || size != "-" && !allASCIIDigits(size) {
+		return "", false
+	}
+	return target, true
+}
+
+// extractPrefixedRequestTarget preserves the compact access-record form used
+// by direct collectors and existing integrations: host METHOD target HTTP/x.
+func extractPrefixedRequestTarget(logLine string) (string, bool) {
+	fields := strings.Fields(logLine)
+	if len(fields) < 4 || !isAccessLogSource(fields[0]) {
+		return "", false
+	}
+	return parseHTTPRequestLine(strings.Join(fields[1:4], " "))
+}
+
+func isAccessLogSource(value string) bool {
+	if _, ok := canonicalSourceAddr(value); ok {
+		return true
+	}
+	addressPort, err := netip.ParseAddrPort(value)
+	if err != nil {
+		return false
+	}
+	_, ok := canonicalSourceAddr(addressPort.Addr().String())
+	return ok && addressPort.Port() != 0
+}
+
+func consumeAccessLogToken(input string, position *int) (string, bool) {
+	consumeAccessLogWhitespace(input, position)
+	if *position >= len(input) {
+		return "", false
+	}
+	start := *position
+	for *position < len(input) {
+		switch input[*position] {
+		case ' ', '\t', '\r', '\n':
+			return input[start:*position], *position > start
+		default:
+			(*position)++
+		}
+	}
+	return input[start:*position], *position > start
+}
+
+func consumeAccessLogWhitespace(input string, position *int) bool {
+	start := *position
+	for *position < len(input) && (input[*position] == ' ' || input[*position] == '\t') {
+		(*position)++
+	}
+	return *position > start
+}
+
+func parseHTTPRequestLine(requestLine string) (string, bool) {
+	if len(requestLine) == 0 || len(requestLine) > maxRequestTargetBytes+64 || strings.ContainsAny(requestLine, "\t\r\n") {
+		return "", false
+	}
+	parts := strings.Split(requestLine, " ")
+	if len(parts) != 3 || !validHTTPMethod(parts[0]) || !validHTTPVersion(parts[2]) || !validRequestTarget(parts[1]) {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func validHTTPMethod(method string) bool {
+	if len(method) == 0 || len(method) > 32 {
+		return false
+	}
+	for index := 0; index < len(method); index++ {
+		character := method[index]
+		if character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' || character >= '0' && character <= '9' {
+			continue
+		}
+		switch character {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func validHTTPVersion(version string) bool {
+	if !strings.HasPrefix(version, "HTTP/") {
+		return false
+	}
+	number := strings.TrimPrefix(version, "HTTP/")
+	if number == "" {
+		return false
+	}
+	dotSeen := false
+	for index := 0; index < len(number); index++ {
+		if number[index] == '.' && !dotSeen && index > 0 && index+1 < len(number) {
+			dotSeen = true
+			continue
+		}
+		if number[index] < '0' || number[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func validRequestTarget(target string) bool {
+	if len(target) == 0 || len(target) > maxRequestTargetBytes {
+		return false
+	}
+	for index := 0; index < len(target); index++ {
+		if target[index] <= ' ' || target[index] == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func allASCIIDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := 0; index < len(value); index++ {
+		if value[index] < '0' || value[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func extractTopLevelJSONRequestTarget(logLine string) (string, bool) {
+	decoder := json.NewDecoder(strings.NewReader(logLine))
+	opening, err := decoder.Token()
+	if err != nil || opening != json.Delim('{') {
+		return "", false
+	}
+
+	seen := make(map[string]struct{})
+	candidate := ""
+	hasCandidate := false
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return "", false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return "", false
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return "", false
+		}
+		seen[key] = struct{}{}
+
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return "", false
+		}
+		_, directTarget := jsonRequestTargetFieldNames[key]
+		_, requestLine := jsonRequestLineFieldNames[key]
+		if !directTarget && !requestLine {
+			continue
+		}
+		var encoded string
+		if err := json.Unmarshal(value, &encoded); err != nil {
+			return "", false
+		}
+		target := encoded
+		if requestLine {
+			var valid bool
+			target, valid = parseHTTPRequestLine(encoded)
+			if !valid {
+				return "", false
+			}
+		} else if !validRequestTarget(target) {
+			return "", false
+		}
+		if hasCandidate && candidate != target {
+			return "", false
+		}
+		candidate = target
+		hasCandidate = true
+	}
+
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return "", false
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return "", false
+	}
+	return candidate, hasCandidate
 }
 
 // EvaluateThreshold returns true if the IP has reached the limit and should be banned

--- a/src/core/syswarden-core/engine/ahocorasick_fuzz_test.go
+++ b/src/core/syswarden-core/engine/ahocorasick_fuzz_test.go
@@ -23,6 +23,10 @@ func FuzzEngineNetworkAndURLInput(f *testing.F) {
 		"Failed password for root from 999.0.2.44 port 22",
 		"GET /..%2Fetc%2Fpasswd HTTP/1.1",
 		"GET /..%ZZetc%2Fpasswd HTTP/1.1",
+		`198.51.100.8 - - [31/Aug/2026:08:00:00 +0200] "GET /?q=SLEEP(5) HTTP/1.1" 403 0 "-" "safe"`,
+		`198.51.100.8 - - [31/Aug/2026:08:00:00 +0200] "GET /safe HTTP/1.1" 200 0 "SLEEP(5)" "php://filter"`,
+		`{"client_ip":"198.51.100.8","path":"/?q=SLEEP(5)"}`,
+		`{"client_ip":"198.51.100.8","path":"/safe","request_uri":"/php://filter"}`,
 		"scanner user-agent sqlmap",
 		"\x00\xff%00%ff",
 	}
@@ -93,6 +97,14 @@ func newFuzzEngine(f *testing.F) *Engine {
       "type": "aho-corasick",
       "patterns": ["../etc/passwd", "sqlmap"],
       "service": "http",
+      "action": "ban"
+    },
+    {
+      "id": "scoped-probe",
+      "type": "aho-corasick",
+      "patterns": ["SLEEP(", "php://filter"],
+      "service": "http",
+      "match_scope": "request-target",
       "action": "ban"
     }
   ]

--- a/src/core/syswarden-core/engine/request_target_scope_test.go
+++ b/src/core/syswarden-core/engine/request_target_scope_test.go
@@ -1,0 +1,294 @@
+package engine
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newRequestTargetScopeTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "signatures.json")
+	config := `{
+  "rules": [
+    {
+      "id": "sqli",
+      "type": "aho-corasick",
+      "patterns": ["UNION SELECT", "SLEEP("],
+      "service": "http",
+      "match_scope": "request-target"
+    },
+    {
+      "id": "lfi-advanced",
+      "type": "aho-corasick",
+      "patterns": ["/etc/passwd", "php://filter"],
+      "service": "http",
+      "match_scope": "request-target"
+    },
+    {
+      "id": "scoped-regex",
+      "type": "regex",
+      "pattern": "WAITFOR DELAY",
+      "service": "http",
+      "match_scope": "request-target",
+      "action": "detect"
+    },
+    {
+      "id": "header-oriented",
+      "type": "aho-corasick",
+      "patterns": ["HeaderCanary"],
+      "service": "http",
+      "action": "detect"
+    }
+  ]
+}`
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	detector, err := NewEngine(configPath, 5, 60)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+	return detector
+}
+
+func TestRequestTargetScopeExcludesCombinedLogHeaders(t *testing.T) {
+	detector := newRequestTargetScopeTestEngine(t)
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "SQLi in Referer",
+			line: `198.51.100.40 - - [31/Aug/2026:08:00:00 +0200] "GET /safe HTTP/1.1" 200 123 "https://example.test/?q=UNION+SELECT" "Mozilla/5.0"`,
+		},
+		{
+			name: "SQLi in User-Agent",
+			line: `198.51.100.41 - - [31/Aug/2026:08:00:01 +0200] "GET /safe HTTP/1.1" 200 123 "-" "scanner SLEEP(5)"`,
+		},
+		{
+			name: "LFI in Referer",
+			line: `198.51.100.42 - - [31/Aug/2026:08:00:02 +0200] "GET /safe HTTP/1.1" 200 123 "https://example.test/%2Fetc%2Fpasswd" "Mozilla/5.0"`,
+		},
+		{
+			name: "LFI in User-Agent",
+			line: `198.51.100.43 - - [31/Aug/2026:08:00:03 +0200] "GET /safe HTTP/1.1" 200 123 "-" "php://filter/convert.base64-encode"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if match := detector.Scan(test.line); match != nil {
+				t.Fatalf("header-only attack matched scoped rule: %#v", match)
+			}
+		})
+	}
+}
+
+func TestRequestTargetScopeMatchesRawAndDecodedTargets(t *testing.T) {
+	detector := newRequestTargetScopeTestEngine(t)
+	tests := []struct {
+		name     string
+		line     string
+		wantRule string
+	}{
+		{
+			name:     "Apache raw SQLi",
+			line:     `198.51.100.50 - - [31/Aug/2026:08:10:00 +0200] "GET /search?q=SLEEP(5) HTTP/1.1" 403 12`,
+			wantRule: "sqli",
+		},
+		{
+			name:     "Nginx percent-encoded SQLi",
+			line:     `198.51.100.51 - - [31/Aug/2026:08:10:01 +0200] "GET /search?q=UNION%20SELECT HTTP/1.1" 403 12 "-" "curl/8"`,
+			wantRule: "sqli",
+		},
+		{
+			name:     "Nginx form-encoded SQLi",
+			line:     `198.51.100.52 - - [31/Aug/2026:08:10:02 +0200] "GET /search?q=UNION+SELECT HTTP/2.0" 403 12 "-" "curl/8"`,
+			wantRule: "sqli",
+		},
+		{
+			name:     "Apache raw LFI",
+			line:     `198.51.100.53 - - [31/Aug/2026:08:10:03 +0200] "GET /../../etc/passwd HTTP/1.0" 404 0`,
+			wantRule: "lfi-advanced",
+		},
+		{
+			name:     "Apache percent-encoded LFI",
+			line:     `198.51.100.54 - - [31/Aug/2026:08:10:04 +0200] "GET /..%2F..%2Fetc%2Fpasswd HTTP/1.1" 404 0`,
+			wantRule: "lfi-advanced",
+		},
+		{
+			name:     "scoped regex decoded target",
+			line:     `198.51.100.55 - - [31/Aug/2026:08:10:05 +0200] "GET /search?q=WAITFOR+DELAY HTTP/1.1" 403 0`,
+			wantRule: "scoped-regex",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			match := detector.Scan(test.line)
+			if match == nil || match.RuleID != test.wantRule {
+				t.Fatalf("Scan() match = %#v, want rule %q", match, test.wantRule)
+			}
+			if match.Payload != test.line {
+				t.Fatalf("Match.Payload = %q, want complete original record", match.Payload)
+			}
+			if match.Host != netip.MustParseAddr(strings.Fields(test.line)[0]) {
+				t.Fatalf("Match.Host = %v, want access-log source", match.Host)
+			}
+		})
+	}
+}
+
+func TestRequestTargetScopeSupportsUnambiguousTopLevelJSON(t *testing.T) {
+	detector := newRequestTargetScopeTestEngine(t)
+	tests := []struct {
+		name     string
+		line     string
+		wantRule string
+	}{
+		{
+			name:     "path raw SQLi",
+			line:     `{"client_ip":"198.51.100.60","path":"/search?q=SLEEP(5)","user_agent":"safe"}`,
+			wantRule: "sqli",
+		},
+		{
+			name:     "path encoded SQLi",
+			line:     `{"remote_ip":"198.51.100.61","path":"/search?q=UNION%20SELECT","referer":"safe"}`,
+			wantRule: "sqli",
+		},
+		{
+			name:     "request URI encoded LFI",
+			line:     `{"ClientHost":"198.51.100.62","request_uri":"/..%2F..%2Fetc%2Fpasswd"}`,
+			wantRule: "lfi-advanced",
+		},
+		{
+			name:     "full request line",
+			line:     `{"ClientAddr":"198.51.100.63","request":"GET /search?q=SLEEP(5) HTTP/3"}`,
+			wantRule: "sqli",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			match := detector.Scan(test.line)
+			if match == nil || match.RuleID != test.wantRule || !match.Host.IsValid() {
+				t.Fatalf("Scan() match = %#v, want %q with authoritative JSON host", match, test.wantRule)
+			}
+		})
+	}
+}
+
+func TestRequestTargetScopeRejectsMissingMalformedAndAmbiguousTargets(t *testing.T) {
+	detector := newRequestTargetScopeTestEngine(t)
+	oversizedTarget := "/" + strings.Repeat("a", maxRequestTargetBytes) + "SLEEP("
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "JSON target missing",
+			line: `{"client_ip":"198.51.100.70","message":"User-Agent SLEEP(5)"}`,
+		},
+		{
+			name: "JSON targets conflict",
+			line: `{"client_ip":"198.51.100.71","path":"/safe","request_uri":"/search?q=SLEEP(5)"}`,
+		},
+		{
+			name: "JSON duplicate target key",
+			line: `{"client_ip":"198.51.100.72","path":"/safe","path":"/search?q=SLEEP(5)"}`,
+		},
+		{
+			name: "JSON target has wrong type",
+			line: `{"client_ip":"198.51.100.73","path":{"raw":"/search?q=SLEEP(5)"}}`,
+		},
+		{
+			name: "JSON trailing text",
+			line: `{"client_ip":"198.51.100.74","path":"/search?q=SLEEP(5)"} trailing`,
+		},
+		{
+			name: "common log missing request",
+			line: `198.51.100.75 - - [31/Aug/2026:08:20:00 +0200] "-" 400 0 "SLEEP(5)" "safe"`,
+		},
+		{
+			name: "common log malformed request spacing",
+			line: `198.51.100.76 - - [31/Aug/2026:08:20:01 +0200] "GET  /search?q=SLEEP(5) HTTP/1.1" 400 0`,
+		},
+		{
+			name: "common log malformed status",
+			line: `198.51.100.77 - - [31/Aug/2026:08:20:02 +0200] "GET /search?q=SLEEP(5) HTTP/1.1" nope 0`,
+		},
+		{
+			name: "request target exceeds bound",
+			line: `198.51.100.78 GET ` + oversizedTarget + ` HTTP/1.1`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if match := detector.Scan(test.line); match != nil {
+				t.Fatalf("malformed or ambiguous target matched: %#v", match)
+			}
+		})
+	}
+}
+
+func TestRecordScopeRemainsBackwardCompatibleForHeaderRules(t *testing.T) {
+	detector := newRequestTargetScopeTestEngine(t)
+	line := `198.51.100.80 - - [31/Aug/2026:08:30:00 +0200] "GET /safe HTTP/1.1" 200 12 "-" "HeaderCanary"`
+	match := detector.Scan(line)
+	if match == nil || match.RuleID != "header-oriented" || match.Action != "detect" {
+		t.Fatalf("record-scoped header rule did not retain legacy behavior: %#v", match)
+	}
+}
+
+func TestProductionOverlappingSQLiAndLFIHeaderRulesAreScoped(t *testing.T) {
+	detector := newProductionTestEngine(t)
+	tests := []string{
+		`198.51.100.81 - - [31/Aug/2026:08:31:00 +0200] "GET /safe HTTP/1.1" 200 12 "https://example.test/?q=UNION+ALL+SELECT" "safe"`,
+		`198.51.100.82 - - [31/Aug/2026:08:31:01 +0200] "GET /safe HTTP/1.1" 200 12 "-" "scanner /etc/passwd"`,
+	}
+	for _, line := range tests {
+		if match := detector.Scan(line); match != nil {
+			t.Fatalf("production target-oriented rule matched an HTTP header: %#v", match)
+		}
+	}
+}
+
+func TestProductionHeaderOrientedRuleRetainsRecordScope(t *testing.T) {
+	detector := newProductionTestEngine(t)
+	line := `198.51.100.83 - - [31/Aug/2026:08:32:00 +0200] "GET /safe HTTP/1.1" 200 12 "-" "GPTBot"`
+	match := detector.Scan(line)
+	if match == nil || match.RuleID != "aibots" {
+		t.Fatalf("production header-oriented rule lost record scope: %#v", match)
+	}
+}
+
+func TestMatchScopeCatalogValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		catalog string
+	}{
+		{
+			name:    "unknown scope",
+			catalog: `{"rules":[{"id":"bad","type":"aho-corasick","patterns":["x"],"service":"http","match_scope":"headers"}]}`,
+		},
+		{
+			name:    "scoped trusted host capture",
+			catalog: `{"rules":[{"id":"bad","type":"regex","pattern":"^GET / from <HOST>$","service":"http","match_scope":"request-target","trusted_host_capture":true}]}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "signatures.json")
+			if err := os.WriteFile(path, []byte(test.catalog), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewEngine(path, 5, 60); err == nil {
+				t.Fatal("NewEngine() accepted an invalid match scope")
+			}
+		})
+	}
+}

--- a/src/core/syswarden-core/network/waap_request_target_linux_test.go
+++ b/src/core/syswarden-core/network/waap_request_target_linux_test.go
@@ -1,0 +1,188 @@
+//go:build linux
+
+package network
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"syswarden-core/engine"
+	corelogger "syswarden-core/logger"
+)
+
+func newWAAPRequestTargetTestEngine(t *testing.T) *engine.Engine {
+	t.Helper()
+	directory := t.TempDir()
+	signaturesPath := filepath.Join(directory, "signatures.json")
+	signatures := `{
+  "rules": [
+    {
+      "id": "waap-scoped-sqli",
+      "type": "aho-corasick",
+      "patterns": ["UNION SELECT"],
+      "service": "http",
+      "match_scope": "request-target",
+      "action": "ban"
+    },
+    {
+      "id": "waap-scoped-lfi",
+      "type": "aho-corasick",
+      "patterns": ["/../etc/passwd"],
+      "service": "http",
+      "match_scope": "request-target",
+      "action": "ban"
+    }
+  ]
+}`
+	if err := os.WriteFile(signaturesPath, []byte(signatures), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	detector, err := engine.NewEngine(signaturesPath, 1, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return detector
+}
+
+func newWAAPRequestTargetTestBoundary(
+	detector *engine.Engine,
+	manager *recordingWAAPFirewall,
+	eventLogger *corelogger.Logger,
+	mode string,
+) *WAAPEngine {
+	return &WAAPEngine{
+		config:                  WAAPConfig{Mode: mode},
+		fw:                      manager,
+		logger:                  eventLogger,
+		engine:                  detector,
+		localInterfaceAddresses: func() ([]netip.Addr, error) { return nil, nil },
+		protectedHAPeers:        func() ([]netip.Prefix, error) { return nil, nil },
+		isWhitelisted:           func(string) (bool, error) { return false, nil },
+	}
+}
+
+func recordedWAAPRequestTargetBans(manager *recordingWAAPFirewall) []string {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return append([]string(nil), manager.banned...)
+}
+
+func assertWAAPRequestTargetNoEnforcementOrTelemetry(t *testing.T, line string) {
+	t.Helper()
+	detector := newWAAPRequestTargetTestEngine(t)
+
+	auditManager := &recordingWAAPFirewall{}
+	telemetryPath := filepath.Join(t.TempDir(), "waap.json")
+	eventLogger := corelogger.NewLogger(telemetryPath)
+	audit := newWAAPRequestTargetTestBoundary(detector, auditManager, eventLogger, "audit")
+	audit.processLogLine(line)
+	eventLogger.Close()
+	if bans := recordedWAAPRequestTargetBans(auditManager); len(bans) != 0 {
+		t.Fatalf("audit request-target fixture mutated firewall: %v", bans)
+	}
+	telemetry, err := os.ReadFile(telemetryPath) // #nosec G304 -- test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(telemetry)) != "" {
+		t.Fatalf("request-target fixture emitted unexpected WAAP telemetry: %s", telemetry)
+	}
+
+	enforcingManager := &recordingWAAPFirewall{}
+	enforcing := newWAAPRequestTargetTestBoundary(detector, enforcingManager, nil, "enforcing")
+	enforcing.processLogLine(line)
+	if bans := recordedWAAPRequestTargetBans(enforcingManager); len(bans) != 0 {
+		t.Fatalf("request-target fixture caused firewall ban: %v", bans)
+	}
+}
+
+func TestWAAPRequestTargetScopeIgnoresCombinedAndJSONHeaders_SW_WAAP_002(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "combined SQLi in Referer only",
+			line: `8.8.8.8 - - [31/Aug/2026:08:15:00 +0200] "GET /safe HTTP/1.1" 200 123 "https://attacker.invalid/?q=UNION%20SELECT" "Mozilla/5.0"`,
+		},
+		{
+			name: "combined LFI in User-Agent only",
+			line: `8.8.4.4 - - [31/Aug/2026:08:15:01 +0200] "GET /safe HTTP/1.1" 200 123 "https://example.invalid/" "scanner /../etc/passwd"`,
+		},
+		{
+			name: "JSON SQLi in Referer only",
+			line: `{"client_ip":"1.1.1.1","path":"/safe","referer":"https://attacker.invalid/?q=UNION%20SELECT","user_agent":"Mozilla/5.0"}`,
+		},
+		{
+			name: "JSON LFI in User-Agent only",
+			line: `{"client_ip":"9.9.9.9","path":"/safe","referer":"https://example.invalid/","user_agent":"scanner /../etc/passwd"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertWAAPRequestTargetNoEnforcementOrTelemetry(t, test.line)
+		})
+	}
+}
+
+func TestWAAPRequestTargetScopeEnforcesCombinedAndJSONTargets_SW_WAAP_002(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		wantIP string
+	}{
+		{
+			name:   "combined LFI target",
+			line:   `8.8.8.8 - - [31/Aug/2026:08:16:00 +0200] "GET /../etc/passwd HTTP/1.1" 404 0 "-" "Mozilla/5.0"`,
+			wantIP: "8.8.8.8",
+		},
+		{
+			name:   "JSON encoded SQLi target",
+			line:   `{"client_ip":"1.1.1.1","path":"/search?q=UNION%20SELECT","referer":"-","user_agent":"Mozilla/5.0"}`,
+			wantIP: "1.1.1.1",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &recordingWAAPFirewall{}
+			waap := newWAAPRequestTargetTestBoundary(
+				newWAAPRequestTargetTestEngine(t),
+				manager,
+				nil,
+				"enforcing",
+			)
+			waap.processLogLine(test.line)
+			if bans := recordedWAAPRequestTargetBans(manager); strings.Join(bans, ",") != test.wantIP {
+				t.Fatalf("request-target firewall bans = %v, want %s", bans, test.wantIP)
+			}
+		})
+	}
+}
+
+func TestWAAPRequestTargetScopeRejectsMissingOrAmbiguousTargets_SW_WAAP_002(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "combined missing request line",
+			line: `8.8.8.8 - - [31/Aug/2026:08:17:00 +0200] "-" 400 0 "https://attacker.invalid/?q=UNION%20SELECT" "scanner /../etc/passwd"`,
+		},
+		{
+			name: "JSON missing target",
+			line: `{"client_ip":"1.1.1.1","referer":"https://attacker.invalid/?q=UNION%20SELECT","user_agent":"scanner /../etc/passwd"}`,
+		},
+		{
+			name: "JSON conflicting target fields",
+			line: `{"client_ip":"9.9.9.9","path":"/safe","request_uri":"/../etc/passwd","referer":"-","user_agent":"Mozilla/5.0"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertWAAPRequestTargetNoEnforcementOrTelemetry(t, test.line)
+		})
+	}
+}

--- a/src/core/syswarden-core/signatures.json
+++ b/src/core/syswarden-core/signatures.json
@@ -328,7 +328,8 @@
         "DROP TABLE",
         "SELECT * FROM"
       ],
-      "service": "http"
+      "service": "http",
+      "match_scope": "request-target"
     },
     {
       "id": "secretshunter",
@@ -378,7 +379,8 @@
         "/windows/win.ini",
         "/windows/system32"
       ],
-      "service": "http"
+      "service": "http",
+      "match_scope": "request-target"
     },
     {
       "id": "apimapper",
@@ -650,6 +652,7 @@
         "UNION ALL SELECT"
       ],
       "service": "http",
+      "match_scope": "request-target",
       "action": "detect"
     },
     {
@@ -802,6 +805,7 @@
         "etc/shadow"
       ],
       "service": "http",
+      "match_scope": "request-target",
       "action": "detect"
     },
     {

--- a/src/core/syswarden-core/telemetry/abuse.go
+++ b/src/core/syswarden-core/telemetry/abuse.go
@@ -55,6 +55,18 @@ func isKnownIP(ip string) bool {
 	return false
 }
 
+// maxReportedURIPathLength bounds the request path published in an AbuseIPDB comment.
+const maxReportedURIPathLength = 120
+
+// reportedURIPath keeps only the path of a matched request, because the query string
+// carries data belonging to whoever sent it and AbuseIPDB comments are public.
+func reportedURIPath(uri string) string {
+	if idx := strings.IndexByte(uri, '?'); idx != -1 {
+		uri = uri[:idx]
+	}
+	return boundedOSINTText(uri, maxReportedURIPathLength, "/")
+}
+
 // ReportAbuseAsync asynchronously reports a banned IP to AbuseIPDB
 func ReportAbuseAsync(ip, jail, payload string) {
 	abuseOnce.Do(initAbuse)
@@ -116,7 +128,7 @@ func ReportAbuseAsync(ip, jail, payload string) {
 					uri = parts[0]
 				}
 			}
-			comment = fmt.Sprintf("[%s] Attempted Web exploit (%s) on URI '%s' by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), uri, ip)
+			comment = fmt.Sprintf("[%s] Attempted Web exploit (%s) on URI '%s' by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), reportedURIPath(uri), ip)
 		} else {
 			comment = fmt.Sprintf("[%s] Attempted attack (%s) by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), ip)
 		}

--- a/src/core/syswarden-core/telemetry/abuse.go
+++ b/src/core/syswarden-core/telemetry/abuse.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,17 @@ var (
 	abuseEnabled   bool
 	abuseOnce      sync.Once
 )
+
+const (
+	abuseReportURL     = "https://api.abuseipdb.com/api/v2/report"
+	abuseReportTimeout = 10 * time.Second
+)
+
+type abuseReportPayload struct {
+	IP         string `json:"ip"`
+	Categories string `json:"categories"`
+	Comment    string `json:"comment"`
+}
 
 func initAbuse() {
 	abuseEnabled = viper.GetBool("integrations.abuseipdb.enabled")
@@ -55,16 +67,143 @@ func isKnownIP(ip string) bool {
 	return false
 }
 
-// maxReportedURIPathLength bounds the request path published in an AbuseIPDB comment.
-const maxReportedURIPathLength = 120
+func normalizedJail(jail string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(jail)), "l7-")
+}
 
-// reportedURIPath keeps only the path of a matched request, because the query string
-// carries data belonging to whoever sent it and AbuseIPDB comments are public.
-func reportedURIPath(uri string) string {
-	if idx := strings.IndexByte(uri, '?'); idx != -1 {
-		uri = uri[:idx]
+func isL7ExploitJail(jail string) bool {
+	jail = normalizedJail(jail)
+	for _, marker := range []string{
+		"sqli", "injection", "xss", "lfi", "path-traversal", "rce", "cmd-exec",
+		"ssrf", "nosql", "ssti", "jndi", "webshell", "deserialization", "exploit", "api",
+	} {
+		if strings.Contains(jail, marker) {
+			return true
+		}
 	}
-	return boundedOSINTText(uri, maxReportedURIPathLength, "/")
+	return false
+}
+
+// reportedPort returns only a canonical decimal TCP/UDP port. The payload is
+// otherwise untrusted and must never be copied into a public AbuseIPDB comment.
+func reportedPort(payload, fallback string) string {
+	for _, marker := range []string{"port ", "DPT="} {
+		searchFrom := 0
+		for {
+			idx := strings.Index(payload[searchFrom:], marker)
+			if idx == -1 {
+				break
+			}
+			idx += searchFrom + len(marker)
+			fields := strings.Fields(payload[idx:])
+			if len(fields) != 0 {
+				candidate := fields[0]
+				if marker == "port " {
+					candidate = strings.TrimSuffix(candidate, ":")
+				}
+				if port, ok := canonicalPort(candidate); ok {
+					return port
+				}
+			}
+			searchFrom = idx
+			if searchFrom >= len(payload) {
+				break
+			}
+		}
+	}
+	return fallback
+}
+
+func canonicalPort(candidate string) (string, bool) {
+	if candidate == "" || len(candidate) > 5 {
+		return "", false
+	}
+	for _, char := range candidate {
+		if char < '0' || char > '9' {
+			return "", false
+		}
+	}
+	port, err := strconv.Atoi(candidate)
+	if err != nil || port < 1 || port > 65535 {
+		return "", false
+	}
+	return strconv.Itoa(port), true
+}
+
+func abuseCategories(jail string) string {
+	jail = normalizedJail(jail)
+	switch {
+	case jail == "sqli":
+		return "16,21"
+	case jail == "xss", jail == "lfi", jail == "lfi-advanced", jail == "rce",
+		jail == "ssrf", jail == "nosql", jail == "api", jail == "apimapper":
+		return "21"
+	case strings.Contains(jail, "scanner"):
+		return "19"
+	case strings.Contains(jail, "bruteforce"):
+		return "18,21"
+	case strings.Contains(jail, "portscan") || strings.Contains(jail, "catch"):
+		return "14"
+	case strings.Contains(jail, "ssh"):
+		return "18,22"
+	case strings.Contains(jail, "geo") || strings.Contains(jail, "asn"):
+		return "14,15"
+	case isL7ExploitJail(jail):
+		return "21"
+	default:
+		return "14,15,18,21"
+	}
+}
+
+func newAbuseReportPayload(ip, jail, payload string, now time.Time) abuseReportPayload {
+	ts := now.Format("2006-01-02 15:04:05")
+	jailLower := strings.ToLower(jail)
+	var comment string
+
+	switch {
+	case strings.Contains(jailLower, "ssh") || strings.Contains(jailLower, "bruteforce") || strings.Contains(jailLower, "auth"):
+		port := reportedPort(payload, "22")
+		comment = fmt.Sprintf("[%s] Attempted SSH brute-force on port %s by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, port, ip)
+	case strings.Contains(jailLower, "scan") || strings.Contains(jailLower, "zero-trust") || strings.Contains(jailLower, "catch-all"):
+		port := reportedPort(payload, "unknown")
+		comment = fmt.Sprintf("[%s] Attempted port scan on port %s by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, port, ip)
+	case isL7ExploitJail(jail):
+		comment = fmt.Sprintf("[%s] Attempted web exploit (%s; request target redacted) by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), ip)
+	default:
+		comment = fmt.Sprintf("[%s] Attempted attack (%s) by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), ip)
+	}
+
+	return abuseReportPayload{
+		IP:         ip,
+		Categories: abuseCategories(jail),
+		Comment:    comment,
+	}
+}
+
+func newAbuseHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: abuseReportTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func newAbuseReportRequest(ip, jail, payload, apiKey string, now time.Time) (*http.Request, error) {
+	report := newAbuseReportPayload(ip, jail, payload, now)
+	reqBody, err := json.Marshal(report)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, abuseReportURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Key", apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
 }
 
 // ReportAbuseAsync asynchronously reports a banned IP to AbuseIPDB
@@ -88,86 +227,12 @@ func ReportAbuseAsync(ip, jail, payload string) {
 	}
 
 	go func() {
-		ts := time.Now().Format("2006-01-02 15:04:05")
-		j := strings.ToLower(jail)
-		var comment string
-
-		if strings.Contains(j, "ssh") || strings.Contains(j, "bruteforce") || strings.Contains(j, "auth") {
-			port := "22"
-			if idx := strings.Index(payload, "port "); idx != -1 {
-				parts := strings.Split(payload[idx+5:], " ")
-				if len(parts) > 0 {
-					port = strings.Trim(parts[0], ":")
-				}
-			} else if idx := strings.Index(payload, "DPT="); idx != -1 {
-				pStr := payload[idx+4:]
-				if spaceIdx := strings.Index(pStr, " "); spaceIdx != -1 {
-					port = pStr[:spaceIdx]
-				}
-			}
-			comment = fmt.Sprintf("[%s] Attempted SSH brute-force on port %s by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, port, ip)
-		} else if strings.Contains(j, "scan") || strings.Contains(j, "zero-trust") || strings.Contains(j, "catch-all") {
-			port := "unknown"
-			if dptIdx := strings.Index(payload, "DPT="); dptIdx != -1 {
-				pStr := payload[dptIdx+4:]
-				if spaceIdx := strings.Index(pStr, " "); spaceIdx != -1 {
-					port = pStr[:spaceIdx]
-				}
-			}
-			comment = fmt.Sprintf("[%s] Attempted port scan on port %s by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, port, ip)
-		} else if strings.Contains(j, "sqli") || strings.Contains(j, "xss") || strings.Contains(j, "lfi") || strings.Contains(j, "rce") {
-			uri := "/"
-			if idx := strings.Index(payload, "GET "); idx != -1 {
-				parts := strings.Split(payload[idx+4:], " ")
-				if len(parts) > 0 {
-					uri = parts[0]
-				}
-			} else if idx := strings.Index(payload, "POST "); idx != -1 {
-				parts := strings.Split(payload[idx+5:], " ")
-				if len(parts) > 0 {
-					uri = parts[0]
-				}
-			}
-			comment = fmt.Sprintf("[%s] Attempted Web exploit (%s) on URI '%s' by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), reportedURIPath(uri), ip)
-		} else {
-			comment = fmt.Sprintf("[%s] Attempted attack (%s) by IP %s (Reported by SysWarden https://github.com/duggytuxy/syswarden)", ts, strings.ToUpper(jail), ip)
-		}
-
-		// Map jails to categories
-		categories := "14,15,18,21"
-		jailLower := strings.ToLower(jail)
-		if strings.Contains(jailLower, "portscan") || strings.Contains(jailLower, "catch") {
-			categories = "14"
-		} else if strings.Contains(jailLower, "ssh") {
-			categories = "18,22"
-		} else if strings.Contains(jailLower, "geo") || strings.Contains(jailLower, "asn") {
-			categories = "14,15"
-		} else if strings.Contains(jailLower, "l7-sqli") {
-			categories = "16,21"
-		} else if strings.Contains(jailLower, "l7-xss") || strings.Contains(jailLower, "l7-lfi") || strings.Contains(jailLower, "l7-rce") || strings.Contains(jailLower, "l7-ssrf") || strings.Contains(jailLower, "l7-nosql") || strings.Contains(jailLower, "l7-api") {
-			categories = "21"
-		} else if strings.Contains(jailLower, "l7-scanner") {
-			categories = "19"
-		} else if strings.Contains(jailLower, "l7-bruteforce") {
-			categories = "18,21"
-		}
-
-		url := "https://api.abuseipdb.com/api/v2/report"
-		reqBody, _ := json.Marshal(map[string]string{
-			"ip":         ip,
-			"categories": categories,
-			"comment":    comment,
-		})
-
-		req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBody))
+		req, err := newAbuseReportRequest(ip, jail, payload, abuseAPIKey, time.Now())
 		if err != nil {
 			return
 		}
-		req.Header.Set("Key", abuseAPIKey)
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Content-Type", "application/json")
 
-		client := &http.Client{Timeout: 10 * time.Second}
+		client := newAbuseHTTPClient()
 		resp, err := client.Do(req)
 		if err != nil {
 			log.Printf("[AbuseIPDB FAIL] Error: %v", err)

--- a/src/core/syswarden-core/telemetry/abuse_test.go
+++ b/src/core/syswarden-core/telemetry/abuse_test.go
@@ -1,21 +1,163 @@
 package telemetry
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestReportedURIPathDropsQueryAndBoundsLength_SW_KPI_001(t *testing.T) {
-	if got := reportedURIPath("/reset-password?token=RESET-TOKEN&email=jane%40example.com"); got != "/reset-password" {
-		t.Fatalf("reported URI path = %q", got)
+type abuseRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn abuseRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestAbuseReportPayloadNeverPublishesRequestData_SW_KPI_001(t *testing.T) {
+	now := time.Date(2026, time.August, 31, 2, 7, 26, 0, time.UTC)
+	payloads := []struct {
+		name    string
+		payload string
+		canary  string
+	}{
+		{name: "query", payload: `GET /login?token=QUERY-CANARY-901 HTTP/1.1`, canary: "QUERY-CANARY-901"},
+		{name: "path segment", payload: `GET /reset/PATH-CANARY-902/confirm HTTP/1.1`, canary: "PATH-CANARY-902"},
+		{name: "absolute URI userinfo", payload: `GET https://ABSOLUTE-CANARY-903@example.test/private HTTP/1.1`, canary: "ABSOLUTE-CANARY-903"},
+		{name: "unicode", payload: `POST /account/UNICODE-CANARY-904-秘密 HTTP/1.1`, canary: "UNICODE-CANARY-904-秘密"},
+		{name: "control characters", payload: "GET /control/CONTROL-CANARY-905\x00\x1f/private HTTP/1.1", canary: "CONTROL-CANARY-905"},
 	}
-	if got := reportedURIPath("/" + strings.Repeat("a", 200)); len([]rune(got)) != maxReportedURIPathLength {
-		t.Fatalf("reported URI path length = %d", len([]rune(got)))
+
+	var firstJSON string
+	for _, test := range payloads {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := newAbuseReportRequest("192.0.2.44", "sqli", test.payload, "test-api-key", now)
+			if err != nil {
+				t.Fatalf("construct AbuseIPDB request: %v", err)
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read final AbuseIPDB request body: %v", err)
+			}
+			bodyText := string(body)
+			if strings.Contains(bodyText, test.canary) || strings.Contains(bodyText, test.payload) ||
+				strings.Contains(bodyText, `\u0000`) || strings.Contains(bodyText, `\u001f`) ||
+				strings.Contains(bodyText, "test-api-key") {
+				t.Fatalf("final AbuseIPDB JSON leaked request data: %s", bodyText)
+			}
+			if strings.Contains(bodyText, "/login") || strings.Contains(bodyText, "/reset/") || strings.Contains(bodyText, "example.test") || strings.Contains(bodyText, "private") {
+				t.Fatalf("final AbuseIPDB JSON leaked a request target fragment: %s", bodyText)
+			}
+			if req.Method != http.MethodPost || req.URL.String() != abuseReportURL {
+				t.Fatalf("request target = %s %s", req.Method, req.URL)
+			}
+			if req.Header.Get("Key") != "test-api-key" || req.Header.Get("Content-Type") != "application/json" {
+				t.Fatalf("request headers = %#v", req.Header)
+			}
+
+			var report abuseReportPayload
+			if err := json.Unmarshal(body, &report); err != nil {
+				t.Fatalf("decode final AbuseIPDB request body: %v", err)
+			}
+			if !strings.Contains(report.Comment, "request target redacted") {
+				t.Fatalf("comment does not state the privacy boundary: %q", report.Comment)
+			}
+			if report.Categories != "16,21" {
+				t.Fatalf("categories = %q, want 16,21", report.Categories)
+			}
+			if firstJSON == "" {
+				firstJSON = bodyText
+			} else if bodyText != firstJSON {
+				t.Fatalf("request payload changed public JSON:\nfirst: %s\n  got: %s", firstJSON, bodyText)
+			}
+		})
 	}
-	if got := reportedURIPath("?q=SELECT+*+FROM+orders"); got != "/" {
-		t.Fatalf("reported URI path = %q", got)
+}
+
+func TestReportedPortIsStrictAndBounded_SW_KPI_002(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  string
+		fallback string
+		want     string
+	}{
+		{name: "ssh port", payload: "failed login on port 2222: user root", fallback: "22", want: "2222"},
+		{name: "firewall destination", payload: "PROTO=TCP DPT=443 SYN", fallback: "unknown", want: "443"},
+		{name: "canonicalizes leading zeroes", payload: "DPT=00443 ", fallback: "unknown", want: "443"},
+		{name: "zero", payload: "DPT=0 ", fallback: "unknown", want: "unknown"},
+		{name: "above maximum", payload: "DPT=65536 ", fallback: "unknown", want: "unknown"},
+		{name: "negative", payload: "DPT=-1 ", fallback: "unknown", want: "unknown"},
+		{name: "suffix injection", payload: "DPT=22;QUERY-CANARY ", fallback: "unknown", want: "unknown"},
+		{name: "newline injection", payload: "port 2222\nQUERY-CANARY", fallback: "22", want: "2222"},
+		{name: "unicode digits", payload: "DPT=４４３ ", fallback: "unknown", want: "unknown"},
+		{name: "empty", payload: "DPT= ", fallback: "unknown", want: "unknown"},
 	}
-	if got := reportedURIPath("/a%3Fb"); got != "/a%3Fb" {
-		t.Fatalf("reported URI path = %q", got)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := reportedPort(test.payload, test.fallback); got != test.want {
+				t.Fatalf("reportedPort(%q) = %q, want %q", test.payload, got, test.want)
+			}
+		})
+	}
+}
+
+func TestAbuseCategoriesUseRealRuleIDs_SW_KPI_003(t *testing.T) {
+	tests := map[string]string{
+		"sqli":              "16,21",
+		"l7-sqli":           "16,21",
+		"lfi-advanced":      "21",
+		"xss":               "21",
+		"owasp-a03-xss":     "21",
+		"rce":               "21",
+		"php-rce-generic":   "21",
+		"ssrf":              "21",
+		"nosql":             "21",
+		"apimapper":         "21",
+		"nginx-scanner":     "19",
+		"l7-bruteforce":     "18,21",
+		"ssh-auth":          "18,22",
+		"firewall-portscan": "14",
+	}
+
+	for jail, want := range tests {
+		t.Run(jail, func(t *testing.T) {
+			if got := abuseCategories(jail); got != want {
+				t.Fatalf("abuseCategories(%q) = %q, want %q", jail, got, want)
+			}
+		})
+	}
+}
+
+func TestAbuseHTTPClientDoesNotFollowRedirects_SW_KPI_004(t *testing.T) {
+	requests := 0
+	client := newAbuseHTTPClient()
+	client.Transport = abuseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if requests != 1 {
+			t.Fatalf("HTTP client followed redirect to %s", req.URL)
+		}
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Header:     http.Header{"Location": []string{"https://redirected.example.test/collect"}},
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	})
+	resp, err := client.Post(abuseReportURL, "application/json", strings.NewReader(`{"ip":"192.0.2.44"}`))
+	if err != nil {
+		t.Fatalf("post redirecting endpoint: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusTemporaryRedirect)
+	}
+	if requests != 1 {
+		t.Fatalf("transport received %d requests, want 1", requests)
+	}
+	if err := client.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("redirect policy error = %v", err)
 	}
 }

--- a/src/core/syswarden-core/telemetry/abuse_test.go
+++ b/src/core/syswarden-core/telemetry/abuse_test.go
@@ -1,0 +1,21 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReportedURIPathDropsQueryAndBoundsLength_SW_KPI_001(t *testing.T) {
+	if got := reportedURIPath("/reset-password?token=RESET-TOKEN&email=jane%40example.com"); got != "/reset-password" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+	if got := reportedURIPath("/" + strings.Repeat("a", 200)); len([]rune(got)) != maxReportedURIPathLength {
+		t.Fatalf("reported URI path length = %d", len([]rune(got)))
+	}
+	if got := reportedURIPath("?q=SELECT+*+FROM+orders"); got != "/" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+	if got := reportedURIPath("/a%3Fb"); got != "/a%3Fb" {
+		t.Fatalf("reported URI path = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- remove every raw HTTP request target from public AbuseIPDB comments and send fixed redacted wording instead
- scope SQL injection and path traversal signatures to a strictly parsed HTTP request target, excluding Referer and User-Agent
- keep the original record locally for forensic evidence while refusing ambiguous, malformed, missing, or oversized request targets
- preserve detection of genuine raw and URL-decoded attacks in Apache/Nginx common and combined logs, supported top-level JSON records, and the compact collector format
- validate reported ports, correct AbuseIPDB category mapping for actual rule IDs, and refuse HTTP redirects carrying the API key

This branch preserves the signed contribution from @NotAFlightRisk in #135 as its first commit and adds the complete privacy and enforcement boundary in a second verified SSH-signed commit.

## Validation

- complete tests, race detector, and vet for every Go module
- 608 CI script tests passed, with only environment-specific optional skips
- bounded engine fuzz campaign: 100,000 executions
- golangci-lint v1.64.8: clean
- gosec v2.28.0 reviewed gate: 0 findings for linux-core
- nosec baseline gate: exact and unchanged
- CLI process compatibility: 50 cases passed
- documentation truth gate and formatting checks passed

This is a `Fix :` change. The source version remains v4.04.0.

Fixes #134
Fixes #136
Supersedes #135
