### PR TITLE
Fix : bound DEB updater lock contention

### DIFF
--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -129,7 +129,12 @@ func runExternalCommand(ctx context.Context, name string, args ...string) error 
 
 func validateExternalCommand(name string, args []string) error {
 	switch name {
-	case "/usr/bin/apt-get", "/usr/bin/dnf", "/usr/bin/yum":
+	case "/usr/bin/apt-get":
+		if len(args) == 5 && args[0] == "-o" && args[1] == aptDPkgLockTimeoutOption &&
+			args[2] == "install" && args[3] == "-y" && validSecurePackageArgument(args[4]) {
+			return nil
+		}
+	case "/usr/bin/dnf", "/usr/bin/yum":
 		if len(args) == 3 && args[0] == "install" && args[1] == "-y" && validSecurePackageArgument(args[2]) {
 			return nil
 		}

--- a/src/core/syswarden-cli/pkg/system/upgrade_manifest.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade_manifest.go
@@ -27,6 +27,7 @@ const (
 	packageFormatDEB                 = "deb"
 	packageFormatRPM                 = "rpm"
 	packageFormatAPK                 = "apk"
+	aptDPkgLockTimeoutOption         = "DPkg::Lock::Timeout=300"
 	releaseTrustRootsSchema          = "syswarden-release-trust-roots/v1"
 )
 
@@ -433,7 +434,13 @@ func packageFilename(version, format, goarch string) (string, error) {
 
 func (target packageTarget) installArguments(packagePath string) []string {
 	switch target.format {
-	case packageFormatDEB, packageFormatRPM:
+	case packageFormatDEB:
+		// Wait for ordinary apt-daily contention for at most five minutes. The
+		// exact option and value are also enforced by validateExternalCommand;
+		// the updater never removes locks, terminates package-manager processes,
+		// or retries outside its independent installation deadline.
+		return []string{"-o", aptDPkgLockTimeoutOption, "install", "-y", packagePath}
+	case packageFormatRPM:
 		return []string{"install", "-y", packagePath}
 	case packageFormatAPK:
 		// APK repository signing is not provisioned yet. The independent

--- a/src/core/syswarden-cli/pkg/system/upgrade_manifest_test.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade_manifest_test.go
@@ -213,6 +213,31 @@ func TestAPKUnsignedFlagRemainsBehindVerifiedManifestPipeline(t *testing.T) {
 	}
 }
 
+func TestDEBInstallArgumentsUseExactBoundedDPkgLockWait(t *testing.T) {
+	t.Parallel()
+
+	if aptDPkgLockTimeoutOption != "DPkg::Lock::Timeout=300" {
+		t.Fatalf("APT dpkg lock timeout option = %q", aptDPkgLockTimeoutOption)
+	}
+	packagePath := "/var/tmp/syswarden-update-safe/package.deb"
+	arguments := (packageTarget{format: packageFormatDEB}).installArguments(packagePath)
+	if len(arguments) != 5 || arguments[0] != "-o" || arguments[1] != aptDPkgLockTimeoutOption ||
+		arguments[2] != "install" || arguments[3] != "-y" || arguments[4] != packagePath {
+		t.Fatalf("DEB install arguments = %#v", arguments)
+	}
+}
+
+func TestRPMInstallArgumentsRemainUnchanged(t *testing.T) {
+	t.Parallel()
+
+	packagePath := "/var/tmp/syswarden-update-safe/package.rpm"
+	arguments := (packageTarget{format: packageFormatRPM}).installArguments(packagePath)
+	if len(arguments) != 3 || arguments[0] != "install" || arguments[1] != "-y" ||
+		arguments[2] != packagePath {
+		t.Fatalf("RPM install arguments = %#v", arguments)
+	}
+}
+
 func TestDetectPackageTargetRejectsWrongOSArchitectureAndPath(t *testing.T) {
 	t.Parallel()
 

--- a/src/core/syswarden-cli/pkg/system/upgrade_security_test.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade_security_test.go
@@ -403,16 +403,25 @@ func TestExternalCommandContractRejectsUnexpectedArguments(t *testing.T) {
 	t.Parallel()
 
 	validPackage := "/var/tmp/syswarden-update-safe/package.deb"
-	if err := validateExternalCommand("/usr/bin/apt-get", []string{"install", "-y", validPackage}); err != nil {
+	validAPT := []string{"-o", aptDPkgLockTimeoutOption, "install", "-y", validPackage}
+	if err := validateExternalCommand("/usr/bin/apt-get", validAPT); err != nil {
 		t.Fatalf("validateExternalCommand() rejected exact installer contract: %v", err)
 	}
 	invalid := []struct {
 		name string
 		args []string
 	}{
-		{name: "/tmp/apt-get", args: []string{"install", "-y", validPackage}},
-		{name: "/usr/bin/apt-get", args: []string{"install", "-y", "/tmp/package.deb"}},
+		{name: "/tmp/apt-get", args: validAPT},
+		{name: "/usr/bin/apt-get", args: []string{"install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o", "DPkg::Lock::Timeout=0", "install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o", "DPkg::Lock::Timeout=-1", "install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o", "DPkg::Lock::Timeout=301", "install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o=" + aptDPkgLockTimeoutOption, "install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"install", "-y", "-o", aptDPkgLockTimeoutOption, validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o", aptDPkgLockTimeoutOption, "-o", aptDPkgLockTimeoutOption, "install", "-y", validPackage}},
+		{name: "/usr/bin/apt-get", args: []string{"-o", aptDPkgLockTimeoutOption, "install", "-y", "/tmp/package.deb"}},
 		{name: "/usr/bin/apt-get", args: []string{"remove", "-y", validPackage}},
+		{name: "/usr/bin/dnf", args: validAPT},
 		{name: "/sbin/apk", args: []string{"add", "/var/tmp/syswarden-update-safe/package.apk"}},
 		{name: "/usr/sbin/service", args: []string{"syswarden", "stop"}},
 		{name: "/usr/sbin/service", args: []string{"operator-service", "restart"}},
@@ -531,17 +540,18 @@ func TestUpdaterInstallsOnlyVerifiedPackageAndCleansWorkspace(t *testing.T) {
 				return nil
 			}
 			installs.Add(1)
-			if len(args) != 3 || args[0] != "install" || args[1] != "-y" {
+			if len(args) != 5 || args[0] != "-o" || args[1] != aptDPkgLockTimeoutOption ||
+				args[2] != "install" || args[3] != "-y" {
 				t.Fatalf("installer arguments = %#v", args)
 			}
-			content, err := os.ReadFile(args[2])
+			content, err := os.ReadFile(args[4])
 			if err != nil {
 				t.Fatalf("ReadFile(installer package) error = %v", err)
 			}
 			if !bytes.Equal(content, packagePayload) {
 				t.Fatalf("installer package content = %q", content)
 			}
-			info, err := os.Lstat(args[2])
+			info, err := os.Lstat(args[4])
 			if err != nil {
 				t.Fatalf("Lstat(installer package) error = %v", err)
 			}
@@ -557,6 +567,46 @@ func TestUpdaterInstallsOnlyVerifiedPackageAndCleansWorkspace(t *testing.T) {
 	}
 	if installs.Load() != 1 {
 		t.Fatalf("installer was called %d times, want 1", installs.Load())
+	}
+	assertEmptyDirectory(t, tempBase)
+}
+
+func TestUpdaterDoesNotRetryFailedDEBInstallation(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	packagePayload := []byte("verified deb package")
+	manifestBytes := testMarshalManifest(t, testUpdateManifest(t, testUpdateVersion, packagePayload))
+	signature := testSignManifest(privateKey, manifestBytes)
+	client := newUpdaterTestClient(manifestBytes, signature, packagePayload)
+	tempBase := t.TempDir()
+	installFailure := errors.New("dpkg lock wait expired")
+	var installs atomic.Int32
+	u := testUpdater(
+		client,
+		tempBase,
+		"amd64",
+		map[string]ed25519.PublicKey{testReleaseKeyID: publicKey},
+		func(_ context.Context, name string, args ...string) error {
+			if name != "/usr/bin/apt-get" {
+				return nil
+			}
+			installs.Add(1)
+			if len(args) != 5 || args[0] != "-o" || args[1] != "DPkg::Lock::Timeout=300" ||
+				args[2] != "install" || args[3] != "-y" {
+				t.Fatalf("installer arguments = %#v", args)
+			}
+			return installFailure
+		},
+	)
+
+	err = u.run(t.Context())
+	if err == nil || !errors.Is(err, installFailure) || !strings.Contains(err.Error(), "install deb package") {
+		t.Fatalf("updater.run() error = %v, want one wrapped installation failure", err)
+	}
+	if installs.Load() != 1 {
+		t.Fatalf("installer was called %d times after failure, want 1", installs.Load())
 	}
 	assertEmptyDirectory(t, tempBase)
 }


### PR DESCRIPTION
## Summary

- add a fixed five-minute `DPkg::Lock::Timeout` to the authenticated DEB updater installation
- keep the external command allowlist exact: only `-o DPkg::Lock::Timeout=300 install -y <verified package>` is accepted for `/usr/bin/apt-get`
- preserve the existing single-attempt behavior and independent 30-minute installation deadline
- leave DNF, YUM and APK installation contracts unchanged

## Security boundary

The updater does not remove dpkg locks, terminate `apt-daily` or `unattended-upgrades`, add a retry loop, or accept operator-controlled timeout values. Missing, zero, negative, different, reordered, duplicated or alternate option forms fail closed, as do untrusted package paths and executable substitutions.

## Qualification

- complete CLI test suite: pass
- targeted race detector and complete CLI vet: pass
- golangci-lint: clean
- gosec: 0 findings in the changed package
- govulncheck: 0 reachable vulnerabilities
- 608 Python CI tests passed, with 9 expected environment-specific skips
- Debian 13 AMD64 offline syntax check accepted the exact apt invocation
- documentation truth and nosec baseline gates passed
- version contract confirms this non-versioning `Fix :` preserves v4.04.0
- commit `67dbd0f0b49e5fb239da6289ea6d25cb1e02b307` is verified SSH-signed by GitHub

## Qualification sequencing

The package artifact produced from base commit `28d4b940ff91c43ab98df1ef3c06a07d58d8784b` is superseded for release qualification by this change. After merge, every container and VPS laboratory must use one new successful `package.yml` artifact bound to the resulting exact `main` SHA. No existing VPS was modified by this PR.

`README.md` and `changelog.md` remain byte-identical.
