### PR TITLE
Fix : close v4.04.0 qualification harness drift

### DIFF
--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -98,6 +98,18 @@ class PlatformSpec:
     purge_semantics: str
 
 
+@dataclass(frozen=True)
+class AlpineOpenRCContract:
+    package_version: str
+    rc_conf_pre_sha256: str
+    rc_conf_post_sha256: str
+    hostname_init_pre_sha256: str
+    hostname_init_post_sha256: str
+    hostname_keyword_pre_pattern: str
+    hostname_keyword_post_pattern: str
+    hostname_mutation: str
+
+
 ARCHITECTURE_LABELS = {
     "amd64": "amd64/x86_64",
 }
@@ -161,9 +173,18 @@ DEB_BOOTSTRAP = (
     "--no-install-recommends systemd systemd-sysv dbus iproute2 nftables ipset curl wget rsyslog cron "
     "bash-completion wireguard-tools qrencode jq unattended-upgrades util-linux "
     "apt-listchanges procps e2fsprogs socat binutils file && "
-    "if [ -f /etc/dpkg/dpkg.cfg.d/docker ]; then "
-    "sed -i '\\|^path-exclude /usr/share/doc/\\*$|d' "
-    "/etc/dpkg/dpkg.cfg.d/docker; fi && "
+    "if [ -d /etc/dpkg/dpkg.cfg.d ]; then "
+    "for syswarden_dpkg_config in /etc/dpkg/dpkg.cfg.d/*; do "
+    "[ ! -L \"${syswarden_dpkg_config}\" ] || exit 1; "
+    "[ -f \"${syswarden_dpkg_config}\" ] || continue; "
+    "sed -E -i "
+    "'\\%^[[:space:]]*path-exclude([[:space:]]+|[[:space:]]*=[[:space:]]*)"
+    "/usr/share/doc/\\*$%d' \"${syswarden_dpkg_config}\" || exit 1; "
+    "if grep -E -q "
+    "'^[[:space:]]*path-exclude([[:space:]]+|[[:space:]]*=[[:space:]]*)"
+    "/usr/share/doc/\\*$' \"${syswarden_dpkg_config}\"; then "
+    "exit 1; else [ \"$?\" -eq 1 ] || exit 1; fi; "
+    "done; fi && "
     "rm -rf /var/lib/apt/lists/*"
 )
 RPM_BOOTSTRAP = (
@@ -190,8 +211,7 @@ HISTORICAL_RPM_TRANSITION_BOOTSTRAPS = {
         "rpm -q qrencode >/dev/null && dnf clean all"
     ),
 }
-APK_BOOTSTRAP = (
-    "apk add --no-cache openrc openrc-init && "
+APK_BOOTSTRAP_SUFFIX = (
     "apk add --no-cache iproute2 nftables cronie cronie-openrc curl wget rsyslog rsyslog-uxsock "
     "bash-completion wireguard-tools libqrencode-tools jq procps-ng "
     "e2fsprogs-extra shadow socat binutils file && test -x /usr/bin/gpasswd"
@@ -297,6 +317,72 @@ ALPINE_HOSTNAME_INIT_PRE_SHA256 = (
 ALPINE_HOSTNAME_INIT_POST_SHA256 = (
     "11eb8ad952a72d82a63987faf51f8d0248acd765f8327f117436b45a378f4f91"
 )
+ALPINE_OPENRC_CONTRACTS = {
+    "3.22": AlpineOpenRCContract(
+        package_version=ALPINE_OPENRC_VERSION,
+        rc_conf_pre_sha256=ALPINE_RC_CONF_PRE_SHA256,
+        rc_conf_post_sha256=ALPINE_RC_CONF_POST_SHA256,
+        hostname_init_pre_sha256=ALPINE_HOSTNAME_INIT_PRE_SHA256,
+        hostname_init_post_sha256=ALPINE_HOSTNAME_INIT_POST_SHA256,
+        hostname_keyword_pre_pattern=(
+            "^[[:space:]]*keyword -prefix -lxc -docker$"
+        ),
+        hostname_keyword_post_pattern=(
+            "^[[:space:]]*keyword -prefix -lxc -docker -podman$"
+        ),
+        hostname_mutation=(
+            "sed -i 's/^\\([[:space:]]*keyword -prefix -lxc -docker\\)$/"
+            "\\1 -podman/' /etc/init.d/hostname && "
+        ),
+    ),
+    "3.24": AlpineOpenRCContract(
+        package_version="0.63.2-r0",
+        rc_conf_pre_sha256=(
+            "c7ce810693680cca288134adc0c109c192aedd37cbbdef7b4f4dc82c8c38696b"
+        ),
+        rc_conf_post_sha256=(
+            "7efeb86569fa28df86e1b59afa43666330056ebee1a049e365c3beb4625ca3a8"
+        ),
+        hostname_init_pre_sha256=(
+            "b52fa145995729852fa931aef5e7426c4bf1413a105a3e55674fb35342b4705a"
+        ),
+        hostname_init_post_sha256=(
+            "b52fa145995729852fa931aef5e7426c4bf1413a105a3e55674fb35342b4705a"
+        ),
+        hostname_keyword_pre_pattern=(
+            "^[[:space:]]*keyword -docker -podman -lxc -prefix "
+            "-systemd-nspawn -wsl$"
+        ),
+        hostname_keyword_post_pattern=(
+            "^[[:space:]]*keyword -docker -podman -lxc -prefix "
+            "-systemd-nspawn -wsl$"
+        ),
+        hostname_mutation="",
+    ),
+}
+
+
+def alpine_openrc_contract(version: str) -> AlpineOpenRCContract:
+    try:
+        return ALPINE_OPENRC_CONTRACTS[version]
+    except KeyError as exc:
+        raise LifecycleLabError(
+            f"unsupported Alpine OpenRC qualification contract: {version!r}"
+        ) from exc
+
+
+def alpine_bootstrap_command(version: str) -> str:
+    contract = alpine_openrc_contract(version)
+    return (
+        "apk add --no-cache "
+        f"openrc={contract.package_version} "
+        f"openrc-init={contract.package_version} && "
+        + APK_BOOTSTRAP_SUFFIX
+    )
+
+
+# Retained as the canonical Alpine 3.22 bootstrap contract for direct callers.
+APK_BOOTSTRAP = alpine_bootstrap_command("3.22")
 FEDORA_LAB_MASK_TARGETS = (
     "systemd-oomd.service",
     "systemd-oomd.socket",
@@ -313,6 +399,56 @@ FEDORA_LAB_MASKED_UNITS = tuple(
         )
     )
 )
+UBUNTU_2404_LAB_BASE_MASKED_UNITS = (
+    "cryptdisks-early.service",
+    "cryptdisks.service",
+    "hwclock.service",
+    "x11-common.service",
+)
+UBUNTU_2404_LAB_MASK_TARGETS = (
+    "dev-mqueue.mount",
+    "systemd-ask-password-console.path",
+    "systemd-ask-password-wall.path",
+)
+UBUNTU_2404_LAB_MASKED_UNITS = tuple(
+    sorted(
+        (
+            *UBUNTU_2404_LAB_BASE_MASKED_UNITS,
+            *UBUNTU_2404_LAB_MASK_TARGETS,
+        )
+    )
+)
+DEBIAN_13_LAB_BASE_MASKED_UNITS = UBUNTU_2404_LAB_BASE_MASKED_UNITS
+DEBIAN_13_LAB_MASK_TARGETS = (
+    "dev-mqueue.mount",
+    "run-lock.mount",
+    "tmp.mount",
+    "systemd-ask-password-console.path",
+    "systemd-ask-password-wall.path",
+)
+DEBIAN_13_LAB_MASKED_UNITS = tuple(
+    sorted(
+        (
+            *DEBIAN_13_LAB_BASE_MASKED_UNITS,
+            *DEBIAN_13_LAB_MASK_TARGETS,
+        )
+    )
+)
+SYSTEMD_LAB_MASK_TARGETS_BY_CELL = {
+    "DEB-13": DEBIAN_13_LAB_MASK_TARGETS,
+    "DEB-U2404": UBUNTU_2404_LAB_MASK_TARGETS,
+    "RPM-F44": FEDORA_LAB_MASK_TARGETS,
+}
+SYSTEMD_LAB_MASKED_UNITS_BY_CELL = {
+    "DEB-13": DEBIAN_13_LAB_MASKED_UNITS,
+    "DEB-U2404": UBUNTU_2404_LAB_MASKED_UNITS,
+    "RPM-F44": FEDORA_LAB_MASKED_UNITS,
+}
+SYSTEMD_LAB_MASK_PREDICATES_BY_CELL = {
+    "DEB-13": "NS14_DEBIAN_13_MASKS",
+    "DEB-U2404": "NS14_UBUNTU_2404_MASKS",
+    "RPM-F44": "NS14_FEDORA_MASKS",
+}
 # A delegated rootless cgroup namespace may expose its own cgroup2 mount as rw.
 # The caller separately proves the non-host-root ID map, private cgroup namespace,
 # exact non-SYS_ADMIN capabilities, and NoNewPrivs. The Alpine runtime additionally
@@ -459,7 +595,6 @@ _PLATFORM_NAMES = {
 _BOOTSTRAP_COMMANDS = {
     "deb": DEB_BOOTSTRAP,
     "rpm": RPM_BOOTSTRAP,
-    "apk": APK_BOOTSTRAP,
 }
 _PURGE_SEMANTICS = {
     "deb": DEB_PURGE_SEMANTICS,
@@ -471,10 +606,15 @@ _PURGE_SEMANTICS = {
 def _platform_from_matrix_cell(cell: dict[str, object]) -> PlatformSpec:
     distribution = str(cell["distribution"])
     family = str(cell["family"])
+    version = str(cell["version"])
     architecture = "amd64"
+    if family == "apk":
+        bootstrap_command = alpine_bootstrap_command(version)
+    else:
+        bootstrap_command = _BOOTSTRAP_COMMANDS[family]
     return PlatformSpec(
         cell_id=str(cell["id"]),
-        version=str(cell["version"]),
+        version=version,
         name=_PLATFORM_NAMES[distribution],
         distribution=distribution,
         family=family,
@@ -491,7 +631,7 @@ def _platform_from_matrix_cell(cell: dict[str, object]) -> PlatformSpec:
         official_repository=OFFICIAL_REPOSITORIES[distribution],
         image=str(cell["image"]),
         package_pattern=EXPECTED_PACKAGE_PATTERNS[(family, architecture)],
-        bootstrap_command=_BOOTSTRAP_COMMANDS[family],
+        bootstrap_command=bootstrap_command,
         scenarios=tuple(str(item) for item in cell["container_scenarios"]),
         purge_semantics=_PURGE_SEMANTICS[family],
     )
@@ -984,13 +1124,12 @@ def expected_event_checks(
         return tuple(checks)
 
     removal_label = "final-removal" if family == "rpm" else scenario
-    if family == "rpm":
-        checks.extend(
-            _generated_rsyslog_pre_removal_event_checks(
-                scenario,
-                removal_label,
-            )
+    checks.extend(
+        _generated_rsyslog_pre_removal_event_checks(
+            scenario,
+            removal_label,
         )
+    )
     checks.extend(
         (
             f"{scenario}.{removal_label}",
@@ -1003,7 +1142,7 @@ def expected_event_checks(
         _generated_cleanup_event_checks(
             scenario,
             removal_label,
-            exact_rsyslog=family == "rpm",
+            exact_rsyslog=True,
         )
     )
     if family in {"deb", "rpm", "apk"}:
@@ -1712,6 +1851,14 @@ def build_containerfile(spec: PlatformSpec) -> str:
         "/usr/local/libexec/syswarden-lab-network && "
         "chmod 0755 /usr/local/libexec/syswarden-lab-network\n"
     )
+    systemd_mask_targets = SYSTEMD_LAB_MASK_TARGETS_BY_CELL.get(
+        spec.cell_id, ()
+    )
+    systemd_masks = ""
+    if systemd_mask_targets:
+        systemd_masks = "RUN systemctl mask " + " ".join(
+            systemd_mask_targets
+        ) + "\n"
     if spec.family == "deb":
         unit_encoded = base64.b64encode(
             SYSTEMD_LAB_NETWORK_UNIT.encode("utf-8")
@@ -1723,18 +1870,14 @@ def build_containerfile(spec: PlatformSpec) -> str:
             "chmod 0644 /etc/systemd/system/syswarden-lab-network.service\n"
             "RUN systemctl enable syswarden-lab-network.service cron.service "
             "rsyslog.service\n"
-            "STOPSIGNAL SIGRTMIN+3\n"
-            'CMD ["/sbin/init"]\n'
+            + systemd_masks
+            + "STOPSIGNAL SIGRTMIN+3\n"
+            + 'CMD ["/sbin/init"]\n'
         )
     elif spec.family == "rpm":
         unit_encoded = base64.b64encode(
             SYSTEMD_LAB_NETWORK_UNIT.encode("utf-8")
         ).decode("ascii")
-        fedora_masks = ""
-        if spec.distribution == "fedora":
-            fedora_masks = "RUN systemctl mask " + " ".join(
-                FEDORA_LAB_MASK_TARGETS
-            ) + "\n"
         init_contract = (
             helper_step
             + f"RUN printf '%s' {shlex.quote(unit_encoded)} | base64 -d > "
@@ -1742,11 +1885,12 @@ def build_containerfile(spec: PlatformSpec) -> str:
             "chmod 0644 /etc/systemd/system/syswarden-lab-network.service\n"
             "RUN systemctl enable syswarden-lab-network.service crond.service "
             "rsyslog.service\n"
-            + fedora_masks
+            + systemd_masks
             + "STOPSIGNAL SIGRTMIN+3\n"
             + 'CMD ["/sbin/init"]\n'
         )
     elif spec.family == "apk":
+        openrc_contract = alpine_openrc_contract(spec.version)
         try:
             rc_conf_append = base64.b64decode(
                 ALPINE_RC_CONF_APPEND_BASE64, validate=True
@@ -1772,11 +1916,14 @@ def build_containerfile(spec: PlatformSpec) -> str:
         ).decode("ascii")
         init_contract = (
             "RUN apk info -e 'openrc="
-            + ALPINE_OPENRC_VERSION
+            + openrc_contract.package_version
+            + "' && "
+            "apk info -e 'openrc-init="
+            + openrc_contract.package_version
             + "' && "
             "test -f /etc/rc.conf && test ! -L /etc/rc.conf && "
             "test \"$(sha256sum /etc/rc.conf | awk '{ print $1 }')\" = "
-            + ALPINE_RC_CONF_PRE_SHA256
+            + openrc_contract.rc_conf_pre_sha256
             + " && "
             "test \"$(awk '/^[[:space:]]*rc_sys[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf)\" -eq 0 && "
             "test \"$(awk '/^[[:space:]]*rc_cgroup_mode[[:space:]]*=/ { count++ } END { print count + 0 }' /etc/rc.conf)\" -eq 0 && "
@@ -1784,19 +1931,24 @@ def build_containerfile(spec: PlatformSpec) -> str:
             + ALPINE_RC_CONF_APPEND_BASE64
             + " | base64 -d >> /etc/rc.conf && "
             "test \"$(sha256sum /etc/rc.conf | awk '{ print $1 }')\" = "
-            + ALPINE_RC_CONF_POST_SHA256
+            + openrc_contract.rc_conf_post_sha256
             + " && "
             "test \"$(grep -Fxc 'rc_sys=\"podman\"' /etc/rc.conf)\" -eq 1 && "
             "test \"$(grep -Fxc 'rc_cgroup_mode=\"legacy\"' /etc/rc.conf)\" -eq 1 && "
             "test -f /etc/init.d/hostname && test ! -L /etc/init.d/hostname && "
             "test \"$(sha256sum /etc/init.d/hostname | awk '{ print $1 }')\" = "
-            + ALPINE_HOSTNAME_INIT_PRE_SHA256
+            + openrc_contract.hostname_init_pre_sha256
             + " && "
-            "test \"$(grep -Ec '^[[:space:]]*keyword -prefix -lxc -docker$' /etc/init.d/hostname)\" -eq 1 && "
-            "sed -i 's/^\\([[:space:]]*keyword -prefix -lxc -docker\\)$/\\1 -podman/' /etc/init.d/hostname && "
-            "test \"$(sha256sum /etc/init.d/hostname | awk '{ print $1 }')\" = "
-            + ALPINE_HOSTNAME_INIT_POST_SHA256
-            + "\n"
+            "test \"$(grep -Ec '"
+            + openrc_contract.hostname_keyword_pre_pattern
+            + "' /etc/init.d/hostname)\" -eq 1 && "
+            + openrc_contract.hostname_mutation
+            + "test \"$(sha256sum /etc/init.d/hostname | awk '{ print $1 }')\" = "
+            + openrc_contract.hostname_init_post_sha256
+            + " && "
+            "test \"$(grep -Ec '"
+            + openrc_contract.hostname_keyword_post_pattern
+            + "' /etc/init.d/hostname)\" -eq 1\n"
             + helper_step
             + f"RUN printf '%s' {shlex.quote(provider_encoded)} | base64 -d > "
             "/etc/init.d/syswarden-lab-net && "
@@ -2901,13 +3053,17 @@ v4032_to_v4033_upgrade_selected() {
         [ "$(installed_version 2>/dev/null || true)" = 4.03.2 ]
 }
 
-attest_v4032_previous_webtui_retirement() {
+v4033_to_v4040_upgrade_selected() {
+    v4033_to_v4040_transition_selected && \
+        [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]
+}
+
+attest_previous_webtui_retirement() {
     previous_webtui_root="${1:-/}"
     previous_webtui_root="${previous_webtui_root%/}"
     previous_webtui_proc_root="${2:-${previous_webtui_root}/proc}"
     previous_webtui_executable="${previous_webtui_root}/opt/syswarden/bin/syswarden-cli"
 
-    v4032_to_v4033_upgrade_selected || return 1
     legacy_webtui_runtime_absent "${previous_webtui_root}" || return 1
     syswarden_verify_no_exact_webtui_process \
         "${previous_webtui_root}" "${previous_webtui_proc_root}" \
@@ -2933,6 +3089,16 @@ attest_v4032_previous_webtui_retirement() {
         fi
     done
     rm -f "${previous_webtui_ss_stderr}" || return 1
+}
+
+attest_v4032_previous_webtui_retirement() {
+    v4032_to_v4033_upgrade_selected || return 1
+    attest_previous_webtui_retirement "$@"
+}
+
+attest_v4033_previous_webtui_retirement() {
+    v4033_to_v4040_upgrade_selected || return 1
+    attest_previous_webtui_retirement "$@"
 }
 
 alpine_apk_owner_version() {
@@ -3279,6 +3445,12 @@ v4032_to_v4033_transition_selected() {
         [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.3 ]
 }
 
+v4033_to_v4040_transition_selected() {
+    [ "${SCENARIO}" = upgrade-rollback ] && \
+        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.0 ]
+}
+
 expected_systemd_enablement_prefix() {
     label="$1"
     case "${SCENARIO}:${label}" in
@@ -3287,7 +3459,8 @@ expected_systemd_enablement_prefix() {
         upgrade-rollback:recovery)
             if v4028_to_v4032_transition_selected; then
                 printf '%s\n' /etc/systemd/system
-            elif v4032_to_v4033_transition_selected; then
+            elif v4032_to_v4033_transition_selected || \
+                 v4033_to_v4040_transition_selected; then
                 printf '%s\n' ..
             else
                 return 1
@@ -3684,8 +3857,9 @@ probe_postinstall_contract() {
         fi
         probe_seeded_operator_listener_preservation "${label}" || mark_postinstall_failure operator-listener
     elif [ "${actual_version}" = "${EXPECTED_PREVIOUS_VERSION}" ]; then
-        if v4032_to_v4033_upgrade_selected; then
-            attest_v4032_previous_webtui_retirement || \
+        if v4032_to_v4033_upgrade_selected || \
+           v4033_to_v4040_upgrade_selected; then
+            attest_previous_webtui_retirement || \
                 mark_postinstall_failure previous-webtui-retirement
         else
             case "${PACKAGE_FAMILY}" in
@@ -3926,17 +4100,18 @@ write_seeded_operator_token() {
             'custom_hash_ipv6 = ""' \
             'use_spamhaus = false' \
             ''
-        if [ "${PACKAGE_FAMILY:-}" = deb ] && \
-           { [ "${SCENARIO}" = remove ] || [ "${SCENARIO}" = purge ]; }; then
-            printf '%s\n' \
-                '[integrations.siem]' \
-                'enabled = true' \
-                'ip = "127.0.0.1"' \
-                'port = "5514"' \
-                'protocol = "udp"' \
-                'tls_ca = ""' \
-                ''
-        fi
+        case "${PACKAGE_FAMILY}:${SCENARIO}" in
+            deb:remove|deb:purge|rpm:remove|apk:remove|apk:purge)
+                printf '%s\n' \
+                    '[integrations.siem]' \
+                    'enabled = true' \
+                    'ip = "127.0.0.1"' \
+                    'port = "5514"' \
+                    'protocol = "udp"' \
+                    'tls_ca = ""' \
+                    ''
+                ;;
+        esac
         printf '%s\n' '[user]' 'profile_name = "lifecycle-operator"'
     } > "${seeded_operator_token}"
 }
@@ -4050,6 +4225,10 @@ quiesce_previous_webtui_runtime() {
     prepare_service_runtime_fixture || return 1
     if v4032_to_v4033_upgrade_selected; then
         attest_v4032_previous_webtui_retirement || return 1
+        return 0
+    fi
+    if v4033_to_v4040_upgrade_selected; then
+        attest_v4033_previous_webtui_retirement || return 1
         return 0
     fi
     case "${PACKAGE_FAMILY}" in
@@ -4407,7 +4586,8 @@ seed_live_legacy_webtui_process() {
         deb|rpm) ;;
         *) return 0 ;;
     esac
-    if v4032_to_v4033_upgrade_selected; then
+    if v4032_to_v4033_upgrade_selected || \
+       v4033_to_v4040_upgrade_selected; then
         return 0
     fi
     /opt/syswarden/bin/syswarden-cli web-tui \
@@ -4494,14 +4674,46 @@ assert_preserved() {
     check_equal "${label}.state.${key}.owner" 0:0 "${actual_owner}"
 }
 
+live_telemetry_contract_for_version() {
+    live_telemetry_version="$1"
+    case "${live_telemetry_version}" in *.*) ;; *) return 1 ;; esac
+    live_telemetry_major="${live_telemetry_version%%.*}"
+    live_telemetry_remainder="${live_telemetry_version#*.}"
+    live_telemetry_minor="${live_telemetry_remainder%%.*}"
+    case "${live_telemetry_major}" in ''|*[!0-9]*) return 1 ;; esac
+    case "${live_telemetry_minor}" in ''|*[!0-9]*) return 1 ;; esac
+    if [ "${live_telemetry_major}" -gt 4 ] || \
+       { [ "${live_telemetry_major}" -eq 4 ] && \
+         [ "${live_telemetry_minor}" -ge 4 ]; }; then
+        printf '%s\n' kpi-v1
+    else
+        printf '%s\n' legacy
+    fi
+}
+
 live_telemetry_schema_valid() {
     live_telemetry_path="$1"
+    live_telemetry_contract="$2"
+    case "${live_telemetry_contract}" in legacy|kpi-v1) ;; *) return 1 ;; esac
     [ -f "${live_telemetry_path}" ] && [ ! -L "${live_telemetry_path}" ] || return 1
     live_telemetry_size="$(wc -c < "${live_telemetry_path}" 2>/dev/null | tr -d ' ')" || return 1
     case "${live_telemetry_size}" in ''|*[!0-9]*) return 1 ;; esac
     [ "${live_telemetry_size}" -gt 0 ] && [ "${live_telemetry_size}" -le 8388608 ] || return 1
-    jq -e '
+    jq -e --arg kpi_contract "${live_telemetry_contract}" '
         def integer: type == "number" and (floor == .);
+        def optional_string($key):
+            (has($key) | not) or (.[$key] | type == "string");
+        def optional_nonnegative_integer($key):
+            (has($key) | not) or (.[$key] | integer and . >= 0);
+        def optional_score($key):
+            (has($key) | not) or
+            (.[$key] | integer and . >= 0 and . <= 100);
+        def optional_boolean($key):
+            (has($key) | not) or (.[$key] | type == "boolean");
+        def attacker_base_keys:
+            ["asn", "country", "hits", "ip", "last_seen", "org", "port", "severity", "threat"];
+        def attacker_kpi_optional_keys:
+            ["attested_hits", "degraded_hits", "effective_threshold", "effective_window_seconds", "enforcement_action", "enforcement_jail", "first_seen", "hit_evidence", "hit_quality", "jail_hits", "legacy_hits", "metric_quality", "metric_scope", "peak_window_hits", "policy_hits", "primary_jail", "recorded_hits", "risk_category", "risk_model_version", "selected_policy_quality", "severity_score", "signature_catalog_sha256", "signature_catalog_version", "threshold_evidence", "threshold_reached"];
         type == "object" and
         (keys == ["github_release", "github_stars", "layer3", "profile_name", "system", "timestamp", "waf", "whitelist"]) and
         (has("ha") | not) and
@@ -4547,10 +4759,46 @@ live_telemetry_schema_valid() {
             (.zero_trust_mode | type == "boolean")) and
         (.waf |
             type == "object" and
-            (keys == ["active_signatures", "allowed_events", "banned_ips", "risk_radar", "signatures_data", "sparkline_24h", "targeted_ports", "top_attackers", "total_banned", "total_detected"]) and
+            ((keys - ["journal_bytes_scanned", "journal_bytes_total", "journal_decode_errors", "journal_scan_complete", "kpi_evidence_quality", "metric_admitted_events", "metric_excluded_events", "metric_rejected_events"]) == ["active_signatures", "allowed_events", "banned_ips", "risk_radar", "signatures_data", "sparkline_24h", "targeted_ports", "top_attackers", "total_banned", "total_detected"]) and
             (.total_banned | integer) and
             (.total_detected | integer) and
             (.active_signatures | integer) and
+            (
+                ($kpi_contract == "legacy" and
+                 (has("kpi_evidence_quality") | not) and
+                 (has("journal_scan_complete") | not) and
+                 (has("journal_bytes_total") | not) and
+                 (has("journal_bytes_scanned") | not) and
+                 (has("journal_decode_errors") | not) and
+                 (has("metric_rejected_events") | not) and
+                 (has("metric_excluded_events") | not) and
+                 (has("metric_admitted_events") | not)) or
+                ($kpi_contract == "kpi-v1" and
+                 has("kpi_evidence_quality") and
+                 has("journal_scan_complete") and
+                 has("journal_bytes_total") and
+                 has("journal_bytes_scanned") and
+                 has("journal_decode_errors") and
+                 has("metric_rejected_events") and
+                 has("metric_excluded_events") and
+                 has("metric_admitted_events") and
+                 (.kpi_evidence_quality == "complete" or
+                  .kpi_evidence_quality == "degraded") and
+                 (.journal_scan_complete | type == "boolean") and
+                 (.journal_bytes_total | integer and . >= 0) and
+                 (.journal_bytes_scanned | integer and . >= 0) and
+                 (.journal_decode_errors | integer and . >= 0) and
+                 (.metric_rejected_events | integer and . >= 0) and
+                 (.metric_excluded_events | integer and . >= 0) and
+                 (.metric_admitted_events | integer and . >= 0) and
+                 (.journal_bytes_scanned <= .journal_bytes_total) and
+                 (if .kpi_evidence_quality == "complete" then
+                      .journal_scan_complete and
+                      .journal_bytes_scanned == .journal_bytes_total and
+                      .journal_decode_errors == 0 and
+                      .metric_rejected_events == 0
+                  else true end))
+            ) and
             (.signatures_data | type == "array" and all(.[];
                 type == "object" and
                 (keys == ["count", "mitre", "name"]) and
@@ -4576,7 +4824,9 @@ live_telemetry_schema_valid() {
                 (.action | type == "string"))) and
             (.top_attackers | type == "array" and all(.[];
                 type == "object" and
-                (keys == ["asn", "country", "hits", "ip", "last_seen", "org", "port", "severity", "threat"]) and
+                (($kpi_contract == "legacy" and keys == attacker_base_keys) or
+                 ($kpi_contract == "kpi-v1" and
+                  (keys - attacker_kpi_optional_keys) == attacker_base_keys)) and
                 (.ip | type == "string") and
                 (.severity | type == "string") and
                 (.port | type == "string") and
@@ -4585,7 +4835,32 @@ live_telemetry_schema_valid() {
                 (.threat | type == "string") and
                 (.org | type == "string") and
                 (.hits | integer) and
-                (.last_seen | type == "string"))) and
+                (.last_seen | type == "string") and
+                optional_string("first_seen") and
+                optional_string("primary_jail") and
+                optional_string("enforcement_jail") and
+                optional_string("enforcement_action") and
+                optional_nonnegative_integer("jail_hits") and
+                optional_nonnegative_integer("policy_hits") and
+                optional_nonnegative_integer("attested_hits") and
+                optional_nonnegative_integer("recorded_hits") and
+                optional_nonnegative_integer("legacy_hits") and
+                optional_string("risk_category") and
+                optional_score("severity_score") and
+                optional_nonnegative_integer("peak_window_hits") and
+                optional_nonnegative_integer("effective_threshold") and
+                optional_nonnegative_integer("effective_window_seconds") and
+                optional_string("metric_quality") and
+                optional_string("selected_policy_quality") and
+                optional_boolean("threshold_reached") and
+                optional_string("threshold_evidence") and
+                optional_string("metric_scope") and
+                optional_string("hit_evidence") and
+                optional_string("hit_quality") and
+                optional_nonnegative_integer("degraded_hits") and
+                optional_string("risk_model_version") and
+                optional_string("signature_catalog_version") and
+                optional_string("signature_catalog_sha256"))) and
             (.risk_radar | . == null or (type == "array" and all(.[]; integer))) and
             (.sparkline_24h | type == "array" and length == 24 and all(.[]; integer)) and
             (.allowed_events | . == null or
@@ -4607,6 +4882,7 @@ live_telemetry_schema_valid() {
 assert_live_telemetry_data() {
     label="$1"
     live_telemetry_path="${2:-/var/lib/syswarden/ui/data.json}"
+    live_telemetry_contract="${3:-invalid}"
     if [ -f "${live_telemetry_path}" ] && [ ! -L "${live_telemetry_path}" ]; then
         actual_type=regular
         actual_mode="$(file_mode "${live_telemetry_path}" 2>/dev/null || true)"
@@ -4624,7 +4900,8 @@ assert_live_telemetry_data() {
                 fi
                 ;;
         esac
-        if live_telemetry_schema_valid "${live_telemetry_path}"; then
+        if live_telemetry_schema_valid \
+            "${live_telemetry_path}" "${live_telemetry_contract}"; then
             actual_schema=dashboard-data-v1
         fi
     elif [ -L "${live_telemetry_path}" ]; then
@@ -4761,7 +5038,8 @@ expected_upgrade_rollback_token_contract() {
     esac
     if v4028_to_v4032_transition_selected; then
         printf '%s\n' historical-webtui-credential
-    elif v4032_to_v4033_transition_selected; then
+    elif v4032_to_v4033_transition_selected || \
+         v4033_to_v4040_transition_selected; then
         printf '%s\n' byte-exact
     else
         return 1
@@ -4802,7 +5080,19 @@ assert_all_state_preserved() {
     assert_preserved "${label}" list_ipv6 /etc/syswarden/lists/syswarden_blacklist.ipv6 "${STATE_LIST_IPV6_HASH}" 600
     assert_preserved "${label}" operator_data /var/lib/syswarden/ui/lifecycle-operator.json "${STATE_OPERATOR_DATA_HASH}" 600
     assert_preserved "${label}" certificate /etc/syswarden/tls/operator.pem "${STATE_CERT_HASH}" 600
-    assert_live_telemetry_data "${label}"
+    live_telemetry_expected_version="${EXPECTED_CANDIDATE_VERSION}"
+    case "${SCENARIO}:${label}" in
+        upgrade-rollback:previous|upgrade-rollback:rollback)
+            live_telemetry_expected_version="${EXPECTED_PREVIOUS_VERSION}"
+            ;;
+    esac
+    live_telemetry_contract="$(
+        live_telemetry_contract_for_version \
+            "${live_telemetry_expected_version}" 2>/dev/null || true
+    )"
+    assert_live_telemetry_data \
+        "${label}" /var/lib/syswarden/ui/data.json \
+        "${live_telemetry_contract}"
 }
 
 assert_deb_removal_log_preserved() {
@@ -4881,6 +5171,7 @@ assert_package_absent() {
 }
 
 rsyslog_reactivation_mode() {
+    [ "$#" -eq 4 ] || return 1
     main_pid_before="$1"
     main_pid_after="$2"
     active_enter_before="$3"
@@ -4907,6 +5198,38 @@ rsyslog_reactivation_mode() {
     return 1
 }
 
+openrc_rsyslog_runtime_snapshot() {
+    [ "$#" -eq 0 ] || return 1
+    rc-service rsyslog status >/dev/null 2>&1 || return 1
+    openrc_rsyslog_pidfile=/run/rsyslog.pid
+    [ -f "${openrc_rsyslog_pidfile}" ] && \
+        [ ! -L "${openrc_rsyslog_pidfile}" ] || return 1
+    [ "$(LC_ALL=C stat -c '%F:%u:%g:%a:%h' "${openrc_rsyslog_pidfile}" \
+        2>/dev/null || true)" = 'regular file:0:0:644:1' ] || return 1
+    openrc_rsyslog_pidfile_size="$(wc -c < "${openrc_rsyslog_pidfile}" | \
+        tr -d ' ')" || return 1
+    case "${openrc_rsyslog_pidfile_size}" in ''|*[!0-9]*) return 1 ;; esac
+    [ "${openrc_rsyslog_pidfile_size}" -gt 0 ] && \
+        [ "${openrc_rsyslog_pidfile_size}" -le 32 ] || return 1
+    openrc_rsyslog_pid="$(cat "${openrc_rsyslog_pidfile}")" || return 1
+    case "${openrc_rsyslog_pid}" in ''|*[!0-9]*) return 1 ;; esac
+    printf '%s' "${openrc_rsyslog_pid}" | \
+        cmp -s - "${openrc_rsyslog_pidfile}" || return 1
+    [ "${openrc_rsyslog_pid}" -gt 1 ] && \
+        kill -0 "${openrc_rsyslog_pid}" 2>/dev/null || return 1
+    [ "$(cat "/proc/${openrc_rsyslog_pid}/comm" \
+        2>/dev/null || true)" = rsyslogd ] || return 1
+    [ "$(readlink "/proc/${openrc_rsyslog_pid}/exe" \
+        2>/dev/null || true)" = /usr/sbin/rsyslogd ] || return 1
+    openrc_rsyslog_starttime="$(
+        awk '{ print $22 }' "/proc/${openrc_rsyslog_pid}/stat" 2>/dev/null
+    )" || return 1
+    case "${openrc_rsyslog_starttime}" in ''|*[!0-9]*) return 1 ;; esac
+    [ "${openrc_rsyslog_starttime}" -gt 0 ] || return 1
+    printf '%s:%s\n' \
+        "${openrc_rsyslog_pid}" "${openrc_rsyslog_starttime}"
+}
+
 attest_owned_cron_seed_state() {
     syswarden_owned_cron_path="$1"
     syswarden_owned_cron_evidence_label="$2"
@@ -4923,12 +5246,13 @@ attest_owned_cron_seed_state() {
 }
 
 seed_generated_runtime_artifacts() {
-    rsyslog_contract="${1:-ambiguous-rsyslog}"
-    evidence_label="${2:-}"
+    [ "$#" -eq 2 ] || return 1
+    rsyslog_contract="$1"
+    evidence_label="$2"
     mkdir -p /etc/rsyslog.d
     case "${rsyslog_contract}" in
         exact-rsyslog)
-            case "${PACKAGE_FAMILY}" in deb|rpm) ;; *) return 1 ;; esac
+            case "${PACKAGE_FAMILY}" in deb|rpm|apk) ;; *) return 1 ;; esac
             [ -n "${evidence_label}" ] || return 1
             for path in \
                 /etc/rsyslog.d/99-syswarden-siem.conf \
@@ -4998,11 +5322,25 @@ seed_generated_runtime_artifacts() {
                 "$(cat /tmp/syswarden-rsyslog-waf-size)" \
                 "$(cat /tmp/syswarden-rsyslog-waf-before)")" \
                 /etc/rsyslog.d/.syswarden-rsyslog-provenance-v1 || return 1
-            LC_ALL=C systemctl show rsyslog.service -p MainPID --value > \
-                /tmp/syswarden-rsyslog-pid-before || return 1
-            LC_ALL=C systemctl show rsyslog.service \
-                -p ActiveEnterTimestampMonotonic --value > \
-                /tmp/syswarden-rsyslog-active-enter-before || return 1
+            case "${PACKAGE_FAMILY}" in
+                deb|rpm)
+                    LC_ALL=C systemctl show rsyslog.service \
+                        -p MainPID --value > \
+                        /tmp/syswarden-rsyslog-pid-before || return 1
+                    LC_ALL=C systemctl show rsyslog.service \
+                        -p ActiveEnterTimestampMonotonic --value > \
+                        /tmp/syswarden-rsyslog-active-enter-before || return 1
+                    ;;
+                apk)
+                    openrc_rsyslog_snapshot="$(
+                        openrc_rsyslog_runtime_snapshot
+                    )" || return 1
+                    printf '%s\n' "${openrc_rsyslog_snapshot%%:*}" > \
+                        /tmp/syswarden-rsyslog-pid-before || return 1
+                    printf '%s\n' "${openrc_rsyslog_snapshot#*:}" > \
+                        /tmp/syswarden-rsyslog-active-enter-before || return 1
+                    ;;
+            esac
             rsyslog_pid_before="$(cat /tmp/syswarden-rsyslog-pid-before)"
             rsyslog_active_enter_before="$(
                 cat /tmp/syswarden-rsyslog-active-enter-before
@@ -5093,8 +5431,9 @@ seed_generated_runtime_artifacts() {
 }
 
 assert_generated_runtime_artifact_contract() {
+    [ "$#" -eq 2 ] || return 1
     label="$1"
-    rsyslog_contract="${2:-ambiguous-rsyslog}"
+    rsyslog_contract="$2"
     if prepare_service_runtime_fixture; then
         record pass "${PREFIX}.${label}.service_manager_calls" "real init, active service manager, and enabled cron provider remain attestable"
     else
@@ -5159,15 +5498,39 @@ assert_generated_runtime_artifact_contract() {
             fi
             rsyslog_pid_before="$(cat /tmp/syswarden-rsyslog-pid-before 2>/dev/null || true)"
             rsyslog_active_enter_before="$(cat /tmp/syswarden-rsyslog-active-enter-before 2>/dev/null || true)"
-            rsyslog_pid_after="$(LC_ALL=C systemctl show rsyslog.service -p MainPID --value 2>/dev/null || true)"
-            rsyslog_active_enter_after="$(LC_ALL=C systemctl show rsyslog.service -p ActiveEnterTimestampMonotonic --value 2>/dev/null || true)"
+            rsyslog_active_after=0
+            case "${PACKAGE_FAMILY}" in
+                deb|rpm)
+                    rsyslog_pid_after="$(LC_ALL=C systemctl show \
+                        rsyslog.service -p MainPID --value 2>/dev/null || true)"
+                    rsyslog_active_enter_after="$(LC_ALL=C systemctl show \
+                        rsyslog.service -p ActiveEnterTimestampMonotonic \
+                        --value 2>/dev/null || true)"
+                    [ "$(systemctl is-active rsyslog.service \
+                        2>/dev/null || true)" = active ] && \
+                        rsyslog_active_after=1
+                    ;;
+                apk)
+                    rsyslog_openrc_after="$(
+                        openrc_rsyslog_runtime_snapshot 2>/dev/null || true
+                    )"
+                    rsyslog_pid_after="${rsyslog_openrc_after%%:*}"
+                    rsyslog_active_enter_after="${rsyslog_openrc_after#*:}"
+                    [ -n "${rsyslog_openrc_after}" ] && \
+                        rsyslog_active_after=1
+                    ;;
+                *)
+                    rsyslog_pid_after=0
+                    rsyslog_active_enter_after=0
+                    ;;
+            esac
             case "${rsyslog_pid_after}" in ''|*[!0-9]*) rsyslog_pid_after=0 ;; esac
             rsyslog_reactivation_proof="$(rsyslog_reactivation_mode \
                 "${rsyslog_pid_before}" "${rsyslog_pid_after}" \
                 "${rsyslog_active_enter_before}" \
                 "${rsyslog_active_enter_after}" 2>/dev/null || true)"
             if [ "${rsyslog_reactivation_proof}" = restart ] && \
-               [ "$(systemctl is-active rsyslog.service 2>/dev/null || true)" = active ] && \
+               [ "${rsyslog_active_after}" -eq 1 ] && \
                [ "${rsyslog_pid_after}" -gt 1 ] && \
                kill -0 "${rsyslog_pid_after}" 2>/dev/null; then
                 record pass "${PREFIX}.${label}.generated.rsyslog_reactivated" \
@@ -5406,10 +5769,10 @@ scenario_remove() {
             assert_dedicated_roots_absent purge-after-remove
             ;;
         apk)
-            seed_generated_runtime_artifacts || return
+            seed_generated_runtime_artifacts exact-rsyslog remove || return
             run_step remove remove_package || return
             assert_package_absent remove candidate
-            assert_generated_runtime_artifact_contract remove
+            assert_generated_runtime_artifact_contract remove exact-rsyslog
             assert_dedicated_roots_absent remove
             ;;
         rpm)
@@ -5437,10 +5800,10 @@ scenario_purge() {
     run_install_step install.candidate "${CANDIDATE_PACKAGE}" || return
     probe_payload fresh candidate "${CANDIDATE_VERSION}"
     assert_all_state_preserved fresh
-    seed_generated_runtime_artifacts || return
+    seed_generated_runtime_artifacts exact-rsyslog purge || return
     run_step purge purge_package || return
     assert_package_absent purge candidate
-    assert_generated_runtime_artifact_contract purge
+    assert_generated_runtime_artifact_contract purge exact-rsyslog
     case "${PACKAGE_FAMILY}" in
         deb)
             assert_dedicated_roots_absent purge
@@ -6962,8 +7325,12 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
             + "    syswarden_namespace_fail NS13_FAILED_UNITS \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" ''\n"
             + "fi\n"
         )
-        if spec.distribution == "fedora":
-            expected_masks = "\n".join(FEDORA_LAB_MASKED_UNITS)
+        expected_mask_inventory = SYSTEMD_LAB_MASKED_UNITS_BY_CELL.get(
+            spec.cell_id
+        )
+        if expected_mask_inventory is not None:
+            expected_masks = "\n".join(expected_mask_inventory)
+            mask_predicate = SYSTEMD_LAB_MASK_PREDICATES_BY_CELL[spec.cell_id]
             systemd_runtime += (
                 "syswarden_namespace_status=0\n"
                 "syswarden_namespace_actual=\"$(systemctl list-unit-files --state=masked "
@@ -6973,9 +7340,10 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
                 "else\n"
                 "    actual_masks=\"${syswarden_namespace_actual}\"\n"
                 "fi\n"
-                f"syswarden_namespace_expect_equal NS14_FEDORA_MASKS \"${{syswarden_namespace_status}}\" \"${{actual_masks}}\" \"{expected_masks}\"\n"
+                f"syswarden_namespace_expect_equal {mask_predicate} \"${{syswarden_namespace_status}}\" \"${{actual_masks}}\" \"{expected_masks}\"\n"
             )
         return systemd_runtime
+    openrc_contract = alpine_openrc_contract(spec.version)
     provider_sha256 = hashlib.sha256(
         ALPINE_LAB_NETWORK_PROVIDER.encode("utf-8")
     ).hexdigest()
@@ -6983,10 +7351,11 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
         common
         + "syswarden_apk_info_actual=\"$(\n"
         + "    syswarden_apk_info_status=0\n"
-        + f"    apk info -e 'openrc={ALPINE_OPENRC_VERSION}' 2>&1 || syswarden_apk_info_status=$?\n"
+        + f"    apk info -e 'openrc={openrc_contract.package_version}' 2>&1 || syswarden_apk_info_status=$?\n"
+        + f"    apk info -e 'openrc-init={openrc_contract.package_version}' 2>&1 || syswarden_apk_info_status=$?\n"
         + "    printf 'syswarden-apk-info-rc=%s' \"${syswarden_apk_info_status}\"\n"
         + ")\"\n"
-        + "syswarden_apk_info_expected=\"$(printf 'openrc\\nsyswarden-apk-info-rc=0')\"\n"
+        + "syswarden_apk_info_expected=\"$(printf 'openrc\\nopenrc-init\\nsyswarden-apk-info-rc=0')\"\n"
         + "syswarden_namespace_expect_equal NS15_OPENRC_PACKAGE 0 \"${syswarden_apk_info_actual}\" \"${syswarden_apk_info_expected}\"\n"
         + "syswarden_namespace_status=0\n"
         + "syswarden_namespace_actual=\"$(sha256sum /etc/init.d/syswarden-lab-net 2>&1)\" || syswarden_namespace_status=$?\n"
@@ -6999,7 +7368,7 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
         + "syswarden_namespace_expect_equal NS18_APK_RC_CONF_STAT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 'regular file:0:0:644'\n"
         + "syswarden_namespace_status=0\n"
         + "syswarden_namespace_actual=\"$(sha256sum /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
-        + f"syswarden_namespace_expect_equal NS19_APK_RC_CONF_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{ALPINE_RC_CONF_POST_SHA256}  /etc/rc.conf\"\n"
+        + f"syswarden_namespace_expect_equal NS19_APK_RC_CONF_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{openrc_contract.rc_conf_post_sha256}  /etc/rc.conf\"\n"
         + "syswarden_namespace_status=0\n"
         + "syswarden_namespace_actual=\"$(grep -Fxc 'rc_sys=\"podman\"' /etc/rc.conf 2>&1)\" || syswarden_namespace_status=$?\n"
         + "syswarden_namespace_expect_integer NS20_APK_RC_SYS_LINE \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
@@ -7038,9 +7407,11 @@ syswarden_namespace_expect_status NS06_ETH0_UP "${{syswarden_namespace_status}}"
         + "syswarden_namespace_expect_equal NS25_APK_HOSTNAME_STAT \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 'regular file:0:0:755'\n"
         + "syswarden_namespace_status=0\n"
         + "syswarden_namespace_actual=\"$(sha256sum /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
-        + f"syswarden_namespace_expect_equal NS26_APK_HOSTNAME_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{ALPINE_HOSTNAME_INIT_POST_SHA256}  /etc/init.d/hostname\"\n"
+        + f"syswarden_namespace_expect_equal NS26_APK_HOSTNAME_SHA \"${{syswarden_namespace_status}}\" \"${{syswarden_namespace_actual}}\" \"{openrc_contract.hostname_init_post_sha256}  /etc/init.d/hostname\"\n"
         + "syswarden_namespace_status=0\n"
-        + "syswarden_namespace_actual=\"$(grep -Ec '^[[:space:]]*keyword -prefix -lxc -docker -podman$' /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
+        + "syswarden_namespace_actual=\"$(grep -Ec '"
+        + openrc_contract.hostname_keyword_post_pattern
+        + "' /etc/init.d/hostname 2>&1)\" || syswarden_namespace_status=$?\n"
         + "syswarden_namespace_expect_integer NS27_APK_HOSTNAME_KEYWORD \"${syswarden_namespace_status}\" \"${syswarden_namespace_actual}\" 1\n"
         + "syswarden_namespace_status=0\n"
         + "syswarden_namespace_pid1_environment=\"$(tr '\\000' '\\n' < /proc/1/environ 2>&1)\" || syswarden_namespace_status=$?\n"

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -1434,12 +1434,92 @@ class PackageLifecycleLabTests(unittest.TestCase):
             {("deb", "amd64"), ("rpm", "x86_64"), ("apk", "x86_64")},
         )
         self.assertIn(
-            "sed -i '\\|^path-exclude /usr/share/doc/\\*$|d'",
+            "path-exclude([[:space:]]+|[[:space:]]*=[[:space:]]*)",
+            package_lifecycle_lab.DEB_BOOTSTRAP,
+        )
+        self.assertIn(
+            "for syswarden_dpkg_config in /etc/dpkg/dpkg.cfg.d/*; do",
+            package_lifecycle_lab.DEB_BOOTSTRAP,
+        )
+        self.assertIn(
+            '[ ! -L "${syswarden_dpkg_config}" ] || exit 1',
+            package_lifecycle_lab.DEB_BOOTSTRAP,
+        )
+        self.assertNotIn(
+            "if [ -f /etc/dpkg/dpkg.cfg.d/docker ]",
             package_lifecycle_lab.DEB_BOOTSTRAP,
         )
         self.assertIn("curl-minimal", package_lifecycle_lab.RPM_BOOTSTRAP)
         self.assertIn("diffutils", package_lifecycle_lab.RPM_BOOTSTRAP)
         self.assertNotIn(" ipset curl wget", package_lifecycle_lab.RPM_BOOTSTRAP)
+
+    def test_deb_bootstrap_removes_both_doc_path_exclude_syntaxes_only(
+        self,
+    ) -> None:
+        config_root = self.root / "dpkg.cfg.d"
+        config_root.mkdir()
+        docker_config = config_root / "docker"
+        excludes_config = config_root / "excludes"
+        other_config = config_root / "other"
+        docker_config.write_text(
+            "path-exclude /usr/share/doc/*\n"
+            "path-exclude=/usr/share/man/*\n"
+            "# path-exclude /usr/share/doc/*\n",
+            encoding="utf-8",
+        )
+        excludes_config.write_text(
+            "  path-exclude = /usr/share/doc/*\n"
+            "path-exclude /usr/share/doc-base/*\n",
+            encoding="utf-8",
+        )
+        other_original = (
+            "path-include=/usr/share/doc/syswarden/*\n"
+            "path-exclude /usr/share/locale/*\n"
+        )
+        other_config.write_text(other_original, encoding="utf-8")
+        production_root = "/etc/dpkg/dpkg.cfg.d"
+        cleanup = package_lifecycle_lab.DEB_BOOTSTRAP.split(
+            f"if [ -d {production_root} ]; then ", 1
+        )[1].split("; fi &&", 1)[0]
+        cleanup = cleanup.replace(
+            production_root,
+            shlex.quote(str(config_root)),
+        )
+        result = subprocess.run(
+            ["/bin/sh", "-eu", "-c", cleanup],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            docker_config.read_text(encoding="utf-8"),
+            "path-exclude=/usr/share/man/*\n"
+            "# path-exclude /usr/share/doc/*\n",
+        )
+        self.assertEqual(
+            excludes_config.read_text(encoding="utf-8"),
+            "path-exclude /usr/share/doc-base/*\n",
+        )
+        self.assertEqual(other_config.read_text(encoding="utf-8"), other_original)
+
+        operator_target = self.root / "operator-dpkg-config"
+        operator_target.write_text(
+            "path-exclude=/usr/share/doc/*\n",
+            encoding="utf-8",
+        )
+        config_root.joinpath("operator-link").symlink_to(operator_target)
+        rejected = subprocess.run(
+            ["/bin/sh", "-eu", "-c", cleanup],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(rejected.returncode, 0, rejected)
+        self.assertEqual(
+            operator_target.read_text(encoding="utf-8"),
+            "path-exclude=/usr/share/doc/*\n",
+        )
 
     def test_rejects_non_official_or_wrong_architecture_platform(self) -> None:
         baseline = package_lifecycle_lab.DEFAULT_PLATFORMS[0]
@@ -1620,8 +1700,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
         self.assertNotIn("/opt/syswarden", containerfile)
         self.assertNotIn("COPY ", containerfile)
 
-    def test_fedora_mask_inventory_is_the_exact_seven_unit_set(self) -> None:
-        expected = (
+    def test_systemd_mask_inventories_are_exact_and_fail_closed(self) -> None:
+        fedora_expected = (
             "dbus-org.freedesktop.oom1.service",
             "dbus-org.freedesktop.resolve1.service",
             "systemd-oomd.service",
@@ -1630,116 +1710,235 @@ class PackageLifecycleLabTests(unittest.TestCase):
             "systemd-resolved-varlink.socket",
             "systemd-resolved.service",
         )
-        self.assertEqual(package_lifecycle_lab.FEDORA_LAB_MASKED_UNITS, expected)
+        ubuntu_base = (
+            "cryptdisks-early.service",
+            "cryptdisks.service",
+            "hwclock.service",
+            "x11-common.service",
+        )
+        ubuntu_targets = (
+            "dev-mqueue.mount",
+            "systemd-ask-password-console.path",
+            "systemd-ask-password-wall.path",
+        )
+        ubuntu_expected = (
+            "cryptdisks-early.service",
+            "cryptdisks.service",
+            "dev-mqueue.mount",
+            "hwclock.service",
+            "systemd-ask-password-console.path",
+            "systemd-ask-password-wall.path",
+            "x11-common.service",
+        )
+        debian_targets = (
+            "dev-mqueue.mount",
+            "run-lock.mount",
+            "tmp.mount",
+            "systemd-ask-password-console.path",
+            "systemd-ask-password-wall.path",
+        )
+        debian_expected = (
+            "cryptdisks-early.service",
+            "cryptdisks.service",
+            "dev-mqueue.mount",
+            "hwclock.service",
+            "run-lock.mount",
+            "systemd-ask-password-console.path",
+            "systemd-ask-password-wall.path",
+            "tmp.mount",
+            "x11-common.service",
+        )
+        self.assertEqual(
+            package_lifecycle_lab.FEDORA_LAB_MASKED_UNITS,
+            fedora_expected,
+        )
         self.assertEqual(
             package_lifecycle_lab.FEDORA_LAB_MASK_TARGETS,
-            expected[2:],
+            fedora_expected[2:],
         )
-        spec = next(
-            item
-            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
-            if item.distribution == "fedora"
+        self.assertEqual(
+            package_lifecycle_lab.UBUNTU_2404_LAB_BASE_MASKED_UNITS,
+            ubuntu_base,
         )
-        containerfile = package_lifecycle_lab.build_containerfile(spec)
-        self.assertIn(
-            "RUN systemctl mask " + " ".join(expected[2:]) + "\n",
-            containerfile,
+        self.assertEqual(
+            package_lifecycle_lab.UBUNTU_2404_LAB_MASK_TARGETS,
+            ubuntu_targets,
         )
-        self.assertNotIn("systemctl mask dbus-org.", containerfile)
-        runtime = package_lifecycle_lab.runtime_namespace_script(spec)
-        expected_masks = "\n".join(expected)
-        self.assertIn(expected_masks, runtime)
-        self.assertNotIn("\\n".join(expected), runtime)
-        self.assertIn("list-unit-files --state=masked", runtime)
-        self.assertNotIn("grep -v", runtime)
-        for predicate in (
-            "NS01_HELPER_SHA",
-            "NS02_HELPER_STAT",
-            "NS03_ETH0_LINK",
-            "NS04_ETH0_DUMMY",
-            "NS05_ETH0_UP_SOURCE",
-            "NS06_ETH0_UP",
-            "NS07_UNIT_SHA",
-            "NS08_UNIT_STAT",
-            "NS09_NET_ENABLED",
-            "NS10_NET_ACTIVE",
-            "NS11_RSYSLOG_ENABLED",
-            "NS12_RSYSLOG_ACTIVE",
-            "NS13_FAILED_UNITS",
-            "NS14_FEDORA_MASKS",
-        ):
-            self.assertEqual(runtime.count(predicate), 1, predicate)
-        syntax = subprocess.run(
-            ["/bin/sh", "-n"],
-            input=package_lifecycle_lab._exec_security_guard_script(spec) + runtime,
-            text=True,
-            capture_output=True,
-            check=False,
+        self.assertEqual(
+            package_lifecycle_lab.UBUNTU_2404_LAB_MASKED_UNITS,
+            ubuntu_expected,
         )
-        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+        self.assertEqual(
+            package_lifecycle_lab.DEBIAN_13_LAB_BASE_MASKED_UNITS,
+            ubuntu_base,
+        )
+        self.assertEqual(
+            package_lifecycle_lab.DEBIAN_13_LAB_MASK_TARGETS,
+            debian_targets,
+        )
+        self.assertEqual(
+            package_lifecycle_lab.DEBIAN_13_LAB_MASKED_UNITS,
+            debian_expected,
+        )
+        expected_targets = {
+            "DEB-13": debian_targets,
+            "DEB-U2404": ubuntu_targets,
+            "RPM-F44": fedora_expected[2:],
+        }
+        expected_inventories = {
+            "DEB-13": debian_expected,
+            "DEB-U2404": ubuntu_expected,
+            "RPM-F44": fedora_expected,
+        }
+        expected_predicates = {
+            "DEB-13": "NS14_DEBIAN_13_MASKS",
+            "DEB-U2404": "NS14_UBUNTU_2404_MASKS",
+            "RPM-F44": "NS14_FEDORA_MASKS",
+        }
+        self.assertEqual(
+            package_lifecycle_lab.SYSTEMD_LAB_MASK_TARGETS_BY_CELL,
+            expected_targets,
+        )
+        self.assertEqual(
+            package_lifecycle_lab.SYSTEMD_LAB_MASKED_UNITS_BY_CELL,
+            expected_inventories,
+        )
+        self.assertEqual(
+            package_lifecycle_lab.SYSTEMD_LAB_MASK_PREDICATES_BY_CELL,
+            expected_predicates,
+        )
+        for cell_id, targets in expected_targets.items():
+            with self.subTest(cell_id=cell_id):
+                expected = expected_inventories[cell_id]
+                predicate = expected_predicates[cell_id]
+                spec = next(
+                    item
+                    for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+                    if item.cell_id == cell_id
+                )
+                containerfile = package_lifecycle_lab.build_containerfile(spec)
+                self.assertIn(
+                    "RUN systemctl mask " + " ".join(targets) + "\n",
+                    containerfile,
+                )
+                for inherited_mask in set(expected) - set(targets):
+                    self.assertNotIn(
+                        f"systemctl mask {inherited_mask}",
+                        containerfile,
+                    )
+                runtime = package_lifecycle_lab.runtime_namespace_script(spec)
+                expected_masks = "\n".join(expected)
+                self.assertIn(expected_masks, runtime)
+                self.assertNotIn("\\n".join(expected), runtime)
+                self.assertIn("list-unit-files --state=masked", runtime)
+                self.assertNotIn("grep -v", runtime)
+                for common_predicate in (
+                    "NS01_HELPER_SHA",
+                    "NS02_HELPER_STAT",
+                    "NS03_ETH0_LINK",
+                    "NS04_ETH0_DUMMY",
+                    "NS05_ETH0_UP_SOURCE",
+                    "NS06_ETH0_UP",
+                    "NS07_UNIT_SHA",
+                    "NS08_UNIT_STAT",
+                    "NS09_NET_ENABLED",
+                    "NS10_NET_ACTIVE",
+                    "NS11_RSYSLOG_ENABLED",
+                    "NS12_RSYSLOG_ACTIVE",
+                    "NS13_FAILED_UNITS",
+                    predicate,
+                ):
+                    self.assertEqual(
+                        runtime.count(common_predicate),
+                        1,
+                        common_predicate,
+                    )
+                syntax = subprocess.run(
+                    ["/bin/sh", "-n"],
+                    input=(
+                        package_lifecycle_lab._exec_security_guard_script(spec)
+                        + runtime
+                    ),
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(syntax.returncode, 0, syntax.stderr)
 
-        masks_start = runtime.rindex(
-            "syswarden_namespace_status=0\n", 0, runtime.index("actual_masks=")
-        )
-        masks_guard = runtime[masks_start:]
+                masks_start = runtime.rindex(
+                    "syswarden_namespace_status=0\n",
+                    0,
+                    runtime.index("actual_masks="),
+                )
+                masks_guard = runtime[masks_start:]
 
-        def attest_masks(value: str) -> subprocess.CompletedProcess[str]:
-            probe = (
-                package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
-                + "systemctl() { printf '%s\\n' \"${MASK_INVENTORY}\"; }\n"
-                + masks_guard
-            )
-            return subprocess.run(
-                ["/bin/sh", "-eu", "-c", probe],
-                env={**os.environ, "MASK_INVENTORY": value},
-                text=True,
-                capture_output=True,
-                check=False,
-            )
+                def attest_masks(value: str) -> subprocess.CompletedProcess[str]:
+                    probe = (
+                        package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                        + "systemctl() { printf '%s\\n' "
+                        '"${MASK_INVENTORY}"; }\n'
+                        + masks_guard
+                    )
+                    return subprocess.run(
+                        ["/bin/sh", "-eu", "-c", probe],
+                        env={**os.environ, "MASK_INVENTORY": value},
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
 
-        canonical = attest_masks(expected_masks)
-        self.assertEqual(canonical.returncode, 0, canonical.stderr)
-        self.assertEqual(canonical.stdout, "")
-        self.assertEqual(canonical.stderr, "")
-        reordered = attest_masks(
-            "\n".join((expected[1], expected[0], *expected[2:]))
-        )
-        self.assertEqual(reordered.returncode, 0, reordered.stderr)
-        for label, adversarial in (
-            ("literal-backslash-n", "\\n".join(expected)),
-            ("missing", "\n".join(expected[:-1])),
-            ("extra", expected_masks + "\noperator.service"),
-            ("duplicate", expected_masks + "\n" + expected[-1]),
-        ):
-            with self.subTest(mask_inventory=label):
-                rejected = attest_masks(adversarial)
-                self.assertEqual(rejected.returncode, 1)
-                self.assertEqual(rejected.stdout, "")
+                canonical = attest_masks(expected_masks)
+                self.assertEqual(canonical.returncode, 0, canonical.stderr)
+                self.assertEqual(canonical.stdout, "")
+                self.assertEqual(canonical.stderr, "")
+                reordered = attest_masks("\n".join(reversed(expected)))
+                self.assertEqual(reordered.returncode, 0, reordered.stderr)
+                for label, adversarial in (
+                    ("literal-backslash-n", "\\n".join(expected)),
+                    ("missing", "\n".join(expected[:-1])),
+                    ("extra", expected_masks + "\noperator.service"),
+                    ("duplicate", expected_masks + "\n" + expected[-1]),
+                ):
+                    with self.subTest(
+                        cell_id=cell_id,
+                        mask_inventory=label,
+                    ):
+                        rejected = attest_masks(adversarial)
+                        self.assertEqual(rejected.returncode, 1)
+                        self.assertEqual(rejected.stdout, "")
+                        self.assertIn(
+                            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
+                            + f"\tpredicate={predicate}\trc=0\t",
+                            rejected.stderr,
+                        )
+
+                command_failure_probe = (
+                    package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
+                    + "systemctl() { printf 'permission denied\\n'; "
+                    "return 7; }\n"
+                    + masks_guard
+                )
+                command_failure = subprocess.run(
+                    ["/bin/sh", "-eu", "-c", command_failure_probe],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(command_failure.returncode, 1)
                 self.assertIn(
                     package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
-                    + "\tpredicate=NS14_FEDORA_MASKS\trc=0\t",
-                    rejected.stderr,
+                    + f"\tpredicate={predicate}\trc=7"
+                    + "\tactual_bytes=17"
+                    + f"\tactual_hex_prefix={'permission denied'.encode().hex()}",
+                    command_failure.stderr,
                 )
 
-        command_failure_probe = (
-            package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
-            + "systemctl() { printf 'permission denied\\n'; return 7; }\n"
-            + masks_guard
-        )
-        command_failure = subprocess.run(
-            ["/bin/sh", "-eu", "-c", command_failure_probe],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        self.assertEqual(command_failure.returncode, 1)
-        self.assertIn(
-            package_lifecycle_lab.NAMESPACE_FAILURE_MARKER
-            + "\tpredicate=NS14_FEDORA_MASKS\trc=7"
-            + "\tactual_bytes=17"
-            + f"\tactual_hex_prefix={'permission denied'.encode().hex()}",
-            command_failure.stderr,
-        )
+        for spec in package_lifecycle_lab.DEFAULT_PLATFORMS:
+            if spec.family == "deb" and spec.cell_id not in expected_targets:
+                self.assertNotIn(
+                    "RUN systemctl mask ",
+                    package_lifecycle_lab.build_containerfile(spec),
+                )
 
     def test_namespace_failure_record_is_numbered_hex_and_injection_safe(
         self,
@@ -1855,6 +2054,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         )
         containerfile = package_lifecycle_lab.build_containerfile(spec)
         self.assertIn("apk info -e 'openrc=0.62.6-r0'", containerfile)
+        self.assertIn("apk info -e 'openrc-init=0.62.6-r0'", containerfile)
         self.assertIn(package_lifecycle_lab.ALPINE_RC_CONF_PRE_SHA256, containerfile)
         self.assertIn(package_lifecycle_lab.ALPINE_RC_CONF_APPEND_BASE64, containerfile)
         self.assertIn(package_lifecycle_lab.ALPINE_RC_CONF_POST_SHA256, containerfile)
@@ -1894,6 +2094,7 @@ class PackageLifecycleLabTests(unittest.TestCase):
         runtime = package_lifecycle_lab.runtime_namespace_script(spec)
         for expected in (
             "openrc=0.62.6-r0",
+            "openrc-init=0.62.6-r0",
             package_lifecycle_lab.ALPINE_RC_CONF_POST_SHA256,
             package_lifecycle_lab.ALPINE_HOSTNAME_INIT_POST_SHA256,
             'container=podman',
@@ -1985,22 +2186,32 @@ class PackageLifecycleLabTests(unittest.TestCase):
             runtime_lines[apk_guard_start : apk_guard_end + 1]
         )
         self.assertIn("NS15_OPENRC_PACKAGE", apk_guard)
-        for output, command_status, accepted in (
-            ("openrc\n", 0, True),
-            ("openrc", 0, False),
-            ("openrc\n\n", 0, False),
-            ("", 0, False),
-            ("OpenRC\n", 0, False),
-            ("openrc\nextra\n", 0, False),
-            ("openrc\n", 7, False),
+        for openrc_output, openrc_init_output, command_status, accepted in (
+            ("openrc\n", "openrc-init\n", 0, True),
+            ("openrc", "openrc-init\n", 0, False),
+            ("openrc\n", "openrc-init", 0, False),
+            ("openrc\n\n", "openrc-init\n", 0, False),
+            ("", "openrc-init\n", 0, False),
+            ("OpenRC\n", "openrc-init\n", 0, False),
+            ("openrc\n", "OpenRC-init\n", 0, False),
+            ("openrc\nextra\n", "openrc-init\n", 0, False),
+            ("openrc\n", "openrc-init\n", 7, False),
         ):
-            with self.subTest(apk_info=output, command_status=command_status):
+            with self.subTest(
+                apk_info=(openrc_output, openrc_init_output),
+                command_status=command_status,
+            ):
                 probe = (
                     "apk() {\n"
                     "    [ \"$#\" -eq 3 ] && [ \"$1\" = info ] && "
-                    "[ \"$2\" = -e ] && "
-                    "[ \"$3\" = 'openrc=0.62.6-r0' ] || return 96\n"
-                    f"    printf '%s' {shlex.quote(output)}\n"
+                    "[ \"$2\" = -e ] || return 96\n"
+                    "    case \"$3\" in\n"
+                    "        openrc=0.62.6-r0) "
+                    f"printf '%s' {shlex.quote(openrc_output)} ;;\n"
+                    "        openrc-init=0.62.6-r0) "
+                    f"printf '%s' {shlex.quote(openrc_init_output)} ;;\n"
+                    "        *) return 96 ;;\n"
+                    "    esac\n"
                     f"    return {command_status}\n"
                     "}\n"
                     + package_lifecycle_lab.NAMESPACE_ATTESTATION_HELPERS
@@ -2092,6 +2303,127 @@ class PackageLifecycleLabTests(unittest.TestCase):
                 "configuration payload is not exact",
             ):
                 package_lifecycle_lab.build_containerfile(spec)
+
+    def test_alpine_openrc_contract_is_total_exact_and_cell_bound(self) -> None:
+        expected_contracts = {
+            "3.22": {
+                "package_version": "0.62.6-r0",
+                "rc_conf_pre_sha256": (
+                    "87799a1b4fa5e3941276e695e8525fcd2c1a08f551d02d1c0b1bdfdd67a71dce"
+                ),
+                "rc_conf_post_sha256": (
+                    "6653be4e72083b79317918a08493ad54671441f83b646555f56c30117a0c0b8f"
+                ),
+                "hostname_init_pre_sha256": (
+                    "29d467628434f1a56b37c0042463ee0253a12ce8743e42f65e9dcbc4ed34ff20"
+                ),
+                "hostname_init_post_sha256": (
+                    "11eb8ad952a72d82a63987faf51f8d0248acd765f8327f117436b45a378f4f91"
+                ),
+                "hostname_keyword_pre_pattern": (
+                    "^[[:space:]]*keyword -prefix -lxc -docker$"
+                ),
+                "hostname_keyword_post_pattern": (
+                    "^[[:space:]]*keyword -prefix -lxc -docker -podman$"
+                ),
+                "hostname_mutation": (
+                    "sed -i 's/^\\([[:space:]]*keyword -prefix -lxc "
+                    "-docker\\)$/\\1 -podman/' /etc/init.d/hostname && "
+                ),
+            },
+            "3.24": {
+                "package_version": "0.63.2-r0",
+                "rc_conf_pre_sha256": (
+                    "c7ce810693680cca288134adc0c109c192aedd37cbbdef7b4f4dc82c8c38696b"
+                ),
+                "rc_conf_post_sha256": (
+                    "7efeb86569fa28df86e1b59afa43666330056ebee1a049e365c3beb4625ca3a8"
+                ),
+                "hostname_init_pre_sha256": (
+                    "b52fa145995729852fa931aef5e7426c4bf1413a105a3e55674fb35342b4705a"
+                ),
+                "hostname_init_post_sha256": (
+                    "b52fa145995729852fa931aef5e7426c4bf1413a105a3e55674fb35342b4705a"
+                ),
+                "hostname_keyword_pre_pattern": (
+                    "^[[:space:]]*keyword -docker -podman -lxc -prefix "
+                    "-systemd-nspawn -wsl$"
+                ),
+                "hostname_keyword_post_pattern": (
+                    "^[[:space:]]*keyword -docker -podman -lxc -prefix "
+                    "-systemd-nspawn -wsl$"
+                ),
+                "hostname_mutation": "",
+            },
+        }
+        apk_specs = tuple(
+            spec
+            for spec in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if spec.family == "apk"
+        )
+        self.assertEqual(
+            [(spec.cell_id, spec.version) for spec in apk_specs],
+            [("APK-322", "3.22"), ("APK-324", "3.24")],
+        )
+        self.assertEqual(
+            set(package_lifecycle_lab.ALPINE_OPENRC_CONTRACTS),
+            set(expected_contracts),
+        )
+
+        for spec in apk_specs:
+            with self.subTest(cell_id=spec.cell_id):
+                contract = package_lifecycle_lab.alpine_openrc_contract(
+                    spec.version
+                )
+                expected = expected_contracts[spec.version]
+                self.assertEqual(
+                    {
+                        field: getattr(contract, field)
+                        for field in expected
+                    },
+                    expected,
+                )
+                pinned_install = (
+                    "apk add --no-cache "
+                    f"openrc={expected['package_version']} "
+                    f"openrc-init={expected['package_version']}"
+                )
+                self.assertIn(pinned_install, spec.bootstrap_command)
+                containerfile = package_lifecycle_lab.build_containerfile(spec)
+                runtime = package_lifecycle_lab.runtime_namespace_script(spec)
+                for expected in (
+                    f"apk info -e 'openrc={expected_contracts[spec.version]['package_version']}'",
+                    f"apk info -e 'openrc-init={expected_contracts[spec.version]['package_version']}'",
+                    expected_contracts[spec.version]["rc_conf_pre_sha256"],
+                    expected_contracts[spec.version]["rc_conf_post_sha256"],
+                    expected_contracts[spec.version]["hostname_init_pre_sha256"],
+                    expected_contracts[spec.version]["hostname_init_post_sha256"],
+                    expected_contracts[spec.version]["hostname_keyword_pre_pattern"],
+                    expected_contracts[spec.version]["hostname_keyword_post_pattern"],
+                ):
+                    self.assertIn(expected, containerfile)
+                for expected in (
+                    f"openrc={expected_contracts[spec.version]['package_version']}",
+                    f"openrc-init={expected_contracts[spec.version]['package_version']}",
+                    expected_contracts[spec.version]["rc_conf_post_sha256"],
+                    expected_contracts[spec.version]["hostname_init_post_sha256"],
+                    expected_contracts[spec.version]["hostname_keyword_post_pattern"],
+                ):
+                    self.assertIn(expected, runtime)
+                mutation = expected_contracts[spec.version]["hostname_mutation"]
+                if mutation:
+                    self.assertIn(mutation, containerfile)
+                else:
+                    self.assertNotIn(
+                        "keyword -prefix -lxc -docker\\)$/\\1 -podman",
+                        containerfile,
+                    )
+
+        with self.assertRaisesRegex(
+            package_lifecycle_lab.LifecycleLabError,
+            "unsupported Alpine OpenRC qualification contract",
+        ):
+            package_lifecycle_lab.alpine_openrc_contract("3.25")
 
     def test_alpine_rsyslog_readiness_provider_is_fail_closed_and_portable(
         self,
@@ -6847,6 +7179,25 @@ probe
         self.assertIn("seed_generated_runtime_artifacts", script)
         self.assertIn("assert_generated_runtime_artifact_contract", script)
         self.assertIn("/etc/systemd/system/syswarden-firewall.service", script)
+        scenario_start = script.index("scenario_remove() {")
+        scenario_end = script.index(
+            '\nif [ "${INVOCATION}" = "initial" ]; then', scenario_start
+        )
+        scenarios = script[scenario_start:scenario_end]
+        self.assertNotIn("ambiguous-rsyslog", scenarios)
+        self.assertNotIn("seed_generated_runtime_artifacts || return", scenarios)
+        self.assertNotIn(
+            "assert_generated_runtime_artifact_contract purge\n", scenarios
+        )
+        for call in (
+            "seed_generated_runtime_artifacts exact-rsyslog remove || return",
+            "seed_generated_runtime_artifacts exact-rsyslog final-removal || return",
+            "seed_generated_runtime_artifacts exact-rsyslog purge || return",
+            "assert_generated_runtime_artifact_contract remove exact-rsyslog",
+            "assert_generated_runtime_artifact_contract final-removal exact-rsyslog",
+            "assert_generated_runtime_artifact_contract purge exact-rsyslog",
+        ):
+            self.assertIn(call, scenarios)
 
     def test_deb_remove_qualifies_reinstall_then_deferred_purge(self) -> None:
         checks = package_lifecycle_lab.expected_event_checks("deb", "remove")
@@ -7105,6 +7456,21 @@ probe
 
     def test_exact_generated_rsyslog_cleanup_is_separate_from_ambiguity(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        snapshot_start = source.index("openrc_rsyslog_runtime_snapshot() {")
+        snapshot_end = source.index(
+            "\n}\n\nattest_owned_cron_seed_state() {", snapshot_start
+        ) + len("\n}\n")
+        snapshot = source[snapshot_start:snapshot_end]
+        exact_pidfile_check = (
+            "printf '%s' \"${openrc_rsyslog_pid}\" | \\\n"
+            "        cmp -s - \"${openrc_rsyslog_pidfile}\" || return 1"
+        )
+        self.assertIn(exact_pidfile_check, snapshot)
+        self.assertLess(
+            snapshot.index(exact_pidfile_check),
+            snapshot.index('kill -0 "${openrc_rsyslog_pid}"'),
+        )
+        self.assertIn("'regular file:0:0:644:1'", snapshot)
         seed_start = source.index("seed_generated_runtime_artifacts() {")
         seed_end = source.index(
             "\n}\n\nassert_generated_runtime_artifact_contract() {",
@@ -7191,6 +7557,39 @@ probe
             "\n}\n\nprepare_expected_payloads() {", assertion_start
         )
         assertion = source[assertion_start:assertion_end]
+        arity_sources = {
+            "seed_generated_runtime_artifacts": seed,
+            "assert_generated_runtime_artifact_contract": assertion,
+        }
+        for name, function_source in arity_sources.items():
+            self.assertTrue(
+                function_source.startswith(
+                    f"{name}() {{\n"
+                    '    [ "$#" -eq 2 ] || return 1\n'
+                )
+            )
+            guard_lines = function_source.splitlines()[:2]
+            arity_probe = (
+                "\n".join(guard_lines)
+                + "\n"
+                "    return 0\n"
+                "}\n"
+                f'{name} "$@"'
+            )
+            for arguments, accepted in (
+                (("one", "two"), True),
+                ((), False),
+                (("one",), False),
+                (("one", "two", "three"), False),
+            ):
+                with self.subTest(function=name, arguments=arguments):
+                    result = subprocess.run(
+                        ["/bin/sh", "-c", arity_probe, name, *arguments],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode == 0, accepted, result)
         exact_assertion_start = assertion.index("exact-rsyslog)")
         ambiguous_assertion_start = assertion.index(
             "ambiguous-rsyslog)", exact_assertion_start
@@ -7235,14 +7634,41 @@ probe
                 self.assertIn(
                     f"remove.{label}.generated.{key}", remove_checks
                 )
-        purge_checks = package_lifecycle_lab.expected_event_checks("deb", "purge")
-        self.assertIn("purge.purge.generated.rsyslog_siem_residual", purge_checks)
-        self.assertIn(
-            "purge.purge.generated.rsyslog_waf_bridge_residual", purge_checks
-        )
-        self.assertIn(
-            "purge.purge.generated.rsyslog_provenance_residual", purge_checks
-        )
+        for family, scenario, label in (
+            ("deb", "purge", "purge"),
+            ("rpm", "remove", "final-removal"),
+            ("apk", "remove", "remove"),
+            ("apk", "purge", "purge"),
+        ):
+            with self.subTest(
+                exact_rsyslog_family=family,
+                exact_rsyslog_scenario=scenario,
+            ):
+                checks = package_lifecycle_lab.expected_event_checks(
+                    family, scenario
+                )
+                for key in (
+                    "rsyslog_siem_exact_generated",
+                    "rsyslog_waf_bridge_exact_generated",
+                    "rsyslog_provenance_exact",
+                    "rsyslog_siem_exact_removed",
+                    "rsyslog_waf_bridge_exact_removed",
+                    "rsyslog_provenance_removed",
+                    "rsyslog_configuration_valid",
+                    "rsyslog_reactivated",
+                ):
+                    self.assertIn(
+                        f"{scenario}.{label}.generated.{key}", checks
+                    )
+                self.assertFalse(
+                    any(
+                        check.startswith(
+                            f"{scenario}.{label}.generated.rsyslog_"
+                        )
+                        and check.endswith("_residual")
+                        for check in checks
+                    )
+                )
         self.assertIn(
             "/tmp/syswarden-rsyslog-provenance-before", ambiguous
         )
@@ -7250,49 +7676,192 @@ probe
             "/tmp/syswarden-rsyslog-provenance-before",
             ambiguous_assertion,
         )
-        rpm_remove_checks = package_lifecycle_lab.expected_event_checks(
-            "rpm", "remove"
-        )
-        for key in (
-            "rsyslog_siem_exact_generated",
-            "rsyslog_waf_bridge_exact_generated",
-            "rsyslog_provenance_exact",
-            "rsyslog_siem_exact_removed",
-            "rsyslog_waf_bridge_exact_removed",
-            "rsyslog_provenance_removed",
-            "rsyslog_configuration_valid",
-            "rsyslog_reactivated",
-        ):
-            self.assertIn(
-                f"remove.final-removal.generated.{key}",
-                rpm_remove_checks,
-            )
-
         writer_start = source.index("write_seeded_operator_token() {")
         writer_end = source.index("\nseed_state() {", writer_start)
         writer = source[writer_start:writer_end]
-        token = self.root / "deb-removal-token.toml"
-        result = subprocess.run(
+        for family, scenario in (
+            ("deb", "remove"),
+            ("deb", "purge"),
+            ("rpm", "remove"),
+            ("apk", "remove"),
+            ("apk", "purge"),
+        ):
+            with self.subTest(
+                siem_family=family,
+                siem_scenario=scenario,
+            ):
+                token = self.root / f"{family}-{scenario}-token.toml"
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        writer
+                        + f"\nPACKAGE_FAMILY={family}; "
+                        + f"SCENARIO={scenario}; "
+                        + 'write_seeded_operator_token "$1"',
+                        "exact-rsyslog-token",
+                        str(token),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                rendered = token.read_text(encoding="utf-8")
+                self.assertIn("[integrations.siem]", rendered)
+                self.assertIn("enabled = true", rendered)
+                self.assertIn('ip = "127.0.0.1"', rendered)
+                self.assertIn('port = "5514"', rendered)
+                self.assertIn('protocol = "udp"', rendered)
+
+        for family in ("deb", "rpm", "apk"):
+            with self.subTest(
+                siem_absent_family=family,
+                siem_absent_scenario="upgrade-rollback",
+            ):
+                upgrade_token = self.root / f"upgrade-{family}-token.toml"
+                upgrade = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        writer
+                        + f"\nPACKAGE_FAMILY={family}; "
+                        + "SCENARIO=upgrade-rollback; "
+                        + 'write_seeded_operator_token "$1"',
+                        "upgrade-token",
+                        str(upgrade_token),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(upgrade.returncode, 0, upgrade.stderr)
+                self.assertNotIn(
+                    "[integrations.siem]",
+                    upgrade_token.read_text(encoding="utf-8"),
+                )
+
+    def test_openrc_rsyslog_snapshot_rejects_noncanonical_pidfile_bytes(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("openrc_rsyslog_runtime_snapshot() {")
+        end = source.index(
+            "\n}\n\nattest_owned_cron_seed_state() {", start
+        ) + len("\n}\n")
+        function = source[start:end]
+        self.assertTrue(
+            function.startswith(
+                'openrc_rsyslog_runtime_snapshot() {\n'
+                '    [ "$#" -eq 0 ] || return 1\n'
+            )
+        )
+        pid = os.getpid()
+        proc_root = self.root / "proc"
+        process = proc_root / str(pid)
+        process.mkdir(parents=True)
+        process.joinpath("comm").write_text("rsyslogd\n", encoding="utf-8")
+        process.joinpath("exe").symlink_to("/usr/sbin/rsyslogd")
+        process.joinpath("stat").write_text(
+            " ".join(["0"] * 21 + ["12345"]) + "\n",
+            encoding="utf-8",
+        )
+        pidfile = self.root / "rsyslog.pid"
+        function = function.replace(
+            "openrc_rsyslog_pidfile=/run/rsyslog.pid",
+            f"openrc_rsyslog_pidfile={shlex.quote(str(pidfile))}",
+        ).replace(
+            '"/proc/${openrc_rsyslog_pid}/',
+            '"${SYSWARDEN_TEST_PROC}/${openrc_rsyslog_pid}/',
+        ).replace(
+            "'regular file:0:0:644:1'",
+            f"'regular file:{os.getuid()}:{os.getgid()}:644:1'",
+        )
+        mock_bin = self.root / "openrc-rsyslog-mock-bin"
+        mock_bin.mkdir()
+        rc_service = mock_bin / "rc-service"
+        rc_service.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        rc_service.chmod(0o700)
+        environment = {
+            **os.environ,
+            "PATH": f"{mock_bin}:{os.environ['PATH']}",
+            "SYSWARDEN_TEST_PROC": str(proc_root),
+            "LC_ALL": "C",
+        }
+
+        for contents, accepted in (
+            (str(pid), True),
+            (f"{pid}\n", False),
+            (f"{pid}\n\n", False),
+            (f" {pid}\n", False),
+            (f"{pid} \n", False),
+            (f"{pid}\n2\n", False),
+        ):
+            with self.subTest(pidfile_bytes=contents.encode().hex()):
+                pidfile.write_bytes(contents.encode("ascii"))
+                pidfile.chmod(0o644)
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        function + "\nopenrc_rsyslog_runtime_snapshot",
+                        "openrc-rsyslog-snapshot",
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+                self.assertEqual(result.returncode == 0, accepted, result)
+                if accepted:
+                    self.assertEqual(result.stdout, f"{pid}:12345\n")
+                    self.assertEqual(result.stderr, "")
+
+        pidfile.write_text(str(pid), encoding="ascii")
+        pidfile.chmod(0o644)
+        extra_argument = subprocess.run(
             [
                 "/bin/sh",
                 "-c",
-                writer
-                + '\nPACKAGE_FAMILY=deb; SCENARIO=remove; '
-                + 'write_seeded_operator_token "$1"',
-                "deb-removal-token",
-                str(token),
+                function + '\nopenrc_rsyslog_runtime_snapshot "$1"',
+                "openrc-rsyslog-snapshot-arity",
+                "unexpected",
             ],
             check=False,
             capture_output=True,
             text=True,
+            env=environment,
         )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        rendered = token.read_text(encoding="utf-8")
-        self.assertIn("[integrations.siem]", rendered)
-        self.assertIn("enabled = true", rendered)
-        self.assertIn('ip = "127.0.0.1"', rendered)
-        self.assertIn('port = "5514"', rendered)
-        self.assertIn('protocol = "udp"', rendered)
+        self.assertNotEqual(extra_argument.returncode, 0, extra_argument)
+
+    def test_ambiguous_rsyslog_contract_is_adversarial_only(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        seed_start = source.index("seed_generated_runtime_artifacts() {")
+        seed_end = source.index(
+            "\n}\n\nassert_generated_runtime_artifact_contract() {", seed_start
+        )
+        seed = source[seed_start:seed_end]
+        assertion_start = source.index(
+            "assert_generated_runtime_artifact_contract() {"
+        )
+        assertion_end = source.index(
+            "\n}\n\nprepare_expected_payloads() {", assertion_start
+        )
+        assertion = source[assertion_start:assertion_end]
+        scenarios_start = source.index("scenario_remove() {")
+        scenarios_end = source.index(
+            '\nif [ "${INVOCATION}" = "initial" ]; then', scenarios_start
+        )
+        scenarios = source[scenarios_start:scenarios_end]
+
+        self.assertIn("ambiguous-rsyslog)", seed)
+        self.assertIn("ambiguous-rsyslog)", assertion)
+        self.assertIn("operator-owned ambiguous SIEM bridge", seed)
+        self.assertIn("operator-owned ambiguous WAF bridge", seed)
+        self.assertIn("rsyslog_siem_residual", assertion)
+        self.assertIn("rsyslog_waf_bridge_residual", assertion)
+        self.assertIn("rsyslog_provenance_residual", assertion)
+        self.assertNotIn("ambiguous-rsyslog", scenarios)
 
     def test_rsyslog_removal_requires_a_new_process_identity(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
@@ -7301,26 +7870,24 @@ probe
             "\nseed_generated_runtime_artifacts() {", helpers_start
         )
         helpers = source[helpers_start:helpers_end]
+        self.assertTrue(
+            helpers.startswith(
+                'rsyslog_reactivation_mode() {\n'
+                '    [ "$#" -eq 4 ] || return 1\n'
+            )
+        )
         self.assertNotIn("reload", helpers.lower())
         self.assertIn('printf \'%s\\n\' restart', helpers)
 
-        def run_mode(
-            pid_before: str,
-            pid_after: str,
-            active_before: str,
-            active_after: str,
-        ) -> subprocess.CompletedProcess[str]:
+        def run_mode(*arguments: str) -> subprocess.CompletedProcess[str]:
             return subprocess.run(
                 [
                     "/bin/sh",
                     "-c",
                     helpers
-                    + '\nrsyslog_reactivation_mode "$1" "$2" "$3" "$4"',
+                    + '\nrsyslog_reactivation_mode "$@"',
                     "rsyslog-reactivation",
-                    pid_before,
-                    pid_after,
-                    active_before,
-                    active_after,
+                    *arguments,
                 ],
                 check=False,
                 capture_output=True,
@@ -7339,6 +7906,8 @@ probe
             ("100", "101", "", "1001"),
             ("1", "101", "1000", "1001"),
             ("100", "1", "1000", "1001"),
+            ("100", "101", "1000"),
+            ("100", "101", "1000", "1001", "extra"),
         )
         for case in rejected_modes:
             with self.subTest(rejected_mode=case):
@@ -7561,6 +8130,10 @@ probe
             ),
             *(
                 ("upgrade-rollback", "4.03.2", "4.03.3", label, "..")
+                for label in upgrade_labels
+            ),
+            *(
+                ("upgrade-rollback", "4.03.3", "4.04.0", label, "..")
                 for label in upgrade_labels
             ),
             ("remove", "4.03.2", "4.03.3", "fresh", ".."),
@@ -7803,12 +8376,11 @@ probe
                 generated = [check for check in checks if ".generated." in check]
                 if family == "deb" and scenario == "remove":
                     labels = ("remove", "remove-before-purge")
-                    exact_rsyslog = True
                 else:
                     labels = (
                         "final-removal" if family == "rpm" else scenario,
                     )
-                    exact_rsyslog = family == "rpm" and scenario == "remove"
+                exact_rsyslog = True
                 expected_generated = [
                     check
                     for label in labels
@@ -8805,7 +9377,12 @@ prepare_package_transition
             'assert_preserved "${label}" operator_data /var/lib/syswarden/ui/lifecycle-operator.json "${STATE_OPERATOR_DATA_HASH}" 600',
             source,
         )
-        self.assertIn('assert_live_telemetry_data "${label}"', source)
+        self.assertIn(
+            'assert_live_telemetry_data \\\n'
+            '        "${label}" /var/lib/syswarden/ui/data.json \\\n'
+            '        "${live_telemetry_contract}"',
+            source,
+        )
         state_contract = source[
             source.index("assert_all_state_preserved() {") : source.index(
                 "\n}\n\nassert_package_absent() {",
@@ -8819,7 +9396,7 @@ prepare_package_transition
             '"${label}" list_ipv6 ',
             '"${label}" operator_data ',
             '"${label}" certificate ',
-            'assert_live_telemetry_data "${label}"',
+            "assert_live_telemetry_data \\",
         )
         positions = [state_contract.index(item) for item in ordered_state_fragments]
         self.assertEqual(positions, sorted(positions))
@@ -8832,6 +9409,99 @@ prepare_package_transition
                 )
             self.assertNotIn(f"remove.{label}.state.telemetry.hash", checks)
 
+    def test_live_telemetry_contract_is_exactly_version_bound(self) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("live_telemetry_contract_for_version() {")
+        end = source.index("\n}\n\nlive_telemetry_schema_valid() {", start) + 2
+        function = source[start:end]
+
+        def contract(version: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    "/bin/sh",
+                    "-c",
+                    function + '\nlive_telemetry_contract_for_version "$1"',
+                    "telemetry-version-contract",
+                    version,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        for version in ("4.02.8", "4.03.2", "4.03.3"):
+            with self.subTest(version=version):
+                result = contract(version)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "legacy\n")
+        for version in ("4.04.0", "4.10.0", "5.00.0"):
+            with self.subTest(version=version):
+                result = contract(version)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "kpi-v1\n")
+        for version in ("", "4", "4.x.0", "v4.04.0"):
+            with self.subTest(invalid=version):
+                self.assertNotEqual(contract(version).returncode, 0)
+
+    def test_live_telemetry_contract_tracks_each_upgrade_phase_version(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        start = source.index("assert_all_state_preserved() {")
+        end = source.index(
+            "\n}\n\nassert_deb_removal_log_preserved() {", start
+        ) + len("\n}\n")
+        function = source[start:end]
+        harness = r'''
+assert_preserved() { :; }
+live_telemetry_contract_for_version() {
+    case "$1" in
+        4.03.3) printf '%s\n' legacy ;;
+        4.04.0) printf '%s\n' kpi-v1 ;;
+        *) return 1 ;;
+    esac
+}
+assert_live_telemetry_data() {
+    printf '%s\t%s\n' "$1" "$3"
+}
+SCENARIO=upgrade-rollback
+PACKAGE_FAMILY=apk
+EXPECTED_PREVIOUS_VERSION=4.03.3
+EXPECTED_CANDIDATE_VERSION=4.04.0
+STATE_CONFIG_HASH=config
+STATE_TOKEN_HASH=token
+STATE_LIST_HASH=list
+STATE_LIST_IPV6_HASH=list6
+STATE_OPERATOR_DATA_HASH=operator
+STATE_CERT_HASH=certificate
+assert_all_state_preserved "$1"
+'''
+        expected = {
+            "previous": "legacy",
+            "candidate": "kpi-v1",
+            "reinstall": "kpi-v1",
+            "restart-one": "kpi-v1",
+            "restart-two": "kpi-v1",
+            "rollback": "legacy",
+            "recovery": "kpi-v1",
+        }
+        for label, contract in expected.items():
+            with self.subTest(label=label):
+                result = subprocess.run(
+                    [
+                        "/bin/sh",
+                        "-c",
+                        function + harness,
+                        "telemetry-phase-contract",
+                        label,
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, f"{label}\t{contract}\n")
+
     def test_live_telemetry_schema_is_exact_and_rejects_adversarial_drift(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         start = source.index("live_telemetry_schema_valid() {")
@@ -8843,7 +9513,7 @@ prepare_package_transition
         )
         baseline = json.loads(fixture_path.read_text(encoding="utf-8"))
 
-        def accepted(payload: bytes) -> bool:
+        def accepted(payload: bytes, contract: str) -> bool:
             path = self.root / "live-telemetry.json"
             path.unlink(missing_ok=True)
             path.write_bytes(payload)
@@ -8851,9 +9521,10 @@ prepare_package_transition
                 [
                     "/bin/sh",
                     "-c",
-                    function + '\nlive_telemetry_schema_valid "$1"',
+                    function + '\nlive_telemetry_schema_valid "$1" "$2"',
                     "telemetry-schema",
                     str(path),
+                    contract,
                 ],
                 check=False,
                 capture_output=True,
@@ -8861,7 +9532,56 @@ prepare_package_transition
             )
             return result.returncode == 0
 
-        self.assertTrue(accepted(json.dumps(baseline).encode("utf-8")))
+        legacy_payload = json.dumps(baseline).encode("utf-8")
+        self.assertTrue(accepted(legacy_payload, "legacy"))
+        self.assertFalse(accepted(legacy_payload, "kpi-v1"))
+        self.assertFalse(accepted(legacy_payload, "unsupported"))
+
+        kpi = json.loads(json.dumps(baseline))
+        kpi["waf"].update(
+            {
+                "kpi_evidence_quality": "complete",
+                "journal_scan_complete": True,
+                "journal_bytes_total": 4096,
+                "journal_bytes_scanned": 4096,
+                "journal_decode_errors": 0,
+                "metric_rejected_events": 0,
+                "metric_excluded_events": 2,
+                "metric_admitted_events": 4,
+            }
+        )
+        kpi["waf"]["top_attackers"][0].update(
+            {
+                "first_seen": "earlier",
+                "primary_jail": "BF-SSH",
+                "enforcement_jail": "BF-SSH",
+                "enforcement_action": "drop",
+                "jail_hits": 6,
+                "policy_hits": 5,
+                "attested_hits": 4,
+                "recorded_hits": 6,
+                "legacy_hits": 2,
+                "risk_category": "credential-access",
+                "severity_score": 80,
+                "peak_window_hits": 4,
+                "effective_threshold": 4,
+                "effective_window_seconds": 60,
+                "metric_quality": "attested",
+                "selected_policy_quality": "exact",
+                "threshold_reached": True,
+                "threshold_evidence": "journal",
+                "metric_scope": "source-jail",
+                "hit_evidence": "recorded",
+                "hit_quality": "exact",
+                "degraded_hits": 0,
+                "risk_model_version": "risk-v1",
+                "signature_catalog_version": "catalog-v1",
+                "signature_catalog_sha256": "a" * 64,
+            }
+        )
+        kpi_payload = json.dumps(kpi).encode("utf-8")
+        self.assertTrue(accepted(kpi_payload, "kpi-v1"))
+        self.assertFalse(accepted(kpi_payload, "legacy"))
         assertion_end = source.index(
             "\n}\n\nsanitize_historical_rollback_token() {", start
         ) + 2
@@ -8876,7 +9596,7 @@ prepare_package_transition
                 "file_mode() { stat -c '%a' \"$1\"; }\n"
                 "check_equal() { printf '%s\\t%s\\t%s\\n' \"$1\" \"$2\" \"$3\"; }\n"
                 + assertion_contract
-                + '\nassert_live_telemetry_data phase "$1"',
+                + '\nassert_live_telemetry_data phase "$1" legacy',
                 "telemetry-assertion",
                 str(asserted),
             ],
@@ -8903,12 +9623,14 @@ prepare_package_transition
         changed = json.loads(json.dumps(baseline))
         changed["timestamp"] = "2026-08-23T12:34:56Z"
         changed["system"]["ram_used_mb"] += 1
-        self.assertTrue(accepted(json.dumps(changed).encode("utf-8")))
+        self.assertTrue(accepted(json.dumps(changed).encode("utf-8"), "legacy"))
         nullable_slices = json.loads(json.dumps(baseline))
         nullable_slices["waf"]["targeted_ports"] = None
         nullable_slices["waf"]["risk_radar"] = None
         nullable_slices["waf"]["allowed_events"] = None
-        self.assertTrue(accepted(json.dumps(nullable_slices).encode("utf-8")))
+        self.assertTrue(
+            accepted(json.dumps(nullable_slices).encode("utf-8"), "legacy")
+        )
 
         adversarial: dict[str, bytes] = {"malformed": b"{"}
         variants: dict[str, dict[str, object]] = {}
@@ -8918,6 +9640,13 @@ prepare_package_transition
         unexpected = json.loads(json.dumps(baseline))
         unexpected["ha"] = {}
         variants["HA must remain absent"] = unexpected
+        legacy_enriched_attacker = json.loads(json.dumps(baseline))
+        legacy_enriched_attacker["waf"]["top_attackers"][0][
+            "recorded_hits"
+        ] = 1
+        variants["legacy attacker must not contain one KPI field"] = (
+            legacy_enriched_attacker
+        )
         top_extension = json.loads(json.dumps(baseline))
         top_extension["unexpected"] = True
         variants["unexpected top-level key"] = top_extension
@@ -8937,7 +9666,80 @@ prepare_package_transition
             adversarial[name] = json.dumps(document).encode("utf-8")
         for name, payload in adversarial.items():
             with self.subTest(name=name):
-                self.assertFalse(accepted(payload))
+                self.assertFalse(accepted(payload, "legacy"))
+
+        for field in (
+            "kpi_evidence_quality",
+            "journal_scan_complete",
+            "journal_bytes_total",
+            "journal_bytes_scanned",
+            "journal_decode_errors",
+            "metric_rejected_events",
+            "metric_excluded_events",
+            "metric_admitted_events",
+        ):
+            with self.subTest(kpi_missing=field):
+                partial = json.loads(json.dumps(kpi))
+                del partial["waf"][field]
+                self.assertFalse(
+                    accepted(json.dumps(partial).encode("utf-8"), "kpi-v1")
+                )
+
+        kpi_variants: dict[str, dict[str, object]] = {}
+        invalid_quality = json.loads(json.dumps(kpi))
+        invalid_quality["waf"]["kpi_evidence_quality"] = "unknown"
+        kpi_variants["unknown KPI quality"] = invalid_quality
+        negative_counter = json.loads(json.dumps(kpi))
+        negative_counter["waf"]["metric_rejected_events"] = -1
+        kpi_variants["negative KPI counter"] = negative_counter
+        fractional_counter = json.loads(json.dumps(kpi))
+        fractional_counter["waf"]["journal_bytes_total"] = 1.5
+        kpi_variants["fractional KPI counter"] = fractional_counter
+        oversized_scan = json.loads(json.dumps(kpi))
+        oversized_scan["waf"]["journal_bytes_scanned"] = 4097
+        kpi_variants["scan exceeds total"] = oversized_scan
+        incomplete_complete = json.loads(json.dumps(kpi))
+        incomplete_complete["waf"]["journal_scan_complete"] = False
+        kpi_variants["complete profile is internally inconsistent"] = (
+            incomplete_complete
+        )
+        unknown_attacker = json.loads(json.dumps(kpi))
+        unknown_attacker["waf"]["top_attackers"][0]["unexpected"] = True
+        kpi_variants["unknown attacker key"] = unknown_attacker
+        wrong_attacker_type = json.loads(json.dumps(kpi))
+        wrong_attacker_type["waf"]["top_attackers"][0][
+            "threshold_reached"
+        ] = "true"
+        kpi_variants["wrong attacker optional type"] = wrong_attacker_type
+        for field in (
+            "jail_hits",
+            "policy_hits",
+            "attested_hits",
+            "recorded_hits",
+            "legacy_hits",
+            "peak_window_hits",
+            "effective_threshold",
+            "effective_window_seconds",
+            "degraded_hits",
+        ):
+            negative_attacker_counter = json.loads(json.dumps(kpi))
+            negative_attacker_counter["waf"]["top_attackers"][0][field] = -1
+            kpi_variants[f"negative attacker counter {field}"] = (
+                negative_attacker_counter
+            )
+        for score in (-1, 101):
+            out_of_range_score = json.loads(json.dumps(kpi))
+            out_of_range_score["waf"]["top_attackers"][0][
+                "severity_score"
+            ] = score
+            kpi_variants[f"out-of-range severity score {score}"] = (
+                out_of_range_score
+            )
+        for name, document in kpi_variants.items():
+            with self.subTest(name=name):
+                self.assertFalse(
+                    accepted(json.dumps(document).encode("utf-8"), "kpi-v1")
+                )
 
         target = self.root / "live-telemetry-target.json"
         target.write_text(json.dumps(baseline), encoding="utf-8")
@@ -8947,7 +9749,7 @@ prepare_package_transition
             [
                 "/bin/sh",
                 "-c",
-                function + '\nlive_telemetry_schema_valid "$1"',
+                function + '\nlive_telemetry_schema_valid "$1" legacy',
                 "telemetry-schema",
                 str(link),
             ],
@@ -9009,7 +9811,11 @@ prepare_package_transition
         self.assertIn('credentials != 1', contract)
         self.assertIn('! grep -Fq "${rollback_secret}" "${COMMAND_LOG}"', contract)
         self.assertIn("if v4028_to_v4032_transition_selected; then", contract)
-        self.assertIn("elif v4032_to_v4033_transition_selected; then", contract)
+        self.assertIn(
+            "elif v4032_to_v4033_transition_selected || \\\n"
+            "         v4033_to_v4040_transition_selected; then",
+            contract,
+        )
         self.assertIn("historical-webtui-credential", contract)
         self.assertIn("byte-exact", contract)
         self.assertIn(
@@ -9066,9 +9872,21 @@ prepare_package_transition
             )
             for family in ("deb", "rpm")
         )
+        minor = (
+            (
+                "upgrade-rollback",
+                "4.03.3",
+                "4.04.0",
+                family,
+                "rollback",
+                "byte-exact",
+            )
+            for family in ("deb", "rpm")
+        )
         for scenario, previous, candidate, family, label, expected in (
             *accepted,
             *current,
+            *minor,
         ):
             with self.subTest(
                 scenario=scenario,
@@ -9380,8 +10198,9 @@ assert_preserved rollback token "$1" "$2" 640
             quiesce,
         )
         self.assertIn(
-            "if v4032_to_v4033_upgrade_selected; then\n"
-            "            attest_v4032_previous_webtui_retirement || \\\n"
+            "if v4032_to_v4033_upgrade_selected || \\\n"
+            "           v4033_to_v4040_upgrade_selected; then\n"
+            "            attest_previous_webtui_retirement || \\\n"
             "                mark_postinstall_failure previous-webtui-retirement\n"
             "        else",
             probe,
@@ -9523,6 +10342,104 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
                     run_case({"TEST_SS_FAILURE": failure}).returncode,
                     0,
                 )
+
+    def test_v4033_to_v4040_previous_webtui_absence_is_exact_and_fail_closed(
+        self,
+    ) -> None:
+        source = package_lifecycle_lab.LIFECYCLE_SCRIPT
+        transition_start = source.index(
+            "v4033_to_v4040_transition_selected() {"
+        )
+        transition_end = source.index(
+            "\n}\n\nexpected_systemd_enablement_prefix() {",
+            transition_start,
+        ) + 2
+        transition = source[transition_start:transition_end]
+        selector_start = source.index("v4033_to_v4040_upgrade_selected() {")
+        selector_end = source.index(
+            "\n}\n\nattest_previous_webtui_retirement() {",
+            selector_start,
+        ) + 2
+        selector = source[selector_start:selector_end]
+        common_start = source.index("attest_previous_webtui_retirement() {")
+        common_end = source.index(
+            "\n}\n\nattest_v4032_previous_webtui_retirement() {",
+            common_start,
+        ) + 2
+        common = source[common_start:common_end]
+        quiesce_start = source.index("quiesce_previous_webtui_runtime() {")
+        quiesce_end = source.index(
+            "\n}\n\nlifecycle_seed_hex_prefix() {", quiesce_start
+        )
+        quiesce = source[quiesce_start:quiesce_end]
+
+        self.assertIn(
+            '[ "${SCENARIO}" = upgrade-rollback ] && \\\n'
+            '        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \\\n'
+            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.0 ]',
+            transition,
+        )
+        self.assertIn(
+            "v4033_to_v4040_upgrade_selected() {\n"
+            "    v4033_to_v4040_transition_selected && \\\n"
+            '        [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]\n'
+            "}",
+            selector,
+        )
+        self.assertIn(
+            'legacy_webtui_runtime_absent "${previous_webtui_root}" || return 1',
+            common,
+        )
+        self.assertIn("syswarden_verify_no_exact_webtui_process \\", common)
+        self.assertIn("for previous_webtui_port in 62027 62028", common)
+        self.assertIn(
+            "if v4033_to_v4040_upgrade_selected; then\n"
+            "        attest_v4033_previous_webtui_retirement || return 1\n"
+            "        return 0\n"
+            "    fi",
+            quiesce,
+        )
+
+        harness = (
+            "#!/bin/sh\nset -u\n"
+            + transition
+            + "\n"
+            + selector
+            + r'''
+installed_version() {
+    printf '%s\n' "${TEST_INSTALLED_VERSION}"
+}
+v4033_to_v4040_upgrade_selected
+'''
+        )
+
+        def selected(overrides: dict[str, str] | None = None) -> bool:
+            environment = {
+                **os.environ,
+                "SCENARIO": "upgrade-rollback",
+                "EXPECTED_PREVIOUS_VERSION": "4.03.3",
+                "EXPECTED_CANDIDATE_VERSION": "4.04.0",
+                "TEST_INSTALLED_VERSION": "4.03.3",
+            }
+            environment.update(overrides or {})
+            result = subprocess.run(
+                [shutil.which("dash") or "/bin/sh", "-c", harness],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            return result.returncode == 0
+
+        self.assertTrue(selected())
+        for label, overrides in (
+            ("scenario", {"SCENARIO": "remove"}),
+            ("previous", {"EXPECTED_PREVIOUS_VERSION": "4.03.2"}),
+            ("candidate", {"EXPECTED_CANDIDATE_VERSION": "4.04.1"}),
+            ("installed", {"TEST_INSTALLED_VERSION": "4.03.2"}),
+        ):
+            with self.subTest(bound=label):
+                self.assertFalse(selected(overrides))
 
     def test_upgrade_seeds_and_proves_exact_browser_retirement_with_port_isolation(self) -> None:
         script = package_lifecycle_lab.LIFECYCLE_SCRIPT
@@ -9716,7 +10633,8 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
         scenario = source[scenario_start:scenario_end]
 
         exact_skip = (
-            "if v4032_to_v4033_upgrade_selected; then\n"
+            "if v4032_to_v4033_upgrade_selected || \\\n"
+            "       v4033_to_v4040_upgrade_selected; then\n"
             "        return 0\n"
             "    fi"
         )
@@ -9810,6 +10728,15 @@ seed_live_legacy_webtui_process
             with self.subTest(exact_family=family):
                 exact = run_case(family=family)
                 self.assertEqual(exact.returncode, 0, exact.stderr)
+                self.assertFalse(marker.exists())
+
+                current = run_case(
+                    family=family,
+                    previous="4.03.3",
+                    candidate="4.04.0",
+                    installed="4.03.3",
+                )
+                self.assertEqual(current.returncode, 0, current.stderr)
                 self.assertFalse(marker.exists())
 
         bounds = (
@@ -10089,7 +11016,7 @@ seed_live_legacy_webtui_process
                 {
                     "nftables", "curl", "wget", "rsyslog", "rsyslog-uxsock",
                     "bash-completion", "wireguard-tools", "libqrencode-tools", "jq",
-                    "openrc", "cronie", "cronie-openrc",
+                    "cronie", "cronie-openrc",
                     "procps-ng",
                     "e2fsprogs-extra",
                     "shadow",
@@ -10106,7 +11033,8 @@ seed_live_legacy_webtui_process
         self.assertNotIn("epel-release", package_lifecycle_lab.RPM_BOOTSTRAP)
         self.assertNotIn("qrencode", package_lifecycle_lab.RPM_BOOTSTRAP)
         self.assertIn(
-            "apk add --no-cache openrc openrc-init && apk add --no-cache",
+            "apk add --no-cache openrc=0.62.6-r0 "
+            "openrc-init=0.62.6-r0 && apk add --no-cache",
             package_lifecycle_lab.APK_BOOTSTRAP,
         )
         self.assertIn("test -x /usr/bin/gpasswd", package_lifecycle_lab.APK_BOOTSTRAP)


### PR DESCRIPTION
## Summary

Close the qualification harness drift exposed by the v4.04.0 AMD64 package lifecycle run.

This change keeps product code, package bytes, documentation, and version metadata unchanged. It updates only the lifecycle harness and its tests.

## Changes

- bind Alpine 3.22 and 3.24 to their exact OpenRC and openrc-init package contracts
- handle exact dpkg documentation exclusions across every regular file in dpkg.cfg.d while rejecting symlinks
- attest the v4.03.3 to v4.04.0 WebTUI retirement as exact absence
- select the legacy or KPI telemetry schema from the installed phase version
- use exact SIEM-enabled rsyslog fixtures for green removal scenarios and keep ambiguous fixtures adversarial only
- require exact rsyslog restart identity on systemd and OpenRC
- attest the OpenRC rsyslog pidfile as the exact decimal PID bytes written by OpenRC
- make Debian 13 and Ubuntu 24.04 systemd container startup deterministic with cell-specific masks for non-applicable infrastructure units, while retaining zero tolerance for failed units and exact full mask inventories

## Validation

- package lifecycle harness tests: 150 passed, 2 skipped as expected
- complete CI Python suite: 615 passed, 8 skipped as expected
- Python compilation, shell syntax, ShellCheck error level, and diff checks passed
- final local AMD64 lifecycle matrix passed all eight cells: DEB-13, DEB-U2404, DEB-U2604, RPM-F44, RPM-A9, RPM-A10, APK-322, and APK-324
- final report status: pass, harness_complete: true, release_ready: true, no blockers, no unexpected failures
- final report SHA-256: b7275872a28d533cce1cbc4c639794b2d8a05c062433efa11fc9396dceb87574

## Release handling

This is a non-versioning Fix commit for the existing v4.04.0 candidate. It does not create a tag or release. The protected qualification workflow must rerun after merge before any release decision.

Reference: qualification run 33595186331.
