### PR TITLE
Patch : align the release qualification schema contract

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -719,6 +719,8 @@ jobs:
           )
           jq --exit-status \
             --slurpfile aggregate "${QUALIFICATION_ROOT}/aggregate/release-qualification.json" \
+            --slurpfile qualification_matrix \
+              "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --arg repository "${GITHUB_REPOSITORY}" \
             --arg release_tag "${RELEASE_TAG}" \
             --arg release_sha "${RELEASE_SHA}" \
@@ -727,6 +729,7 @@ jobs:
               "candidate_package_artifact_name",
               "candidate_package_run_id",
               "candidate_package_workflow",
+              "previous_commit_sha",
               "previous_package_asset_ids",
               "previous_release_id",
               "previous_tag",
@@ -735,7 +738,7 @@ jobs:
               "repository",
               "schema_version"
             ] and
-            .schema_version == 1 and
+            .schema_version == 2 and
             .repository == $repository and
             .release_tag == $release_tag and
             .release_sha == $release_sha and
@@ -750,6 +753,9 @@ jobs:
             .previous_release_id > 0 and
             (.previous_tag | type) == "string" and
             .previous_tag == $aggregate[0].bindings.previous_version and
+            (.previous_commit_sha | type) == "string" and
+            .previous_commit_sha ==
+              $qualification_matrix[0].package_sources.baseline.commit and
             (.previous_package_asset_ids | type) == "array" and
             (.previous_package_asset_ids | length) == 4 and
             ([.previous_package_asset_ids[].name] | sort) == ([
@@ -1257,6 +1263,8 @@ jobs:
           )
           jq --exit-status \
             --slurpfile aggregate "${QUALIFICATION_ROOT}/aggregate/release-qualification.json" \
+            --slurpfile qualification_matrix \
+              "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --arg repository "${GITHUB_REPOSITORY}" \
             --arg release_tag "${RELEASE_TAG}" \
             --arg release_sha "${RELEASE_SHA}" \
@@ -1265,6 +1273,7 @@ jobs:
               "candidate_package_artifact_name",
               "candidate_package_run_id",
               "candidate_package_workflow",
+              "previous_commit_sha",
               "previous_package_asset_ids",
               "previous_release_id",
               "previous_tag",
@@ -1273,7 +1282,7 @@ jobs:
               "repository",
               "schema_version"
             ] and
-            .schema_version == 1 and
+            .schema_version == 2 and
             .repository == $repository and
             .release_tag == $release_tag and
             .release_sha == $release_sha and
@@ -1288,6 +1297,9 @@ jobs:
             .previous_release_id > 0 and
             (.previous_tag | type) == "string" and
             .previous_tag == $aggregate[0].bindings.previous_version and
+            (.previous_commit_sha | type) == "string" and
+            .previous_commit_sha ==
+              $qualification_matrix[0].package_sources.baseline.commit and
             (.previous_package_asset_ids | type) == "array" and
             (.previous_package_asset_ids | length) == 4 and
             ([.previous_package_asset_ids[].name] | sort) == ([

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ defense layer without placing another proxy in the application data path.
 SysWarden is not an inline HTTP proxy, a traffic sanitizer or a regulatory
 certification product.
 
-Current source version: **v4.04.0**.
+Current source version: **v4.04.1**.
 
 The latest qualified, stable public release is
 [v4.03.3](https://github.com/duggytuxy/syswarden/releases/tag/v4.03.3).

--- a/assets/syswarden_architecture.svg
+++ b/assets/syswarden_architecture.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title description" data-theme="dark" data-theme-status="legacy">
-  <title id="title">SysWarden v4.04.0 candidate architecture</title>
+  <title id="title">SysWarden v4.04.1 candidate architecture</title>
   <desc id="description">Protected Linux workloads emit logs and host telemetry to a local SysWarden core. The core commits authoritative nftables policy and may reconcile one already active UFW or firewalld compatibility frontend. It also manages local telemetry and an authenticated peer-scoped HA API. Operators use a privileged CLI and a local terminal dashboard. A challenge-bound HA fence protects partner migration cleanup.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
   <g transform="translate(30 5) scale(0.68)">
     <use href="#syswardenOfficialLogo"/>
   </g>
-  <text x="475" y="62" class="h1">v4.04.0 candidate architecture</text>
+  <text x="475" y="62" class="h1">v4.04.1 candidate architecture</text>
   <text x="475" y="98" class="body">Linux-only host enforcement, local terminal operations and condition-bound HA migration</text>
 
   <g transform="translate(70 154)" filter="url(#shadow)">

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,75 @@
+# Release v4.04.1
+
+> Candidate status: v4.04.1 is the Patch candidate for the release
+> qualification contract correction and includes the complete unpublished
+> v4.04.0 candidate scope. This block does not authorize a tag or public
+> Release.
+
+### ADDED
+
+- **Typed ICMP operator policy:** Add a closed `[[operator_policy.rules]]`
+  schema for inbound IPv4 ICMP and IPv6 ICMPv6 echo requests. Rules are
+  declared only in `modules/99-user.toml`, use canonical IP or CIDR sources and
+  support the bounded `accept` action without exposing raw nftables input.
+- **Deterministic nftables compilation:** Compile validated rules into one
+  dedicated `operator-policy` chain, sort them by canonical identifier and
+  dispatch to the chain immediately before the product-owned catch-all deny.
+  A non-match always returns to the existing terminal policy.
+
+### FIXED
+
+- **Exact qualification schema consumption:** Align both unprivileged and
+  privileged release-manager validators with qualification context schema 2,
+  require the `previous_commit_sha` field and bind it to the frozen baseline
+  commit in the AMD64 qualification matrix.
+- **Release-chain regression coverage:** Require both publisher stages to
+  consume schema 2 and the exact baseline commit binding so producer and
+  consumer drift fails during pre-merge validation.
+
+### SECURITY
+
+- **Closed configuration provenance:** Reject unknown or missing fields,
+  duplicate identifiers, protocol and family mismatches, non-canonical or
+  overlapping sources, IPv4-mapped IPv6 values and every environment variable
+  prefixed with `SYSWARDEN_OPERATOR_POLICY`. Limit the operator module to
+  256 KiB, the policy to 64 rules and the compiled fragment to 64 KiB.
+- **Commit-bound source attestation:** Bind a non-empty policy to the exact
+  validated `99-user.toml` identity and digest, then revalidate and reattest it
+  at the pre-apply commit boundary and again after post-apply verification,
+  before persistent publication.
+- **Exact post-apply verification:** Verify the dedicated chain, ordered rule
+  expressions, provenance comments, terminal return, unique dispatch and
+  catch-all log and drop sequence from nftables JSON. Any mismatch restores the
+  previous policy and prevents publication.
+- **Durable interrupted-transaction recovery:** Journal the previous kernel and
+  persistent firewall state before apply, preserve only live bounded dynamic
+  bans, quarantine legacy maximum-ending intervals and recover an interrupted
+  transaction before a new reload. An indeterminate apply result is rolled back
+  and never treated as an unchanged ruleset.
+- **Frontend ownership boundary:** Refuse a non-empty operator policy when UFW
+  or firewalld is active so nftables remains the sole authoritative policy
+  owner for this capability.
+- **Immutable publication recovery:** Preserve the signed v4.04.0 tag and its
+  successful qualification evidence without moving the tag, rewriting the
+  evidence or bypassing tag-bound provenance. Require v4.04.1 to complete a new
+  qualification, signed tag and protected publication sequence.
+
+### TESTING
+
+- **Shared CLI and daemon contract corpus:** Exercise the same raw TOML,
+  semantic, environment, 64/65-rule and 256 KiB boundary cases in both config
+  implementations without coupling their Go modules.
+- **Real nftables and failure-path coverage:** Add deterministic golden
+  fixtures, validate the generated topology and populated IPv4/IPv6 rules in
+  isolated real-nftables namespaces, and add exact JSON mutation tests plus
+  injected failures for apply, verification, persistence, rollback and restart
+  recovery.
+- **Executable publisher schema regression:** Execute both embedded release
+  manager predicates against a valid schema 2 context and reject schema, key or
+  baseline commit mutations before merge.
+
+---
+
 # Release v4.04.0
 
 > Candidate status: v4.04.0 is the Minor candidate for the typed operator

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -181,7 +181,7 @@
       "stream": "stdout",
       "reason": "Advance the minor version while preserving the bounded built-in operator reference.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.04.0 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.04.1 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     },
     {
       "case": "help:syswarden",

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -20,7 +20,7 @@ import release_gate
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOURCE_CANDIDATE_VERSION = "v4.04.0"
+SOURCE_CANDIDATE_VERSION = "v4.04.1"
 STABLE_PUBLIC_VERSION = "v4.03.3"
 REPORT = REPO_ROOT / (
     f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{STABLE_PUBLIC_VERSION}.md"
@@ -108,7 +108,7 @@ class DocumentationGateTest(unittest.TestCase):
             [],
         )
         errors = documentation_gate.validate_public_version_order(
-            SOURCE_CANDIDATE_VERSION, "v4.04.1"
+            SOURCE_CANDIDATE_VERSION, "v4.04.2"
         )
         self.assertTrue(any("cannot be newer" in error for error in errors))
 

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -3053,8 +3053,8 @@ v4032_to_v4033_upgrade_selected() {
         [ "$(installed_version 2>/dev/null || true)" = 4.03.2 ]
 }
 
-v4033_to_v4040_upgrade_selected() {
-    v4033_to_v4040_transition_selected && \
+v4033_to_v4041_upgrade_selected() {
+    v4033_to_v4041_transition_selected && \
         [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]
 }
 
@@ -3097,7 +3097,7 @@ attest_v4032_previous_webtui_retirement() {
 }
 
 attest_v4033_previous_webtui_retirement() {
-    v4033_to_v4040_upgrade_selected || return 1
+    v4033_to_v4041_upgrade_selected || return 1
     attest_previous_webtui_retirement "$@"
 }
 
@@ -3445,10 +3445,10 @@ v4032_to_v4033_transition_selected() {
         [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.3 ]
 }
 
-v4033_to_v4040_transition_selected() {
+v4033_to_v4041_transition_selected() {
     [ "${SCENARIO}" = upgrade-rollback ] && \
         [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \
-        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.0 ]
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.1 ]
 }
 
 expected_systemd_enablement_prefix() {
@@ -3460,7 +3460,7 @@ expected_systemd_enablement_prefix() {
             if v4028_to_v4032_transition_selected; then
                 printf '%s\n' /etc/systemd/system
             elif v4032_to_v4033_transition_selected || \
-                 v4033_to_v4040_transition_selected; then
+                 v4033_to_v4041_transition_selected; then
                 printf '%s\n' ..
             else
                 return 1
@@ -3858,7 +3858,7 @@ probe_postinstall_contract() {
         probe_seeded_operator_listener_preservation "${label}" || mark_postinstall_failure operator-listener
     elif [ "${actual_version}" = "${EXPECTED_PREVIOUS_VERSION}" ]; then
         if v4032_to_v4033_upgrade_selected || \
-           v4033_to_v4040_upgrade_selected; then
+           v4033_to_v4041_upgrade_selected; then
             attest_previous_webtui_retirement || \
                 mark_postinstall_failure previous-webtui-retirement
         else
@@ -4227,7 +4227,7 @@ quiesce_previous_webtui_runtime() {
         attest_v4032_previous_webtui_retirement || return 1
         return 0
     fi
-    if v4033_to_v4040_upgrade_selected; then
+    if v4033_to_v4041_upgrade_selected; then
         attest_v4033_previous_webtui_retirement || return 1
         return 0
     fi
@@ -4587,7 +4587,7 @@ seed_live_legacy_webtui_process() {
         *) return 0 ;;
     esac
     if v4032_to_v4033_upgrade_selected || \
-       v4033_to_v4040_upgrade_selected; then
+       v4033_to_v4041_upgrade_selected; then
         return 0
     fi
     /opt/syswarden/bin/syswarden-cli web-tui \
@@ -5039,7 +5039,7 @@ expected_upgrade_rollback_token_contract() {
     if v4028_to_v4032_transition_selected; then
         printf '%s\n' historical-webtui-credential
     elif v4032_to_v4033_transition_selected || \
-         v4033_to_v4040_transition_selected; then
+         v4033_to_v4041_transition_selected; then
         printf '%s\n' byte-exact
     else
         return 1

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -8133,7 +8133,7 @@ probe
                 for label in upgrade_labels
             ),
             *(
-                ("upgrade-rollback", "4.03.3", "4.04.0", label, "..")
+                ("upgrade-rollback", "4.03.3", "4.04.1", label, "..")
                 for label in upgrade_labels
             ),
             ("remove", "4.03.2", "4.03.3", "fresh", ".."),
@@ -9813,7 +9813,7 @@ assert_all_state_preserved "$1"
         self.assertIn("if v4028_to_v4032_transition_selected; then", contract)
         self.assertIn(
             "elif v4032_to_v4033_transition_selected || \\\n"
-            "         v4033_to_v4040_transition_selected; then",
+            "         v4033_to_v4041_transition_selected; then",
             contract,
         )
         self.assertIn("historical-webtui-credential", contract)
@@ -9876,7 +9876,7 @@ assert_all_state_preserved "$1"
             (
                 "upgrade-rollback",
                 "4.03.3",
-                "4.04.0",
+                "4.04.1",
                 family,
                 "rollback",
                 "byte-exact",
@@ -10199,7 +10199,7 @@ assert_preserved rollback token "$1" "$2" 640
         )
         self.assertIn(
             "if v4032_to_v4033_upgrade_selected || \\\n"
-            "           v4033_to_v4040_upgrade_selected; then\n"
+            "           v4033_to_v4041_upgrade_selected; then\n"
             "            attest_previous_webtui_retirement || \\\n"
             "                mark_postinstall_failure previous-webtui-retirement\n"
             "        else",
@@ -10343,19 +10343,19 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
                     0,
                 )
 
-    def test_v4033_to_v4040_previous_webtui_absence_is_exact_and_fail_closed(
+    def test_v4033_to_v4041_previous_webtui_absence_is_exact_and_fail_closed(
         self,
     ) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         transition_start = source.index(
-            "v4033_to_v4040_transition_selected() {"
+            "v4033_to_v4041_transition_selected() {"
         )
         transition_end = source.index(
             "\n}\n\nexpected_systemd_enablement_prefix() {",
             transition_start,
         ) + 2
         transition = source[transition_start:transition_end]
-        selector_start = source.index("v4033_to_v4040_upgrade_selected() {")
+        selector_start = source.index("v4033_to_v4041_upgrade_selected() {")
         selector_end = source.index(
             "\n}\n\nattest_previous_webtui_retirement() {",
             selector_start,
@@ -10376,12 +10376,12 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
         self.assertIn(
             '[ "${SCENARIO}" = upgrade-rollback ] && \\\n'
             '        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \\\n'
-            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.0 ]',
+            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.1 ]',
             transition,
         )
         self.assertIn(
-            "v4033_to_v4040_upgrade_selected() {\n"
-            "    v4033_to_v4040_transition_selected && \\\n"
+            "v4033_to_v4041_upgrade_selected() {\n"
+            "    v4033_to_v4041_transition_selected && \\\n"
             '        [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]\n'
             "}",
             selector,
@@ -10393,7 +10393,7 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
         self.assertIn("syswarden_verify_no_exact_webtui_process \\", common)
         self.assertIn("for previous_webtui_port in 62027 62028", common)
         self.assertIn(
-            "if v4033_to_v4040_upgrade_selected; then\n"
+            "if v4033_to_v4041_upgrade_selected; then\n"
             "        attest_v4033_previous_webtui_retirement || return 1\n"
             "        return 0\n"
             "    fi",
@@ -10409,7 +10409,7 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
 installed_version() {
     printf '%s\n' "${TEST_INSTALLED_VERSION}"
 }
-v4033_to_v4040_upgrade_selected
+v4033_to_v4041_upgrade_selected
 '''
         )
 
@@ -10418,7 +10418,7 @@ v4033_to_v4040_upgrade_selected
                 **os.environ,
                 "SCENARIO": "upgrade-rollback",
                 "EXPECTED_PREVIOUS_VERSION": "4.03.3",
-                "EXPECTED_CANDIDATE_VERSION": "4.04.0",
+                "EXPECTED_CANDIDATE_VERSION": "4.04.1",
                 "TEST_INSTALLED_VERSION": "4.03.3",
             }
             environment.update(overrides or {})
@@ -10435,7 +10435,7 @@ v4033_to_v4040_upgrade_selected
         for label, overrides in (
             ("scenario", {"SCENARIO": "remove"}),
             ("previous", {"EXPECTED_PREVIOUS_VERSION": "4.03.2"}),
-            ("candidate", {"EXPECTED_CANDIDATE_VERSION": "4.04.1"}),
+            ("candidate", {"EXPECTED_CANDIDATE_VERSION": "4.04.0"}),
             ("installed", {"TEST_INSTALLED_VERSION": "4.03.2"}),
         ):
             with self.subTest(bound=label):
@@ -10634,7 +10634,7 @@ v4033_to_v4040_upgrade_selected
 
         exact_skip = (
             "if v4032_to_v4033_upgrade_selected || \\\n"
-            "       v4033_to_v4040_upgrade_selected; then\n"
+            "       v4033_to_v4041_upgrade_selected; then\n"
             "        return 0\n"
             "    fi"
         )
@@ -10733,7 +10733,7 @@ seed_live_legacy_webtui_process
                 current = run_case(
                     family=family,
                     previous="4.03.3",
-                    candidate="4.04.0",
+                    candidate="4.04.1",
                     installed="4.03.3",
                 )
                 self.assertEqual(current.returncode, 0, current.stderr)

--- a/scripts/ci/package_qualification_matrix.json
+++ b/scripts/ci/package_qualification_matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "matrix_id": "syswarden-package-qualification/v1",
-  "target_release": "v4.04.0",
+  "target_release": "v4.04.1",
   "architecture": {
     "oci_platform": "linux/amd64",
     "kernel": "x86_64",

--- a/scripts/ci/package_qualification_matrix.py
+++ b/scripts/ci/package_qualification_matrix.py
@@ -634,8 +634,8 @@ def validate_document(document: object) -> dict[str, Any]:
         raise QualificationMatrixError("schema_version must equal integer 1")
     if matrix["matrix_id"] != "syswarden-package-qualification/v1":
         raise QualificationMatrixError("matrix_id does not match the v1 contract")
-    if matrix["target_release"] != "v4.04.0":
-        raise QualificationMatrixError("target_release must equal v4.04.0")
+    if matrix["target_release"] != "v4.04.1":
+        raise QualificationMatrixError("target_release must equal v4.04.1")
     _require_exact_mapping(matrix["architecture"], EXPECTED_ARCHITECTURE, "architecture")
     _validate_package_sources(matrix["package_sources"])
     _validate_budgets(matrix["budgets"])

--- a/scripts/ci/package_qualification_matrix_test.py
+++ b/scripts/ci/package_qualification_matrix_test.py
@@ -39,7 +39,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
     def test_repository_matrix_is_the_exact_frozen_contract(self) -> None:
         document = self.canonical
         self.assertEqual(document["schema_version"], 1)
-        self.assertEqual(document["target_release"], "v4.04.0")
+        self.assertEqual(document["target_release"], "v4.04.1")
         self.assertEqual(document["architecture"], matrix.EXPECTED_ARCHITECTURE)
         self.assertEqual(
             tuple(cell["id"] for cell in document["cells"]),
@@ -72,7 +72,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
         for arguments in (
             (),
             ("--check", str(matrix.DEFAULT_MATRIX)),
-            ("--expected-target-release", "v4.04.0"),
+            ("--expected-target-release", "v4.04.1"),
         ):
             with self.subTest(arguments=arguments):
                 stdout = io.StringIO()
@@ -81,14 +81,14 @@ class PackageQualificationMatrixTests(unittest.TestCase):
                     result = matrix.main(arguments)
                 self.assertEqual(result, 0, stderr.getvalue())
                 self.assertEqual(stderr.getvalue(), "")
-                self.assertIn("8 AMD64 cells for v4.04.0", stdout.getvalue())
+                self.assertIn("8 AMD64 cells for v4.04.1", stdout.getvalue())
                 self.assertRegex(stdout.getvalue(), r"sha256=[0-9a-f]{64}\n$")
 
     def test_cli_rejects_a_target_release_mismatch(self) -> None:
         stdout = io.StringIO()
         stderr = io.StringIO()
         with redirect_stdout(stdout), redirect_stderr(stderr):
-            result = matrix.main(("--expected-target-release", "v4.04.1"))
+            result = matrix.main(("--expected-target-release", "v4.04.0"))
         self.assertEqual(result, 1)
         self.assertEqual(stdout.getvalue(), "")
         self.assertIn("target_release", stderr.getvalue())
@@ -118,7 +118,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
             ("schema_version", "1", "schema_version"),
             ("schema_version", None, "schema_version"),
             ("matrix_id", "syswarden-package-qualification/v2", "matrix_id"),
-            ("target_release", "v4.04.1", "target_release"),
+            ("target_release", "v4.04.0", "target_release"),
         ):
             with self.subTest(field=field, value=value):
                 changed = self.document()

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -1964,6 +1964,10 @@ printf 'gh\\n' >> "${FAKE_LOG}"
             workflow.count("sha256sum --check --strict EVIDENCE_SHA256SUMS.txt"),
             2,
         )
+        self.assertEqual(workflow.count("--slurpfile qualification_matrix"), 2)
+        self.assertEqual(workflow.count('"previous_commit_sha",'), 2)
+        self.assertEqual(workflow.count(".schema_version == 2"), 2)
+        self.assertNotIn(".schema_version == 1", workflow)
         self.assertEqual(
             workflow.count(
                 'gh run download "${qualification_run_id}" \\\n'
@@ -2017,8 +2021,14 @@ printf 'gh\\n' >> "${FAKE_LOG}"
             self.assertIn('.repository == $repository', section)
             self.assertIn('.release_tag == $release_tag', section)
             self.assertIn('.release_sha == $release_sha', section)
+            self.assertIn('(.previous_commit_sha | type) == "string"', section)
             self.assertIn(
                 '.previous_tag == $aggregate[0].bindings.previous_version', section
+            )
+            self.assertIn(
+                ".previous_commit_sha ==\n"
+                "              $qualification_matrix[0].package_sources.baseline.commit",
+                section,
             )
             self.assertIn("(.previous_package_asset_ids | length) == 4", section)
             self.assertIn("all(.[]; . == 0)", section)
@@ -2109,6 +2119,102 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         )[1].split("      - name: Verify Private Draft Assets Before Publication", 1)[0]
         self.assertIn("release_payload/assets/*", release_creation)
         self.assertNotIn("syswarden-release-qualification", release_creation)
+
+    def test_release_manager_executes_schema_v2_context_contract(self) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        validate = workflow.split("  validate-and-stage:", 1)[1].split(
+            "  attest-and-publish:", 1
+        )[0]
+        privileged = workflow.split("  attest-and-publish:", 1)[1]
+        repository = "duggytuxy/syswarden"
+        release_tag = "v4.04.1"
+        release_sha = "a" * 40
+        previous_tag = "v4.03.3"
+        previous_commit_sha = "cdd66600a1505bae1f1e754dea096ee71e9cee82"
+        context = {
+            "schema_version": 2,
+            "repository": repository,
+            "release_tag": release_tag,
+            "release_sha": release_sha,
+            "previous_tag": previous_tag,
+            "previous_commit_sha": previous_commit_sha,
+            "candidate_package_workflow": "package.yml",
+            "candidate_package_run_id": 101,
+            "candidate_package_artifact_id": 102,
+            "candidate_package_artifact_name": "syswarden-packages-4.04.1",
+            "previous_release_id": 103,
+            "previous_package_asset_ids": [
+                {"id": 1, "name": "SHA256SUMS.txt"},
+                {"id": 2, "name": "syswarden-4.03.3-1.x86_64.rpm"},
+                {"id": 3, "name": "syswarden_4.03.3_amd64.deb"},
+                {"id": 4, "name": "syswarden_4.03.3_x86_64.apk"},
+            ],
+        }
+        aggregate = {"bindings": {"previous_version": previous_tag}}
+        qualification_matrix = {
+            "package_sources": {
+                "baseline": {"commit": previous_commit_sha},
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            aggregate_path = root / "aggregate.json"
+            matrix_path = root / "matrix.json"
+            context_path = root / "qualification-context.json"
+            aggregate_path.write_text(json.dumps(aggregate), encoding="utf-8")
+            matrix_path.write_text(json.dumps(qualification_matrix), encoding="utf-8")
+
+            for stage, section in (("validate", validate), ("privileged", privileged)):
+                start_marker = "'(keys | sort) == ["
+                end_marker = "' \"${QUALIFICATION_ROOT}/qualification-context.json\""
+                self.assertEqual(section.count(start_marker), 1, stage)
+                start = section.index(start_marker) + 1
+                end = section.index(end_marker, start)
+                predicate = section[start:end]
+
+                def execute(candidate: dict[str, object]) -> subprocess.CompletedProcess[str]:
+                    context_path.write_text(json.dumps(candidate), encoding="utf-8")
+                    return subprocess.run(
+                        [
+                            "jq",
+                            "--exit-status",
+                            "--slurpfile",
+                            "aggregate",
+                            str(aggregate_path),
+                            "--slurpfile",
+                            "qualification_matrix",
+                            str(matrix_path),
+                            "--arg",
+                            "repository",
+                            repository,
+                            "--arg",
+                            "release_tag",
+                            release_tag,
+                            "--arg",
+                            "release_sha",
+                            release_sha,
+                            predicate,
+                            str(context_path),
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                with self.subTest(stage=stage, mutation="valid"):
+                    result = execute(context)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                for mutation, mutate in (
+                    ("schema", lambda value: value.__setitem__("schema_version", 1)),
+                    ("commit", lambda value: value.__setitem__("previous_commit_sha", "b" * 40)),
+                    ("extra", lambda value: value.__setitem__("unexpected", True)),
+                    ("missing", lambda value: value.pop("previous_commit_sha")),
+                ):
+                    candidate = json.loads(json.dumps(context))
+                    mutate(candidate)
+                    with self.subTest(stage=stage, mutation=mutation):
+                        self.assertNotEqual(execute(candidate).returncode, 0)
 
     def test_privileged_publisher_requires_a_protected_maintainer_environment(self) -> None:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -61,14 +61,14 @@ def replace_snapshot_identity_maps(
 
 
 class AdapterFixture:
-    version = "v4.04.0"
+    version = "v4.04.1"
     previous_version = "v4.03.3"
     repository = "duggytuxy/syswarden"
     workflow_run_id = 1001
     workflow_run_attempt = 1
     candidate_run_id = 900
     candidate_artifact_id = 901
-    candidate_artifact_name = "syswarden-packages-4.04.0"
+    candidate_artifact_name = "syswarden-packages-4.04.1"
     previous_release_id = 377680978
 
     def __init__(self, root: Path) -> None:
@@ -93,7 +93,7 @@ class AdapterFixture:
         self.now = datetime.now(UTC).replace(microsecond=0)
         self._make_repository()
         self.commit = self._git("rev-parse", "HEAD")
-        self._make_package_set(self.candidate, "4.04.0", b"candidate")
+        self._make_package_set(self.candidate, "4.04.1", b"candidate")
         self._make_package_set(self.previous, "4.03.3", b"previous")
         self._make_raw_reports()
 

--- a/scripts/ci/release_qualification_gate_test.py
+++ b/scripts/ci/release_qualification_gate_test.py
@@ -24,7 +24,7 @@ import package_qualification_matrix as qualification_matrix
 
 
 class QualificationFixture:
-    version = "v4.04.0"
+    version = "v4.04.1"
     previous_version = "v4.03.3"
 
     def __init__(self, root: Path, *, profile: str = "release") -> None:

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -902,7 +902,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
     def test_three_packages_and_eight_native_matrix_cells_are_exact(self) -> None:
         catalog = self.package_qualification_matrix
         cells = catalog["cells"]
-        self.assertEqual(catalog["target_release"], "v4.04.0")
+        self.assertEqual(catalog["target_release"], "v4.04.1")
         self.assertEqual(
             catalog["architecture"],
             package_qualification_matrix.EXPECTED_ARCHITECTURE,

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -153,7 +153,7 @@ var installCmd = &cobra.Command{
 			return installStageError("legacy shell completion reconciliation failed", err)
 		}
 
-		fmt.Println("[SYSWARDEN] v4.04.0 native installation complete.")
+		fmt.Println("[SYSWARDEN] v4.04.1 native installation complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.04.0
+# Version=v4.04.1
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.04.0", Inline: true},
+						{Name: "Version", Value: "v4.04.1", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-var Version = "v4.04.0"
+var Version = "v4.04.1"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -240,7 +240,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -280,7 +280,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -399,7 +399,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.0 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.04.0"
+const SysWardenVersion = "v4.04.1"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary

- Align both release-manager qualification-context consumers with schema 2.
- Require `previous_commit_sha` and bind it to the frozen v4.03.3 baseline commit in the AMD64 qualification matrix.
- Execute both embedded jq predicates in regression tests with a valid context and adversarial schema, key and commit mutations.
- Advance the source candidate from v4.04.0 to v4.04.1 as a Patch transition while preserving the complete unpublished v4.04.0 product scope in the release notes.
- Retarget the exact eight-cell AMD64 qualification matrix and lifecycle transition to v4.03.3 -> v4.04.1.

## Root cause

The v4.04.0 qualification producer emitted `qualification-context.json` schema 2 with `previous_commit_sha`, while both release-manager consumers still required schema 1 and an exact key set without that field. The tag publisher therefore failed closed before the protected production environment and before any GitHub Release was created.

The signed v4.04.0 tag remains immutable and unpublished. A rerun would reuse the workflow contained in that tag, so v4.04.1 must complete a new qualification, signed annotated tag and protected publication sequence.

Failed publisher evidence: https://github.com/duggytuxy/syswarden/actions/runs/33618562322

## Validation

- 616 Python CI tests passed, with 8 expected skips.
- Go CLI, Core, TUI and versionctl test suites passed.
- The executable release-manager schema 2 regression passed for both publisher stages.
- The source and current GitHub wiki documentation gate passed.
- `versionctl` validated `v4.04.0 -> v4.04.1 (Patch)`.
- The frozen matrix validated 8 AMD64 cells for v4.04.1 with v4.03.3 as the exact public baseline.
- `git diff --check` passed.
