### PR TITLE
Fix : close exact CIS package cleanup

### DIFF
--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -762,6 +762,16 @@ def _generated_cleanup_event_checks(
         "openrc_firewall_enablement",
         "runtime_socket",
         "runtime_lock",
+        "cis_filesystems_absent_after_removal",
+        "cis_filesystems_quarantine_absent",
+        "cis_protocols_absent_after_removal",
+        "cis_protocols_quarantine_absent",
+        "cis_limits_absent_after_removal",
+        "cis_limits_quarantine_absent",
+        "cis_sysctl_absent_after_removal",
+        "cis_sysctl_quarantine_absent",
+        "cis_coredump_absent_after_removal",
+        "cis_coredump_quarantine_absent",
         "rsyslog_antiforging_exact_removed",
         "rsyslog_selinux_provenance_removed",
         "completion_residual",
@@ -5102,6 +5112,26 @@ assert_generated_runtime_artifact_contract() {
     check_absent "${label}.generated.openrc_firewall_enablement" /etc/runlevels/default/syswarden-firewall
     check_absent "${label}.generated.runtime_socket" /run/syswarden.sock
     check_absent "${label}.generated.runtime_lock" /run/syswarden-firewall.lock
+    check_absent "${label}.generated.cis_filesystems_absent_after_removal" \
+        /etc/modprobe.d/syswarden-cis-fs.conf
+    check_absent "${label}.generated.cis_filesystems_quarantine_absent" \
+        /etc/modprobe.d/.syswarden-cis-fs.conf.syswarden-removal-v1
+    check_absent "${label}.generated.cis_protocols_absent_after_removal" \
+        /etc/modprobe.d/syswarden-cis-net.conf
+    check_absent "${label}.generated.cis_protocols_quarantine_absent" \
+        /etc/modprobe.d/.syswarden-cis-net.conf.syswarden-removal-v1
+    check_absent "${label}.generated.cis_limits_absent_after_removal" \
+        /etc/security/limits.d/99-syswarden-cis.conf
+    check_absent "${label}.generated.cis_limits_quarantine_absent" \
+        /etc/security/limits.d/.99-syswarden-cis.conf.syswarden-removal-v1
+    check_absent "${label}.generated.cis_sysctl_absent_after_removal" \
+        /etc/sysctl.d/99-syswarden-cis-level2.conf
+    check_absent "${label}.generated.cis_sysctl_quarantine_absent" \
+        /etc/sysctl.d/.99-syswarden-cis-level2.conf.syswarden-removal-v1
+    check_absent "${label}.generated.cis_coredump_absent_after_removal" \
+        /etc/systemd/coredump.conf.d/99-syswarden.conf
+    check_absent "${label}.generated.cis_coredump_quarantine_absent" \
+        /etc/systemd/coredump.conf.d/.99-syswarden.conf.syswarden-removal-v1
     check_absent "${label}.generated.rsyslog_antiforging_exact_removed" \
         /etc/rsyslog.d/99-syswarden-antiforging.conf
     check_absent "${label}.generated.rsyslog_selinux_provenance_removed" \

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -6781,6 +6781,19 @@ probe
         self.assertIn("remove.final-removal.generated.openrc_webtui", checks)
         self.assertIn("remove.final-removal.generated.runtime_socket", checks)
         self.assertIn("remove.final-removal.generated.runtime_lock", checks)
+        for key in (
+            "cis_filesystems_absent_after_removal",
+            "cis_filesystems_quarantine_absent",
+            "cis_protocols_absent_after_removal",
+            "cis_protocols_quarantine_absent",
+            "cis_limits_absent_after_removal",
+            "cis_limits_quarantine_absent",
+            "cis_sysctl_absent_after_removal",
+            "cis_sysctl_quarantine_absent",
+            "cis_coredump_absent_after_removal",
+            "cis_coredump_quarantine_absent",
+        ):
+            self.assertIn(f"remove.final-removal.generated.{key}", checks)
         self.assertIn(
             "remove.final-removal.generated.rsyslog_antiforging_exact_removed",
             checks,
@@ -7719,6 +7732,19 @@ probe
         self.assertIn("/etc/init.d/syswarden-firewall", script)
         self.assertIn("/etc/bash_completion.d/syswarden", script)
         self.assertIn("/etc/rsyslog.d/99-syswarden-siem.conf", script)
+        for path in (
+            "/etc/modprobe.d/syswarden-cis-fs.conf",
+            "/etc/modprobe.d/.syswarden-cis-fs.conf.syswarden-removal-v1",
+            "/etc/modprobe.d/syswarden-cis-net.conf",
+            "/etc/modprobe.d/.syswarden-cis-net.conf.syswarden-removal-v1",
+            "/etc/security/limits.d/99-syswarden-cis.conf",
+            "/etc/security/limits.d/.99-syswarden-cis.conf.syswarden-removal-v1",
+            "/etc/sysctl.d/99-syswarden-cis-level2.conf",
+            "/etc/sysctl.d/.99-syswarden-cis-level2.conf.syswarden-removal-v1",
+            "/etc/systemd/coredump.conf.d/99-syswarden.conf",
+            "/etc/systemd/coredump.conf.d/.99-syswarden.conf.syswarden-removal-v1",
+        ):
+            self.assertIn(path, removal_assertion)
         seed = script[
             script.index("seed_generated_runtime_artifacts() {") : script.index(
                 "\n}\n\nassert_generated_runtime_artifact_contract() {"

--- a/src/core/syswarden-cli/cmd/removal_prepare.go
+++ b/src/core/syswarden-cli/cmd/removal_prepare.go
@@ -5,6 +5,7 @@ import (
 	"syswarden-cli/pkg/firewall"
 	"syswarden-cli/pkg/integration"
 	"syswarden-cli/pkg/network"
+	"syswarden-cli/pkg/security"
 	"syswarden-cli/pkg/system"
 
 	"github.com/spf13/cobra"
@@ -22,6 +23,8 @@ var removePreparedFirewallRuntimeLock = system.RemovePreparedFirewallRuntimeLock
 var removeOwnedIntegrationArtifactsForRemoval = integration.RemoveOwnedRsyslogArtifactsForPackageRemoval
 var removeExactRuntimeSocketForRemoval = system.RemoveExactRuntimeSocketForPackageRemoval
 var removeOwnedRsyslogSELinuxPolicyForRemoval = integration.RemoveOwnedRsyslogSELinuxPolicyForPackageRemoval
+var requireRemovalTombstoneForCISPolicyRemoval = system.RequireRemovalTombstone
+var removeExactCISHardeningPoliciesForRemoval = security.RemoveExactCISHardeningPoliciesForRemoval
 
 func prepareVerifiedFirewallRemoval() error {
 	if err := beginRemoval(); err != nil {
@@ -82,6 +85,18 @@ func prepareVerifiedFirewallRemoval() error {
 		return fmt.Errorf(
 			"refusing removal after an unrecognized rsyslog package-removal outcome %d; the runtime socket and SELinux policy are retained, and the durable removal barrier is retained",
 			rsyslogOutcome,
+		)
+	}
+	if err := requireRemovalTombstoneForCISPolicyRemoval(); err != nil {
+		return fmt.Errorf(
+			"refusing removal before exact CIS hardening policy cleanup because the durable removal barrier could not be reattested; CIS policies, prepared service artifacts, and runtime lock are retained: %w",
+			err,
+		)
+	}
+	if err := removeExactCISHardeningPoliciesForRemoval(); err != nil {
+		return fmt.Errorf(
+			"refusing removal before exact CIS hardening policy cleanup; the durable removal barrier, prepared service artifacts, and runtime lock are retained for retry: %w",
+			err,
 		)
 	}
 	if err := removePreparedServiceArtifacts(); err != nil {

--- a/src/core/syswarden-cli/cmd/uninstall_test.go
+++ b/src/core/syswarden-cli/cmd/uninstall_test.go
@@ -195,6 +195,8 @@ func TestUninstallRunsHostRemovalOnlyAfterVerifiedFirewallPreparation_SW2_FWBACK
 	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
 	previousSocket := removeExactRuntimeSocketForRemoval
 	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
 	previousRemoveServices := removePreparedServiceArtifacts
 	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
 	previousUninstall := uninstallHostSystem
@@ -207,6 +209,8 @@ func TestUninstallRunsHostRemovalOnlyAfterVerifiedFirewallPreparation_SW2_FWBACK
 		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
 		removeExactRuntimeSocketForRemoval = previousSocket
 		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
 		removePreparedServiceArtifacts = previousRemoveServices
 		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
 		uninstallHostSystem = previousUninstall
@@ -245,6 +249,14 @@ func TestUninstallRunsHostRemovalOnlyAfterVerifiedFirewallPreparation_SW2_FWBACK
 		order = append(order, "rsyslog-selinux-policy-removal")
 		return nil
 	}
+	requireRemovalTombstoneForCISPolicyRemoval = func() error {
+		order = append(order, "tombstone-reattest")
+		return nil
+	}
+	removeExactCISHardeningPoliciesForRemoval = func() error {
+		order = append(order, "cis-hardening-policy-removal")
+		return nil
+	}
 	removePreparedServiceArtifacts = func() error {
 		order = append(order, "service-artifact-removal")
 		return nil
@@ -260,7 +272,7 @@ func TestUninstallRunsHostRemovalOnlyAfterVerifiedFirewallPreparation_SW2_FWBACK
 	if err := uninstallCmd.RunE(uninstallCmd, nil); err != nil {
 		t.Fatalf("verified uninstall: %v", err)
 	}
-	if got := strings.Join(order, ","); got != "tombstone-publish,service-stop,cron-state-removal,wireguard-removal,firewall-cleanup,rsyslog-artifact-removal-and-restart,runtime-socket-removal,rsyslog-selinux-policy-removal,service-artifact-removal,runtime-lock-removal,host-removal" {
+	if got := strings.Join(order, ","); got != "tombstone-publish,service-stop,cron-state-removal,wireguard-removal,firewall-cleanup,rsyslog-artifact-removal-and-restart,runtime-socket-removal,rsyslog-selinux-policy-removal,tombstone-reattest,cis-hardening-policy-removal,service-artifact-removal,runtime-lock-removal,host-removal" {
 		t.Fatalf("uninstall order = %q", got)
 	}
 }
@@ -274,6 +286,8 @@ func TestPackageRemovalUsesVerifiedFirewallPreparationOnly_SW2_FWBACKEND_001(t *
 	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
 	previousSocket := removeExactRuntimeSocketForRemoval
 	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
 	previousRemoveServices := removePreparedServiceArtifacts
 	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
 	t.Cleanup(func() {
@@ -285,6 +299,8 @@ func TestPackageRemovalUsesVerifiedFirewallPreparationOnly_SW2_FWBACKEND_001(t *
 		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
 		removeExactRuntimeSocketForRemoval = previousSocket
 		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
 		removePreparedServiceArtifacts = previousRemoveServices
 		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
 	})
@@ -322,6 +338,14 @@ func TestPackageRemovalUsesVerifiedFirewallPreparationOnly_SW2_FWBACKEND_001(t *
 		order = append(order, "rsyslog-selinux-policy-removal")
 		return nil
 	}
+	requireRemovalTombstoneForCISPolicyRemoval = func() error {
+		order = append(order, "tombstone-reattest")
+		return nil
+	}
+	removeExactCISHardeningPoliciesForRemoval = func() error {
+		order = append(order, "cis-hardening-policy-removal")
+		return nil
+	}
 	removePreparedServiceArtifacts = func() error {
 		order = append(order, "service-artifact-removal")
 		return nil
@@ -333,7 +357,7 @@ func TestPackageRemovalUsesVerifiedFirewallPreparationOnly_SW2_FWBACKEND_001(t *
 	if err := preparePackageRemovalCmd.RunE(preparePackageRemovalCmd, nil); err != nil {
 		t.Fatalf("prepare-package-removal: %v", err)
 	}
-	if got := strings.Join(order, ","); got != "tombstone-publish,service-stop,cron-state-removal,wireguard-removal,firewall-cleanup,rsyslog-artifact-removal-and-restart,runtime-socket-removal,rsyslog-selinux-policy-removal,service-artifact-removal,runtime-lock-removal" {
+	if got := strings.Join(order, ","); got != "tombstone-publish,service-stop,cron-state-removal,wireguard-removal,firewall-cleanup,rsyslog-artifact-removal-and-restart,runtime-socket-removal,rsyslog-selinux-policy-removal,tombstone-reattest,cis-hardening-policy-removal,service-artifact-removal,runtime-lock-removal" {
 		t.Fatalf("package removal preparation order = %q", got)
 	}
 }
@@ -347,6 +371,8 @@ func TestPackageRemovalBranchesOnTypedRsyslogOutcome_SW2_PKG_001(t *testing.T) {
 	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
 	previousSocket := removeExactRuntimeSocketForRemoval
 	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
 	previousRemoveServices := removePreparedServiceArtifacts
 	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
 	t.Cleanup(func() {
@@ -358,6 +384,8 @@ func TestPackageRemovalBranchesOnTypedRsyslogOutcome_SW2_PKG_001(t *testing.T) {
 		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
 		removeExactRuntimeSocketForRemoval = previousSocket
 		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
 		removePreparedServiceArtifacts = previousRemoveServices
 		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
 	})
@@ -385,6 +413,14 @@ func TestPackageRemovalBranchesOnTypedRsyslogOutcome_SW2_PKG_001(t *testing.T) {
 			order = append(order, "forbidden-policy-mutation")
 			return nil
 		}
+		requireRemovalTombstoneForCISPolicyRemoval = func() error {
+			order = append(order, "tombstone-reattest")
+			return nil
+		}
+		removeExactCISHardeningPoliciesForRemoval = func() error {
+			order = append(order, "cis-hardening-policy-removal")
+			return nil
+		}
 		removePreparedServiceArtifacts = func() error {
 			order = append(order, "service-artifact-removal")
 			return nil
@@ -397,7 +433,7 @@ func TestPackageRemovalBranchesOnTypedRsyslogOutcome_SW2_PKG_001(t *testing.T) {
 		if err := prepareVerifiedFirewallRemoval(); err != nil {
 			t.Fatalf("offline-complete removal preparation: %v", err)
 		}
-		if got := strings.Join(order, ","); got != "offline-attestation,service-artifact-removal,runtime-lock-removal" {
+		if got := strings.Join(order, ","); got != "offline-attestation,tombstone-reattest,cis-hardening-policy-removal,service-artifact-removal,runtime-lock-removal" {
 			t.Fatalf("offline-complete order = %q", got)
 		}
 	})
@@ -410,6 +446,8 @@ func TestPackageRemovalBranchesOnTypedRsyslogOutcome_SW2_PKG_001(t *testing.T) {
 		}
 		removeExactRuntimeSocketForRemoval = func() error { laterCalls++; return nil }
 		removeOwnedRsyslogSELinuxPolicyForRemoval = func() error { laterCalls++; return nil }
+		requireRemovalTombstoneForCISPolicyRemoval = func() error { laterCalls++; return nil }
+		removeExactCISHardeningPoliciesForRemoval = func() error { laterCalls++; return nil }
 		removePreparedServiceArtifacts = func() error { laterCalls++; return nil }
 		removePreparedFirewallRuntimeLock = func() error { laterCalls++; return nil }
 
@@ -562,7 +600,7 @@ func TestPackageRemovalKeepsSELinuxPolicyUntilProducerAndSocketTeardownSucceed_S
 	}
 }
 
-func TestPackageRemovalRetainsBarrierWhenRuntimeLockCleanupFails_SW2_PKG_001(t *testing.T) {
+func TestPackageRemovalRefusesCISCleanupWhenTombstoneReattestationFails_SW2_PKG_001(t *testing.T) {
 	previousBegin := beginRemoval
 	previousCron := removeOwnedCronStateForRemoval
 	previousPrepare := prepareFirewallStateForRemoval
@@ -571,6 +609,8 @@ func TestPackageRemovalRetainsBarrierWhenRuntimeLockCleanupFails_SW2_PKG_001(t *
 	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
 	previousSocket := removeExactRuntimeSocketForRemoval
 	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
 	previousRemoveServices := removePreparedServiceArtifacts
 	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
 	t.Cleanup(func() {
@@ -582,6 +622,159 @@ func TestPackageRemovalRetainsBarrierWhenRuntimeLockCleanupFails_SW2_PKG_001(t *
 		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
 		removeExactRuntimeSocketForRemoval = previousSocket
 		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
+		removePreparedServiceArtifacts = previousRemoveServices
+		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
+	})
+
+	sentinel := errors.New("synthetic removal tombstone loss")
+	var order []string
+	beginRemoval = func() error { return nil }
+	prepareFirewallStateForRemoval = func() error { return nil }
+	removeOwnedCronStateForRemoval = func() error { return nil }
+	removeOwnedWireGuardStateForRemoval = func() error { return nil }
+	cleanupFirewallStateForRemoval = func() error { return nil }
+	removeOwnedIntegrationArtifactsForRemoval = func() (integration.RsyslogPackageRemovalOutcome, error) {
+		order = append(order, "rsyslog-restart")
+		return integration.RsyslogPackageRemovalActiveQuiesced, nil
+	}
+	removeExactRuntimeSocketForRemoval = func() error {
+		order = append(order, "runtime-socket")
+		return nil
+	}
+	removeOwnedRsyslogSELinuxPolicyForRemoval = func() error {
+		order = append(order, "rsyslog-selinux-policy")
+		return nil
+	}
+	requireRemovalTombstoneForCISPolicyRemoval = func() error {
+		order = append(order, "tombstone-reattest")
+		return sentinel
+	}
+	removeExactCISHardeningPoliciesForRemoval = func() error {
+		order = append(order, "forbidden-cis-hardening-policy")
+		return nil
+	}
+	removePreparedServiceArtifacts = func() error {
+		order = append(order, "forbidden-service-artifacts")
+		return nil
+	}
+	removePreparedFirewallRuntimeLock = func() error {
+		order = append(order, "forbidden-runtime-lock")
+		return nil
+	}
+
+	err := prepareVerifiedFirewallRemoval()
+	if err == nil || !errors.Is(err, sentinel) ||
+		!strings.Contains(err.Error(), "durable removal barrier could not be reattested") ||
+		!strings.Contains(err.Error(), "CIS policies, prepared service artifacts, and runtime lock are retained") {
+		t.Fatalf("CIS tombstone reattestation refusal = %v", err)
+	}
+	if got := strings.Join(order, ","); got != "rsyslog-restart,runtime-socket,rsyslog-selinux-policy,tombstone-reattest" {
+		t.Fatalf("CIS tombstone reattestation failure order = %q", got)
+	}
+}
+
+func TestPackageRemovalRetainsBarrierWhenCISHardeningPolicyCleanupFails_SW2_PKG_001(t *testing.T) {
+	previousBegin := beginRemoval
+	previousCron := removeOwnedCronStateForRemoval
+	previousPrepare := prepareFirewallStateForRemoval
+	previousWireGuard := removeOwnedWireGuardStateForRemoval
+	previousCleanup := cleanupFirewallStateForRemoval
+	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
+	previousSocket := removeExactRuntimeSocketForRemoval
+	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
+	previousRemoveServices := removePreparedServiceArtifacts
+	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
+	t.Cleanup(func() {
+		beginRemoval = previousBegin
+		removeOwnedCronStateForRemoval = previousCron
+		prepareFirewallStateForRemoval = previousPrepare
+		removeOwnedWireGuardStateForRemoval = previousWireGuard
+		cleanupFirewallStateForRemoval = previousCleanup
+		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
+		removeExactRuntimeSocketForRemoval = previousSocket
+		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
+		removePreparedServiceArtifacts = previousRemoveServices
+		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
+	})
+
+	sentinel := errors.New("synthetic CIS hardening policy cleanup failure")
+	var order []string
+	beginRemoval = func() error { return nil }
+	prepareFirewallStateForRemoval = func() error { return nil }
+	removeOwnedCronStateForRemoval = func() error { return nil }
+	removeOwnedWireGuardStateForRemoval = func() error { return nil }
+	cleanupFirewallStateForRemoval = func() error { return nil }
+	removeOwnedIntegrationArtifactsForRemoval = func() (integration.RsyslogPackageRemovalOutcome, error) {
+		order = append(order, "rsyslog-restart")
+		return integration.RsyslogPackageRemovalActiveQuiesced, nil
+	}
+	removeExactRuntimeSocketForRemoval = func() error {
+		order = append(order, "runtime-socket")
+		return nil
+	}
+	removeOwnedRsyslogSELinuxPolicyForRemoval = func() error {
+		order = append(order, "rsyslog-selinux-policy")
+		return nil
+	}
+	requireRemovalTombstoneForCISPolicyRemoval = func() error {
+		order = append(order, "tombstone-reattest")
+		return nil
+	}
+	removeExactCISHardeningPoliciesForRemoval = func() error {
+		order = append(order, "cis-hardening-policy")
+		return sentinel
+	}
+	removePreparedServiceArtifacts = func() error {
+		order = append(order, "forbidden-service-artifacts")
+		return nil
+	}
+	removePreparedFirewallRuntimeLock = func() error {
+		order = append(order, "forbidden-runtime-lock")
+		return nil
+	}
+
+	err := prepareVerifiedFirewallRemoval()
+	if err == nil || !errors.Is(err, sentinel) ||
+		!strings.Contains(err.Error(), "before exact CIS hardening policy cleanup") ||
+		!strings.Contains(err.Error(), "durable removal barrier") ||
+		!strings.Contains(err.Error(), "retained for retry") {
+		t.Fatalf("CIS hardening policy cleanup refusal = %v", err)
+	}
+	if got := strings.Join(order, ","); got != "rsyslog-restart,runtime-socket,rsyslog-selinux-policy,tombstone-reattest,cis-hardening-policy" {
+		t.Fatalf("CIS hardening policy cleanup failure order = %q", got)
+	}
+}
+
+func TestPackageRemovalRetainsBarrierWhenRuntimeLockCleanupFails_SW2_PKG_001(t *testing.T) {
+	previousBegin := beginRemoval
+	previousCron := removeOwnedCronStateForRemoval
+	previousPrepare := prepareFirewallStateForRemoval
+	previousWireGuard := removeOwnedWireGuardStateForRemoval
+	previousCleanup := cleanupFirewallStateForRemoval
+	previousIntegration := removeOwnedIntegrationArtifactsForRemoval
+	previousSocket := removeExactRuntimeSocketForRemoval
+	previousPolicy := removeOwnedRsyslogSELinuxPolicyForRemoval
+	previousCISTombstone := requireRemovalTombstoneForCISPolicyRemoval
+	previousCISPolicies := removeExactCISHardeningPoliciesForRemoval
+	previousRemoveServices := removePreparedServiceArtifacts
+	previousRemoveRuntimeLock := removePreparedFirewallRuntimeLock
+	t.Cleanup(func() {
+		beginRemoval = previousBegin
+		removeOwnedCronStateForRemoval = previousCron
+		prepareFirewallStateForRemoval = previousPrepare
+		removeOwnedWireGuardStateForRemoval = previousWireGuard
+		cleanupFirewallStateForRemoval = previousCleanup
+		removeOwnedIntegrationArtifactsForRemoval = previousIntegration
+		removeExactRuntimeSocketForRemoval = previousSocket
+		removeOwnedRsyslogSELinuxPolicyForRemoval = previousPolicy
+		requireRemovalTombstoneForCISPolicyRemoval = previousCISTombstone
+		removeExactCISHardeningPoliciesForRemoval = previousCISPolicies
 		removePreparedServiceArtifacts = previousRemoveServices
 		removePreparedFirewallRuntimeLock = previousRemoveRuntimeLock
 	})
@@ -597,6 +790,8 @@ func TestPackageRemovalRetainsBarrierWhenRuntimeLockCleanupFails_SW2_PKG_001(t *
 	}
 	removeExactRuntimeSocketForRemoval = func() error { return nil }
 	removeOwnedRsyslogSELinuxPolicyForRemoval = func() error { return nil }
+	requireRemovalTombstoneForCISPolicyRemoval = func() error { return nil }
+	removeExactCISHardeningPoliciesForRemoval = func() error { return nil }
 	removePreparedServiceArtifacts = func() error { return nil }
 	removePreparedFirewallRuntimeLock = func() error { return sentinel }
 	err := preparePackageRemovalCmd.RunE(preparePackageRemovalCmd, nil)

--- a/src/core/syswarden-cli/pkg/security/cis_linux.go
+++ b/src/core/syswarden-cli/pkg/security/cis_linux.go
@@ -41,6 +41,51 @@ var cisSSHDaemonSignalPaths = []string{
 	"/etc/systemd/system/sockets.target.wants/sshd.socket",
 }
 
+const (
+	cisFilesystemPolicyPath = "/etc/modprobe.d/syswarden-cis-fs.conf"
+	cisFilesystemPolicy     = `# --- SYSWARDEN: CIS Level 2 Filesystem Hardening ---
+install cramfs /bin/true
+install freevxfs /bin/true
+install jffs2 /bin/true
+install hfs /bin/true
+install hfsplus /bin/true
+install squashfs /bin/true
+install udf /bin/true
+`
+	cisNetworkPolicyPath = "/etc/modprobe.d/syswarden-cis-net.conf"
+	cisNetworkPolicy     = `# --- SYSWARDEN: CIS Level 2 Network Protocol Hardening ---
+install dccp /bin/true
+install sctp /bin/true
+install rds /bin/true
+install tipc /bin/true
+`
+	cisSysctlPolicyPath = "/etc/sysctl.d/99-syswarden-cis-level2.conf"
+	cisSysctlPolicy     = `# --- SYSWARDEN: CIS Level 2 Kernel Hardening ---
+fs.suid_dumpable = 0
+kernel.randomize_va_space = 2
+kernel.unprivileged_bpf_disabled = 1
+net.core.bpf_jit_harden = 2
+kernel.dmesg_restrict = 1
+kernel.kptr_restrict = 2
+kernel.yama.ptrace_scope = 1
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 0
+net.ipv4.conf.default.secure_redirects = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.tcp_syncookies = 1
+`
+	cisLimitsPolicyPath   = "/etc/security/limits.d/99-syswarden-cis.conf"
+	cisLimitsPolicy       = "# --- SYSWARDEN: CIS Level 2 Limits ---\n* hard core 0\n"
+	cisCoredumpPolicyPath = "/etc/systemd/coredump.conf.d/99-syswarden.conf"
+	cisCoredumpPolicy     = "[Coredump]\nStorage=none\nProcessSizeMax=0\n"
+)
+
 type hardeningStage struct {
 	name string
 	run  func() error
@@ -77,16 +122,7 @@ func ApplyCISHardening() error {
 
 func disableObscureFilesystemsOn(host hardeningHost) error {
 	fmt.Println(" -> Disabling obscure filesystems (CIS 1.1.1.1 - 1.1.1.8)")
-	content := `# --- SYSWARDEN: CIS Level 2 Filesystem Hardening ---
-install cramfs /bin/true
-install freevxfs /bin/true
-install jffs2 /bin/true
-install hfs /bin/true
-install hfsplus /bin/true
-install squashfs /bin/true
-install udf /bin/true
-`
-	if err := host.write("/etc/modprobe.d/syswarden-cis-fs.conf", []byte(content), 0600); err != nil {
+	if err := host.write(cisFilesystemPolicyPath, []byte(cisFilesystemPolicy), 0600); err != nil {
 		return err
 	}
 	active, reason, err := hardeningKernelRuntimeApplicable(host, "kernel module removal")
@@ -102,13 +138,7 @@ install udf /bin/true
 
 func disableUncommonProtocolsOn(host hardeningHost) error {
 	fmt.Println(" -> Disabling uncommon network protocols (CIS 3.3.1 - 3.3.4)")
-	content := `# --- SYSWARDEN: CIS Level 2 Network Protocol Hardening ---
-install dccp /bin/true
-install sctp /bin/true
-install rds /bin/true
-install tipc /bin/true
-`
-	if err := host.write("/etc/modprobe.d/syswarden-cis-net.conf", []byte(content), 0600); err != nil {
+	if err := host.write(cisNetworkPolicyPath, []byte(cisNetworkPolicy), 0600); err != nil {
 		return err
 	}
 	active, reason, err := hardeningKernelRuntimeApplicable(host, "kernel protocol module removal")
@@ -167,27 +197,8 @@ func removeLoadedModules(host hardeningHost, modules []string) error {
 
 func applySysctlOn(host hardeningHost) error {
 	fmt.Println(" -> Applying strict kernel parameters (CIS 1.5, 3.2)")
-	content := `# --- SYSWARDEN: CIS Level 2 Kernel Hardening ---
-fs.suid_dumpable = 0
-kernel.randomize_va_space = 2
-kernel.unprivileged_bpf_disabled = 1
-net.core.bpf_jit_harden = 2
-kernel.dmesg_restrict = 1
-kernel.kptr_restrict = 2
-kernel.yama.ptrace_scope = 1
-net.ipv4.conf.all.accept_source_route = 0
-net.ipv4.conf.default.accept_source_route = 0
-net.ipv4.conf.all.accept_redirects = 0
-net.ipv4.conf.default.accept_redirects = 0
-net.ipv4.conf.all.secure_redirects = 0
-net.ipv4.conf.default.secure_redirects = 0
-net.ipv4.conf.all.log_martians = 1
-net.ipv4.conf.default.log_martians = 1
-net.ipv4.conf.all.rp_filter = 1
-net.ipv4.conf.default.rp_filter = 1
-net.ipv4.tcp_syncookies = 1
-`
-	logical := "/etc/sysctl.d/99-syswarden-cis-level2.conf"
+	content := cisSysctlPolicy
+	logical := cisSysctlPolicyPath
 	physical, err := host.path(logical)
 	if err != nil {
 		return err
@@ -310,8 +321,7 @@ func attestSysctlValues(host hardeningHost, expected map[string]string) error {
 
 func restrictCoreDumpsOn(host hardeningHost) error {
 	fmt.Println(" -> Enforcing hard limits on core dumps (CIS 1.5.1)")
-	limitsContent := "# --- SYSWARDEN: CIS Level 2 Limits ---\n* hard core 0\n"
-	if err := host.write("/etc/security/limits.d/99-syswarden-cis.conf", []byte(limitsContent), 0600); err != nil {
+	if err := host.write(cisLimitsPolicyPath, []byte(cisLimitsPolicy), 0600); err != nil {
 		return err
 	}
 	decision, err := host.executionDecision()
@@ -329,7 +339,7 @@ func restrictCoreDumpsOn(host hardeningHost) error {
 		fmt.Println(" -> Systemd coredump policy is not applicable because no complete trusted coredump consumer is installed. The limits policy remains attested; no systemd coredump policy was claimed.")
 		return nil
 	}
-	content := []byte("[Coredump]\nStorage=none\nProcessSizeMax=0\n")
+	content := []byte(cisCoredumpPolicy)
 	validate := func() error {
 		output, err := host.executor.output("systemd-analyze", "cat-config", "systemd/coredump.conf")
 		if err != nil {
@@ -341,7 +351,7 @@ func restrictCoreDumpsOn(host hardeningHost) error {
 		}
 		return nil
 	}
-	logical := "/etc/systemd/coredump.conf.d/99-syswarden.conf"
+	logical := cisCoredumpPolicyPath
 	if !runtimeActive {
 		if err := host.applyManagedFile(logical, content, validate, nil); err != nil {
 			return err

--- a/src/core/syswarden-cli/pkg/security/cis_removal_linux.go
+++ b/src/core/syswarden-cli/pkg/security/cis_removal_linux.go
@@ -1,0 +1,534 @@
+//go:build linux
+
+package security
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type cisRemovalPolicy struct {
+	path            string
+	quarantinePath  string
+	expectedContent [][]byte
+}
+
+type cisRemovalDisposition uint8
+
+const (
+	cisRemovalAbsent cisRemovalDisposition = iota
+	cisRemovalExact
+	cisRemovalPreserved
+	cisRemovalPending
+)
+
+func cisSysctlRemovalContent() [][]byte {
+	content := make([][]byte, 0, 12)
+	for _, includeBPFJITHardening := range []bool{true, false} {
+		for _, unprivilegedBPF := range []string{"1", "2"} {
+			for _, ptraceScope := range []string{"1", "2", "3"} {
+				policy := cisSysctlPolicy
+				if !includeBPFJITHardening {
+					policy = strings.Replace(policy, "net.core.bpf_jit_harden = 2\n", "", 1)
+				}
+				if unprivilegedBPF != "1" {
+					policy = strings.Replace(
+						policy,
+						"kernel.unprivileged_bpf_disabled = 1",
+						"kernel.unprivileged_bpf_disabled = "+unprivilegedBPF,
+						1,
+					)
+				}
+				if ptraceScope != "1" {
+					policy = strings.Replace(
+						policy,
+						"kernel.yama.ptrace_scope = 1",
+						"kernel.yama.ptrace_scope = "+ptraceScope,
+						1,
+					)
+				}
+				content = append(content, []byte(policy))
+			}
+		}
+	}
+	return content
+}
+
+func cisRemovalPolicies() []cisRemovalPolicy {
+	return []cisRemovalPolicy{
+		{
+			path:            cisFilesystemPolicyPath,
+			quarantinePath:  cisRemovalQuarantinePath(cisFilesystemPolicyPath),
+			expectedContent: [][]byte{[]byte(cisFilesystemPolicy)},
+		},
+		{
+			path:            cisNetworkPolicyPath,
+			quarantinePath:  cisRemovalQuarantinePath(cisNetworkPolicyPath),
+			expectedContent: [][]byte{[]byte(cisNetworkPolicy)},
+		},
+		{
+			path:            cisSysctlPolicyPath,
+			quarantinePath:  cisRemovalQuarantinePath(cisSysctlPolicyPath),
+			expectedContent: cisSysctlRemovalContent(),
+		},
+		{
+			path:            cisLimitsPolicyPath,
+			quarantinePath:  cisRemovalQuarantinePath(cisLimitsPolicyPath),
+			expectedContent: [][]byte{[]byte(cisLimitsPolicy)},
+		},
+		{
+			path:            cisCoredumpPolicyPath,
+			quarantinePath:  cisRemovalQuarantinePath(cisCoredumpPolicyPath),
+			expectedContent: [][]byte{[]byte(cisCoredumpPolicy)},
+		},
+	}
+}
+
+func cisRemovalQuarantinePath(logical string) string {
+	return filepath.Join(
+		filepath.Dir(logical),
+		"."+filepath.Base(logical)+".syswarden-removal-v1",
+	)
+}
+
+func cisRemovalContentIsExact(content []byte, expected [][]byte) bool {
+	for _, candidate := range expected {
+		if bytes.Equal(content, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func cisRemovalMetadataIsExact(host hardeningHost, info fs.FileInfo) bool {
+	if info == nil || !info.Mode().IsRegular() || info.Mode() != 0600 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Nlink == 1 && int(stat.Uid) == host.expectedRootUID &&
+		int(stat.Gid) == host.expectedRootGID
+}
+
+func inspectCISRemovalArtifact(
+	host hardeningHost,
+	logical string,
+	expectedContent [][]byte,
+) (cisRemovalDisposition, hardeningFileSnapshot, string, error) {
+	physical, err := host.path(logical)
+	if err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", err
+	}
+	if _, err := os.Lstat(physical); errors.Is(err, fs.ErrNotExist) {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", nil
+	} else if err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("inspect CIS hardening policy artifact %s: %w", logical, err)
+	}
+
+	if err := host.verifyHardeningPolicyParent(logical); err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("attest CIS hardening policy parent %s: %w", logical, err)
+	}
+	target, err := host.target(logical, false)
+	if err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", err
+	}
+	root, err := openSecurityDirectory(target)
+	if err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("open CIS hardening policy parent %s: %w", logical, err)
+	}
+	pathInfo, inspectErr := root.Lstat(target.name)
+	closeErr := root.Close()
+	if inspectErr != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", errors.Join(
+			fmt.Errorf("reinspect CIS hardening policy artifact %s: %w", logical, inspectErr),
+			closeErr,
+		)
+	}
+	if closeErr != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("close CIS hardening policy parent %s: %w", logical, closeErr)
+	}
+	if !cisRemovalMetadataIsExact(host, pathInfo) {
+		return cisRemovalPreserved, hardeningFileSnapshot{}, "metadata is not the exact managed state", nil
+	}
+
+	snapshot, err := host.snapshot(logical)
+	if err != nil {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("snapshot CIS hardening policy artifact %s: %w", logical, err)
+	}
+	if !snapshot.existed || !sameHardeningArtifactIdentity(pathInfo, snapshot.identity.info) {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("CIS hardening policy artifact changed during attestation: %s", logical)
+	}
+	if !cisRemovalMetadataIsExact(host, snapshot.identity.info) {
+		return cisRemovalAbsent, hardeningFileSnapshot{}, "", fmt.Errorf("CIS hardening policy artifact metadata changed during attestation: %s", logical)
+	}
+	if !cisRemovalContentIsExact(snapshot.content, expectedContent) {
+		return cisRemovalPreserved, hardeningFileSnapshot{}, "content is not an exact managed variant", nil
+	}
+	return cisRemovalExact, snapshot, "", nil
+}
+
+type cisRemovalPlan struct {
+	policy      cisRemovalPolicy
+	disposition cisRemovalDisposition
+	snapshot    hardeningFileSnapshot
+	reason      string
+}
+
+func inspectCISRemovalPolicy(host hardeningHost, policy cisRemovalPolicy) (cisRemovalPlan, error) {
+	disposition, snapshot, reason, err := inspectCISRemovalArtifact(
+		host,
+		policy.path,
+		policy.expectedContent,
+	)
+	if err != nil {
+		return cisRemovalPlan{}, err
+	}
+	quarantineDisposition, quarantineSnapshot, quarantineReason, err := inspectCISRemovalArtifact(
+		host,
+		policy.quarantinePath,
+		policy.expectedContent,
+	)
+	if err != nil {
+		return cisRemovalPlan{}, err
+	}
+	if quarantineDisposition != cisRemovalAbsent {
+		if disposition != cisRemovalAbsent {
+			return cisRemovalPlan{}, fmt.Errorf(
+				"both canonical and deterministic-quarantine CIS hardening policy artifacts are present: %s and %s",
+				policy.path,
+				policy.quarantinePath,
+			)
+		}
+		if quarantineDisposition != cisRemovalExact {
+			return cisRemovalPlan{}, fmt.Errorf(
+				"refusing ambiguous deterministic CIS hardening policy quarantine %s: %s",
+				policy.quarantinePath,
+				quarantineReason,
+			)
+		}
+		return cisRemovalPlan{
+			policy:      policy,
+			disposition: cisRemovalPending,
+			snapshot:    quarantineSnapshot,
+		}, nil
+	}
+	return cisRemovalPlan{
+		policy:      policy,
+		disposition: disposition,
+		snapshot:    snapshot,
+		reason:      reason,
+	}, nil
+}
+
+func removeAttestedCISPolicyUsing(
+	host hardeningHost,
+	policy cisRemovalPolicy,
+	snapshot hardeningFileSnapshot,
+	rename hardeningArtifactRename,
+) error {
+	if err := host.verifyHardeningPolicyParent(policy.path); err != nil {
+		return fmt.Errorf("reattest CIS hardening policy parent %s: %w", policy.path, err)
+	}
+	target, err := host.target(policy.path, false)
+	if err != nil {
+		return err
+	}
+	quarantineTarget, err := host.target(policy.quarantinePath, false)
+	if err != nil {
+		return err
+	}
+	if quarantineTarget.directory != target.directory || quarantineTarget.name == target.name {
+		return fmt.Errorf("invalid deterministic CIS hardening policy quarantine for %s", policy.path)
+	}
+	root, err := openSecurityDirectory(target)
+	if err != nil {
+		return fmt.Errorf("open CIS hardening policy parent %s for removal: %w", policy.path, err)
+	}
+	defer func() { _ = root.Close() }()
+
+	expectedIdentity := snapshot.identity
+	attest := func(root *os.Root, name string) (fs.FileInfo, error) {
+		candidate := target
+		candidate.name = name
+		identity, existed, inspectErr := inspectSecurityDestination(root, candidate)
+		if inspectErr != nil {
+			return nil, inspectErr
+		}
+		if !existed {
+			return nil, fs.ErrNotExist
+		}
+		if !cisRemovalMetadataIsExact(host, identity.info) ||
+			!sameSecurityFileState(expectedIdentity, identity.info, identity.digest) {
+			return identity.info, fmt.Errorf("CIS hardening policy changed before removal: %s", policy.path)
+		}
+		return identity.info, nil
+	}
+	if _, err := attest(root, target.name); err != nil {
+		return fmt.Errorf("reattest exact CIS hardening policy %s before quarantine: %w", policy.path, err)
+	}
+	if _, err := root.Lstat(quarantineTarget.name); err == nil {
+		return fmt.Errorf("deterministic CIS hardening policy quarantine already exists: %s", policy.quarantinePath)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("inspect deterministic CIS hardening policy quarantine %s: %w", policy.quarantinePath, err)
+	}
+	directory, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("open CIS hardening policy parent for quarantine: %w", err)
+	}
+	defer func() { _ = directory.Close() }()
+	directoryFD := int(directory.Fd())
+	if err := rename(
+		directoryFD,
+		target.name,
+		directoryFD,
+		quarantineTarget.name,
+		unix.RENAME_NOREPLACE,
+	); err != nil {
+		return fmt.Errorf("quarantine exact CIS hardening policy %s atomically: %w", policy.path, err)
+	}
+	moved, attestErr := attest(root, quarantineTarget.name)
+	canonicalInfo, canonicalErr := root.Lstat(target.name)
+	canonicalAbsent := errors.Is(canonicalErr, fs.ErrNotExist)
+	syncErr := host.directorySync(root)
+	if attestErr != nil || !sameHardeningArtifactIdentity(snapshot.identity.info, moved) ||
+		!canonicalAbsent || syncErr != nil {
+		if canonicalAbsent {
+			canonicalErr = nil
+		} else if canonicalErr == nil && canonicalInfo != nil {
+			canonicalErr = fmt.Errorf("a concurrent canonical artifact appeared")
+		}
+		restoreErr := restoreHardeningQuarantine(
+			root,
+			directoryFD,
+			target.name,
+			quarantineTarget.name,
+			rename,
+			host.directorySync,
+		)
+		return errors.Join(
+			fmt.Errorf("CIS hardening policy %s changed before deterministic quarantine", policy.path),
+			attestErr,
+			canonicalErr,
+			syncErr,
+			restoreErr,
+		)
+	}
+	committed, commitErr := attest(root, quarantineTarget.name)
+	_, canonicalErr = root.Lstat(target.name)
+	canonicalAbsent = errors.Is(canonicalErr, fs.ErrNotExist)
+	if commitErr != nil || !sameHardeningArtifactIdentity(snapshot.identity.info, committed) || !canonicalAbsent {
+		if canonicalAbsent {
+			canonicalErr = nil
+		} else if canonicalErr == nil {
+			canonicalErr = fmt.Errorf("a concurrent canonical artifact appeared")
+		}
+		restoreErr := restoreHardeningQuarantine(
+			root,
+			directoryFD,
+			target.name,
+			quarantineTarget.name,
+			rename,
+			host.directorySync,
+		)
+		return errors.Join(
+			fmt.Errorf("CIS hardening policy %s changed before quarantine commit", policy.path),
+			commitErr,
+			canonicalErr,
+			restoreErr,
+		)
+	}
+	if err := unix.Unlinkat(directoryFD, quarantineTarget.name, 0); err != nil {
+		restoreErr := restoreHardeningQuarantine(
+			root,
+			directoryFD,
+			target.name,
+			quarantineTarget.name,
+			rename,
+			host.directorySync,
+		)
+		return errors.Join(
+			fmt.Errorf("remove deterministic CIS hardening policy quarantine %s: %w", policy.quarantinePath, err),
+			restoreErr,
+		)
+	}
+	if err := host.directorySync(root); err != nil {
+		recreateErr := host.writeExpected(
+			policy.path,
+			snapshot.content,
+			0600,
+			hardeningFileSnapshot{},
+		)
+		return errors.Join(
+			fmt.Errorf("sync removal of deterministic CIS hardening policy quarantine %s: %w", policy.quarantinePath, err),
+			recreateErr,
+		)
+	}
+	if _, err := root.Lstat(target.name); !errors.Is(err, fs.ErrNotExist) {
+		if err == nil {
+			err = fmt.Errorf("a replacement appeared after removal")
+		}
+		return fmt.Errorf("verify removal of CIS hardening policy %s: %w", policy.path, err)
+	}
+	if _, err := root.Lstat(quarantineTarget.name); !errors.Is(err, fs.ErrNotExist) {
+		if err == nil {
+			err = fmt.Errorf("the deterministic quarantine remains after removal")
+		}
+		return fmt.Errorf("verify deterministic CIS hardening policy quarantine removal %s: %w", policy.quarantinePath, err)
+	}
+	return nil
+}
+
+func finishPendingCISPolicyRemovalUsing(
+	host hardeningHost,
+	plan cisRemovalPlan,
+	rename hardeningArtifactRename,
+) error {
+	policy := plan.policy
+	if err := host.verifyHardeningPolicyParent(policy.path); err != nil {
+		return fmt.Errorf("reattest pending CIS hardening policy parent %s: %w", policy.path, err)
+	}
+	target, err := host.target(policy.path, false)
+	if err != nil {
+		return err
+	}
+	quarantineTarget, err := host.target(policy.quarantinePath, false)
+	if err != nil {
+		return err
+	}
+	if quarantineTarget.directory != target.directory || quarantineTarget.name == target.name {
+		return fmt.Errorf("invalid deterministic CIS hardening policy quarantine for %s", policy.path)
+	}
+	root, err := openSecurityDirectory(target)
+	if err != nil {
+		return fmt.Errorf("open pending CIS hardening policy parent %s: %w", policy.path, err)
+	}
+	defer func() { _ = root.Close() }()
+	directory, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("open pending CIS hardening policy directory: %w", err)
+	}
+	defer func() { _ = directory.Close() }()
+	if _, err := root.Lstat(target.name); err == nil {
+		return fmt.Errorf("canonical CIS hardening policy appeared beside its deterministic quarantine: %s", policy.path)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("inspect canonical CIS hardening policy before retry recovery %s: %w", policy.path, err)
+	}
+	expectedIdentity := plan.snapshot.identity
+	identity, existed, err := inspectSecurityDestination(root, quarantineTarget)
+	if err != nil {
+		return fmt.Errorf("reattest pending CIS hardening policy quarantine %s: %w", policy.quarantinePath, err)
+	}
+	if !existed || !cisRemovalMetadataIsExact(host, identity.info) ||
+		!sameSecurityFileState(expectedIdentity, identity.info, identity.digest) {
+		return fmt.Errorf("pending CIS hardening policy quarantine changed before retry recovery: %s", policy.quarantinePath)
+	}
+	if _, err := root.Lstat(target.name); err == nil {
+		return fmt.Errorf("canonical CIS hardening policy appeared before pending removal: %s", policy.path)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("reattest canonical CIS hardening policy absence %s: %w", policy.path, err)
+	}
+	identity, existed, err = inspectSecurityDestination(root, quarantineTarget)
+	if err != nil {
+		return fmt.Errorf("final reattestation of pending CIS hardening policy quarantine %s: %w", policy.quarantinePath, err)
+	}
+	if !existed || !cisRemovalMetadataIsExact(host, identity.info) ||
+		!sameSecurityFileState(expectedIdentity, identity.info, identity.digest) {
+		return fmt.Errorf("pending CIS hardening policy quarantine changed before removal: %s", policy.quarantinePath)
+	}
+	if _, err := root.Lstat(target.name); err == nil {
+		return fmt.Errorf("canonical CIS hardening policy appeared at pending removal commit: %s", policy.path)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("final canonical CIS hardening policy absence reattestation %s: %w", policy.path, err)
+	}
+	if err := unix.Unlinkat(int(directory.Fd()), quarantineTarget.name, 0); err != nil {
+		restoreErr := restoreHardeningQuarantine(
+			root,
+			int(directory.Fd()),
+			target.name,
+			quarantineTarget.name,
+			rename,
+			host.directorySync,
+		)
+		return errors.Join(
+			fmt.Errorf("remove pending CIS hardening policy quarantine %s: %w", policy.quarantinePath, err),
+			restoreErr,
+		)
+	}
+	if err := host.directorySync(root); err != nil {
+		recreateErr := host.writeExpected(
+			policy.path,
+			plan.snapshot.content,
+			0600,
+			hardeningFileSnapshot{},
+		)
+		return errors.Join(
+			fmt.Errorf("sync pending CIS hardening policy removal %s: %w", policy.quarantinePath, err),
+			recreateErr,
+		)
+	}
+	for _, candidate := range []struct {
+		name  string
+		label string
+	}{
+		{name: target.name, label: policy.path},
+		{name: quarantineTarget.name, label: policy.quarantinePath},
+	} {
+		if _, err := root.Lstat(candidate.name); !errors.Is(err, fs.ErrNotExist) {
+			if err == nil {
+				err = fmt.Errorf("artifact remains present")
+			}
+			return fmt.Errorf("verify pending CIS hardening policy removal %s: %w", candidate.label, err)
+		}
+	}
+	return nil
+}
+
+func removeExactCISHardeningPoliciesForRemovalOn(
+	host hardeningHost,
+	rename hardeningArtifactRename,
+) error {
+	plans := make([]cisRemovalPlan, 0, len(cisRemovalPolicies()))
+	for _, policy := range cisRemovalPolicies() {
+		plan, err := inspectCISRemovalPolicy(host, policy)
+		if err != nil {
+			return err
+		}
+		plans = append(plans, plan)
+	}
+
+	for _, plan := range plans {
+		switch plan.disposition {
+		case cisRemovalAbsent:
+			continue
+		case cisRemovalPreserved:
+			fmt.Printf("[WARN] Preserving modified or ambiguous SysWarden CIS hardening policy %s: %s.\n", plan.policy.path, plan.reason)
+			continue
+		case cisRemovalPending:
+			if err := finishPendingCISPolicyRemovalUsing(host, plan, rename); err != nil {
+				return err
+			}
+			fmt.Printf("[INFO] Finished pending removal of exact SysWarden CIS hardening policy: %s\n", plan.policy.path)
+		case cisRemovalExact:
+			if err := removeAttestedCISPolicyUsing(host, plan.policy, plan.snapshot, rename); err != nil {
+				return err
+			}
+			fmt.Printf("[INFO] Removed exact SysWarden CIS hardening policy: %s\n", plan.policy.path)
+		default:
+			return fmt.Errorf("unknown CIS hardening removal disposition for %s", plan.policy.path)
+		}
+	}
+	return nil
+}
+
+// RemoveExactCISHardeningPoliciesForRemoval removes only exact SysWarden CIS
+// policy artifacts. Modified or ambiguous host policy is preserved.
+func RemoveExactCISHardeningPoliciesForRemoval() error {
+	return removeExactCISHardeningPoliciesForRemovalOn(productionHardeningHost(), unix.Renameat2)
+}

--- a/src/core/syswarden-cli/pkg/security/cis_removal_linux_test.go
+++ b/src/core/syswarden-cli/pkg/security/cis_removal_linux_test.go
@@ -1,0 +1,420 @@
+//go:build linux
+
+package security
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func writeCISRemovalFixture(
+	t *testing.T,
+	host hardeningHost,
+	logical string,
+	content []byte,
+	mode fs.FileMode,
+) string {
+	t.Helper()
+	physical, err := host.path(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(physical), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHardeningFixtureFile(physical, content, mode); err != nil {
+		t.Fatal(err)
+	}
+	return physical
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalRemovesManagedPolicies(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	policies := cisRemovalPolicies()
+	for _, policy := range policies {
+		writeCISRemovalFixture(t, host, policy.path, policy.expectedContent[0], 0600)
+	}
+
+	if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+		t.Fatal(err)
+	}
+	for _, policy := range policies {
+		for _, logical := range []string{policy.path, policy.quarantinePath} {
+			physical, err := host.path(logical)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Lstat(physical); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("managed CIS policy artifact remains after removal: %s: %v", logical, err)
+			}
+		}
+	}
+}
+
+func TestCISRemovalQuarantinePathsAreFixedInactiveNames(t *testing.T) {
+	want := map[string]string{
+		cisFilesystemPolicyPath: "/etc/modprobe.d/.syswarden-cis-fs.conf.syswarden-removal-v1",
+		cisNetworkPolicyPath:    "/etc/modprobe.d/.syswarden-cis-net.conf.syswarden-removal-v1",
+		cisSysctlPolicyPath:     "/etc/sysctl.d/.99-syswarden-cis-level2.conf.syswarden-removal-v1",
+		cisLimitsPolicyPath:     "/etc/security/limits.d/.99-syswarden-cis.conf.syswarden-removal-v1",
+		cisCoredumpPolicyPath:   "/etc/systemd/coredump.conf.d/.99-syswarden.conf.syswarden-removal-v1",
+	}
+	policies := cisRemovalPolicies()
+	if len(policies) != len(want) {
+		t.Fatalf("CIS removal policy count=%d, want %d", len(policies), len(want))
+	}
+	for _, policy := range policies {
+		if got := policy.quarantinePath; got != want[policy.path] {
+			t.Fatalf("CIS quarantine path for %s=%q, want %q", policy.path, got, want[policy.path])
+		}
+		if strings.HasSuffix(policy.quarantinePath, ".conf") {
+			t.Fatalf("CIS quarantine path remains an active configuration filename: %s", policy.quarantinePath)
+		}
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalIsIdempotentWhenAbsent(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+			t.Fatalf("attempt %d: %v", attempt+1, err)
+		}
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalPreflightsSecondArtifactBeforeMutation(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	first := writeCISRemovalFixture(
+		t,
+		host,
+		cisFilesystemPolicyPath,
+		[]byte(cisFilesystemPolicy),
+		0600,
+	)
+	second := writeCISRemovalFixture(
+		t,
+		host,
+		cisNetworkPolicyPath,
+		make([]byte, hardeningMaximumFileSize+1),
+		0600,
+	)
+
+	err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") || !strings.Contains(err.Error(), cisNetworkPolicyPath) {
+		t.Fatalf("second-artifact preflight result: %v", err)
+	}
+	for _, physical := range []string{first, second} {
+		if _, statErr := os.Lstat(physical); statErr != nil {
+			t.Fatalf("global preflight mutated artifact %s: %v", physical, statErr)
+		}
+	}
+	firstQuarantine, err := host.path(cisRemovalQuarantinePath(cisFilesystemPolicyPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(firstQuarantine); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("global preflight created first quarantine: %v", err)
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalRecoversDeterministicQuarantineAfterCrash(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	policy := cisRemovalPolicies()[0]
+	canonical := writeCISRemovalFixture(t, host, policy.path, policy.expectedContent[0], 0600)
+	quarantine, err := host.path(policy.quarantinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	panicked := false
+	rename := func(oldDirectory int, oldName string, newDirectory int, newName string, flags uint) error {
+		if err := unix.Renameat2(oldDirectory, oldName, newDirectory, newName, flags); err != nil {
+			return err
+		}
+		panic("synthetic CIS removal crash after rename")
+	}
+	func() {
+		defer func() { panicked = recover() != nil }()
+		_ = removeExactCISHardeningPoliciesForRemovalOn(host, rename)
+	}()
+	if !panicked {
+		t.Fatal("synthetic CIS removal crash boundary was not reached")
+	}
+	if _, err := os.Lstat(canonical); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("canonical CIS policy after crash: %v", err)
+	}
+	if content, err := os.ReadFile(quarantine); err != nil || string(content) != string(policy.expectedContent[0]) { // #nosec G304 -- quarantine is confined to the private hardening fixture root
+		t.Fatalf("durable CIS quarantine after crash=%q error=%v", content, err)
+	}
+
+	if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+		t.Fatalf("CIS removal crash retry: %v", err)
+	}
+	for _, physical := range []string{canonical, quarantine} {
+		if _, err := os.Lstat(physical); !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("CIS removal crash retry left %s: %v", physical, err)
+		}
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalRejectsCanonicalQuarantineCollision(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	policy := cisRemovalPolicies()[0]
+	canonical := writeCISRemovalFixture(t, host, policy.path, policy.expectedContent[0], 0600)
+	quarantine := writeCISRemovalFixture(t, host, policy.quarantinePath, policy.expectedContent[0], 0600)
+
+	err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2)
+	if err == nil || !strings.Contains(err.Error(), "both canonical") {
+		t.Fatalf("canonical/quarantine collision result: %v", err)
+	}
+	for _, physical := range []string{canonical, quarantine} {
+		if _, statErr := os.Lstat(physical); statErr != nil {
+			t.Fatalf("collision did not preserve %s: %v", physical, statErr)
+		}
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalRejectsLateQuarantineCollision(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	policy := cisRemovalPolicies()[0]
+	canonical := writeCISRemovalFixture(t, host, policy.path, policy.expectedContent[0], 0600)
+	quarantine, err := host.path(policy.quarantinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operatorContent := []byte("operator quarantine\n")
+	injected := false
+	rename := func(oldDirectory int, oldName string, newDirectory int, newName string, flags uint) error {
+		if !injected {
+			injected = true
+			if err := writeHardeningFixtureFile(quarantine, operatorContent, 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return unix.Renameat2(oldDirectory, oldName, newDirectory, newName, flags)
+	}
+
+	err = removeExactCISHardeningPoliciesForRemovalOn(host, rename)
+	if err == nil || !errors.Is(err, unix.EEXIST) {
+		t.Fatalf("late quarantine collision result: %v", err)
+	}
+	if content, readErr := os.ReadFile(canonical); readErr != nil || // #nosec G304 -- canonical is confined to the private hardening fixture root
+		string(content) != string(policy.expectedContent[0]) {
+		t.Fatalf("late collision changed canonical policy: %q, %v", content, readErr)
+	}
+	if content, readErr := os.ReadFile(quarantine); readErr != nil || // #nosec G304 -- quarantine is confined to the private hardening fixture root
+		string(content) != string(operatorContent) {
+		t.Fatalf("late collision changed operator quarantine: %q, %v", content, readErr)
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalPreservesAmbiguousQuarantine(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	policy := cisRemovalPolicies()[0]
+	quarantine := writeCISRemovalFixture(
+		t,
+		host,
+		policy.quarantinePath,
+		[]byte(cisFilesystemPolicy+"# operator quarantine\n"),
+		0600,
+	)
+
+	err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous deterministic") {
+		t.Fatalf("ambiguous quarantine result: %v", err)
+	}
+	if content, readErr := os.ReadFile(quarantine); readErr != nil || // #nosec G304 -- quarantine is confined to the private hardening fixture root
+		string(content) != cisFilesystemPolicy+"# operator quarantine\n" {
+		t.Fatalf("ambiguous quarantine was not preserved: %q, %v", content, readErr)
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalAcceptsEveryManagedSysctlVariant(t *testing.T) {
+	variants := cisSysctlRemovalContent()
+	if len(variants) != 12 {
+		t.Fatalf("managed sysctl variant count=%d, want 12", len(variants))
+	}
+	unique := make(map[string]struct{}, len(variants))
+	for _, content := range variants {
+		unique[string(content)] = struct{}{}
+	}
+	if len(unique) != len(variants) {
+		t.Fatalf("managed sysctl variants are not unique: %d/%d", len(unique), len(variants))
+	}
+
+	for index, content := range variants {
+		t.Run(fmt.Sprintf("variant-%02d", index+1), func(t *testing.T) {
+			host := hardeningTestHost(t, hardeningExecutor{
+				run: func(name string, args ...string) error {
+					return fmt.Errorf("runtime command must not run during policy removal: %s %v", name, args)
+				},
+			})
+			physical := writeCISRemovalFixture(t, host, cisSysctlPolicyPath, content, 0600)
+			if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Lstat(physical); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("managed sysctl policy remains: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalPreservesAmbiguousArtifacts(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, hardeningHost) string
+	}{
+		{
+			name: "modified content",
+			setup: func(t *testing.T, host hardeningHost) string {
+				return writeCISRemovalFixture(
+					t,
+					host,
+					cisFilesystemPolicyPath,
+					[]byte(cisFilesystemPolicy+"# operator policy\n"),
+					0600,
+				)
+			},
+		},
+		{
+			name: "wrong mode",
+			setup: func(t *testing.T, host hardeningHost) string {
+				return writeCISRemovalFixture(t, host, cisFilesystemPolicyPath, []byte(cisFilesystemPolicy), 0640)
+			},
+		},
+		{
+			name: "hard link",
+			setup: func(t *testing.T, host hardeningHost) string {
+				physical := writeCISRemovalFixture(t, host, cisFilesystemPolicyPath, []byte(cisFilesystemPolicy), 0600)
+				if err := os.Link(physical, physical+".operator-link"); err != nil {
+					t.Fatal(err)
+				}
+				return physical
+			},
+		},
+		{
+			name: "symbolic link",
+			setup: func(t *testing.T, host hardeningHost) string {
+				physical, err := host.path(cisFilesystemPolicyPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(physical), 0750); err != nil {
+					t.Fatal(err)
+				}
+				target := physical + ".operator"
+				if err := writeHardeningFixtureFile(target, []byte(cisFilesystemPolicy), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(filepath.Base(target), physical); err != nil {
+					t.Fatal(err)
+				}
+				return physical
+			},
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, host hardeningHost) string {
+				physical, err := host.path(cisFilesystemPolicyPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(physical, 0750); err != nil {
+					t.Fatal(err)
+				}
+				return physical
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := hardeningTestHost(t, hardeningExecutor{})
+			physical := test.setup(t, host)
+			if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Lstat(physical); err != nil {
+				t.Fatalf("ambiguous artifact was not preserved: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalContinuesAfterPreservation(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	modified := writeCISRemovalFixture(
+		t,
+		host,
+		cisFilesystemPolicyPath,
+		[]byte(cisFilesystemPolicy+"# operator policy\n"),
+		0600,
+	)
+	exact := writeCISRemovalFixture(t, host, cisNetworkPolicyPath, []byte(cisNetworkPolicy), 0600)
+
+	if err := removeExactCISHardeningPoliciesForRemovalOn(host, unix.Renameat2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(modified); err != nil {
+		t.Fatalf("modified policy was not preserved: %v", err)
+	}
+	if _, err := os.Lstat(exact); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("exact policy remains after an earlier preservation: %v", err)
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalRejectsConcurrentSubstitution(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	physical := writeCISRemovalFixture(t, host, cisFilesystemPolicyPath, []byte(cisFilesystemPolicy), 0600)
+	var replacement fs.FileInfo
+	calls := 0
+	rename := func(oldDirectory int, oldName string, newDirectory int, newName string, flags uint) error {
+		calls++
+		if calls == 1 {
+			if err := os.Remove(physical); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeHardeningFixtureFile(physical, []byte(cisFilesystemPolicy), 0600); err != nil {
+				t.Fatal(err)
+			}
+			var err error
+			replacement, err = os.Lstat(physical)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		return unix.Renameat2(oldDirectory, oldName, newDirectory, newName, flags)
+	}
+
+	err := removeExactCISHardeningPoliciesForRemovalOn(host, rename)
+	if err == nil || !strings.Contains(err.Error(), "changed before removal") {
+		t.Fatalf("concurrent substitution result: %v", err)
+	}
+	restored, statErr := os.Lstat(physical)
+	if statErr != nil || !os.SameFile(replacement, restored) {
+		t.Fatalf("concurrent replacement was not preserved: info=%v error=%v", restored, statErr)
+	}
+}
+
+func TestRemoveExactCISHardeningPoliciesForRemovalPropagatesRenameFailure(t *testing.T) {
+	host := hardeningTestHost(t, hardeningExecutor{})
+	physical := writeCISRemovalFixture(t, host, cisFilesystemPolicyPath, []byte(cisFilesystemPolicy), 0600)
+	injected := errors.New("injected rename failure")
+	rename := func(int, string, int, string, uint) error { return injected }
+
+	err := removeExactCISHardeningPoliciesForRemovalOn(host, rename)
+	if !errors.Is(err, injected) {
+		t.Fatalf("rename failure was not propagated: %v", err)
+	}
+	if _, err := os.Lstat(physical); err != nil {
+		t.Fatalf("policy was not preserved after rename failure: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Remove only byte-exact, root-owned SysWarden CIS persistence files during verified final package removal.
- Preserve every modified, linked or otherwise ambiguous operator policy.
- Preflight the complete policy set before mutation and reattest the durable removal barrier immediately before cleanup.
- Recover deterministic inactive quarantines after an interrupted removal and require both canonical and recovery paths to be absent.
- Keep effective sysctl values hardened until reboot by avoiding any runtime reload during removal.
- Extend DEB, RPM and APK lifecycle evidence with exact post-removal absence checks.

## Validation

- `go test ./...`
- `go test -race ./pkg/security ./cmd`
- `go vet ./pkg/security ./cmd`
- 225 package lifecycle and contract tests passed, with 8 sandbox-only socket skips.
- 422 package and release validator tests passed, with 8 sandbox-only socket skips.
- Documentation unit gate passed.
- The version contract passed as a non-versioning fix that preserves the unreleased v4.04.0 Minor candidate.
- The commit has a GitHub-verified SSH signature.
- Package, Security Audit, Plumber and OSSF Scorecard checks passed.

## Native Alpine qualification

The exact APK built by Package run `33528216574` from commit `2c25e7d87243858eca1877e69597302196ea40af` was qualified on a clean Alpine 3.24.1 x86_64 host.

- APK SHA-256: `d14514af0c5cfe5b974099ed981e9572b0eea9dc2ddce72f2d33a9be89cc3f9d`
- Fresh install: pass.
- Fresh purge with exact baseline restoration: pass.
- Public v4.03.3 to v4.04.0 upgrade: pass.
- First real reboot and post-boot verification: pass.
- Second real reboot, rollback to v4.03.3 and re-upgrade to v4.04.0: pass.
- Manual persistent policy block, kernel verification and unblock: pass.
- Final `apk del` with CIS cleanup and rsyslog restart: pass.
- Candidate reinstall followed by `apk del --purge`: pass.
- Final state: package absent, zero SysWarden-named product paths and zero reserved nftables tables.
- All eight phase evidence manifests were verified after collection.

The first policy probe targeted the runtime-only `banned_ips` set instead of the persistent `syswarden_blacklist` set. Live inspection proved the product behavior correct, the probe was corrected and the complete policy phase then passed. This was a private harness classification issue, not a product defect.
