### PR TITLE
Patch : close the release publisher CLI contract

### DIFF
--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -797,6 +797,7 @@ jobs:
             --nft-raw "${QUALIFICATION_ROOT}/raw/nftables-raw.json" \
             --package-raw "${QUALIFICATION_ROOT}/raw/package-lifecycle-raw.json" \
             --package-amd64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-amd64.json" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --expected-repository "${GITHUB_REPOSITORY}" \
             --expected-workflow-run-id "${QUALIFICATION_RUN_ID}" \
             --expected-workflow-run-attempt 1 \
@@ -1341,6 +1342,7 @@ jobs:
             --nft-raw "${QUALIFICATION_ROOT}/raw/nftables-raw.json" \
             --package-raw "${QUALIFICATION_ROOT}/raw/package-lifecycle-raw.json" \
             --package-amd64-shard "${QUALIFICATION_ROOT}/raw/package-lifecycle-amd64.json" \
+            --qualification-matrix "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json" \
             --expected-repository "${GITHUB_REPOSITORY}" \
             --expected-workflow-run-id "${QUALIFICATION_RUN_ID}" \
             --expected-workflow-run-attempt 1 \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ defense layer without placing another proxy in the application data path.
 SysWarden is not an inline HTTP proxy, a traffic sanitizer or a regulatory
 certification product.
 
-Current source version: **v4.04.1**.
+Current source version: **v4.04.2**.
 
 The latest qualified, stable public release is
 [v4.03.3](https://github.com/duggytuxy/syswarden/releases/tag/v4.03.3).

--- a/assets/syswarden_architecture.svg
+++ b/assets/syswarden_architecture.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" role="img" aria-labelledby="title description" data-theme="dark" data-theme-status="legacy">
-  <title id="title">SysWarden v4.04.1 candidate architecture</title>
+  <title id="title">SysWarden v4.04.2 candidate architecture</title>
   <desc id="description">Protected Linux workloads emit logs and host telemetry to a local SysWarden core. The core commits authoritative nftables policy and may reconcile one already active UFW or firewalld compatibility frontend. It also manages local telemetry and an authenticated peer-scoped HA API. Operators use a privileged CLI and a local terminal dashboard. A challenge-bound HA fence protects partner migration cleanup.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
@@ -57,7 +57,7 @@
   <g transform="translate(30 5) scale(0.68)">
     <use href="#syswardenOfficialLogo"/>
   </g>
-  <text x="475" y="62" class="h1">v4.04.1 candidate architecture</text>
+  <text x="475" y="62" class="h1">v4.04.2 candidate architecture</text>
   <text x="475" y="98" class="body">Linux-only host enforcement, local terminal operations and condition-bound HA migration</text>
 
   <g transform="translate(70 154)" filter="url(#shadow)">

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,80 @@
+# Release v4.04.2
+
+> Candidate status: v4.04.2 is the Patch candidate for the publisher CLI
+> contract correction and includes the complete unpublished v4.04.0 and
+> v4.04.1 candidate scope. This block does not authorize a tag or public
+> Release.
+
+### ADDED
+
+- **Typed ICMP operator policy:** Add a closed `[[operator_policy.rules]]`
+  schema for inbound IPv4 ICMP and IPv6 ICMPv6 echo requests. Rules are
+  declared only in `modules/99-user.toml`, use canonical IP or CIDR sources and
+  support the bounded `accept` action without exposing raw nftables input.
+- **Deterministic nftables compilation:** Compile validated rules into one
+  dedicated `operator-policy` chain, sort them by canonical identifier and
+  dispatch to the chain immediately before the product-owned catch-all deny.
+  A non-match always returns to the existing terminal policy.
+
+### FIXED
+
+- **Complete publisher CLI binding:** Pass the frozen qualification matrix to
+  both unprivileged and privileged release-manager adapter invocations so the
+  exact pre-tag evidence can be revalidated before staging and publication.
+- **Exact qualification schema consumption:** Align both release-manager
+  validators with qualification context schema 2, require the
+  `previous_commit_sha` field and bind it to the frozen baseline commit in the
+  AMD64 qualification matrix.
+- **Release-chain regression coverage:** Require both publisher stages to
+  consume schema 2, the exact baseline commit binding and every mandatory
+  adapter option so producer and consumer drift fails during pre-merge
+  validation.
+
+### SECURITY
+
+- **Closed configuration provenance:** Reject unknown or missing fields,
+  duplicate identifiers, protocol and family mismatches, non-canonical or
+  overlapping sources, IPv4-mapped IPv6 values and every environment variable
+  prefixed with `SYSWARDEN_OPERATOR_POLICY`. Limit the operator module to
+  256 KiB, the policy to 64 rules and the compiled fragment to 64 KiB.
+- **Commit-bound source attestation:** Bind a non-empty policy to the exact
+  validated `99-user.toml` identity and digest, then revalidate and reattest it
+  at the pre-apply commit boundary and again after post-apply verification,
+  before persistent publication.
+- **Exact post-apply verification:** Verify the dedicated chain, ordered rule
+  expressions, provenance comments, terminal return, unique dispatch and
+  catch-all log and drop sequence from nftables JSON. Any mismatch restores the
+  previous policy and prevents publication.
+- **Durable interrupted-transaction recovery:** Journal the previous kernel and
+  persistent firewall state before apply, preserve only live bounded dynamic
+  bans, quarantine legacy maximum-ending intervals and recover an interrupted
+  transaction before a new reload. An indeterminate apply result is rolled back
+  and never treated as an unchanged ruleset.
+- **Frontend ownership boundary:** Refuse a non-empty operator policy when UFW
+  or firewalld is active so nftables remains the sole authoritative policy
+  owner for this capability.
+- **Immutable publication recovery:** Preserve the signed v4.04.0 and v4.04.1
+  tags and their successful qualification evidence without moving either tag,
+  rewriting evidence or bypassing tag-bound provenance. Require v4.04.2 to
+  complete a new qualification, signed tag and protected publication sequence.
+
+### TESTING
+
+- **Shared CLI and daemon contract corpus:** Exercise the same raw TOML,
+  semantic, environment, 64/65-rule and 256 KiB boundary cases in both config
+  implementations without coupling their Go modules.
+- **Real nftables and failure-path coverage:** Add deterministic golden
+  fixtures, validate the generated topology and populated IPv4/IPv6 rules in
+  isolated real-nftables namespaces, and add exact JSON mutation tests plus
+  injected failures for apply, verification, persistence, rollback and restart
+  recovery.
+- **Executable publisher contract regression:** Extract both exact continued
+  adapter commands from the release-manager workflow, derive every mandatory
+  option from the live parser and reject missing, unknown, duplicate or
+  valueless options before merge.
+
+---
+
 # Release v4.04.1
 
 > Candidate status: v4.04.1 is the Patch candidate for the release

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -181,7 +181,7 @@
       "stream": "stdout",
       "reason": "Advance the minor version while preserving the bounded built-in operator reference.",
       "before": "SYSWARDEN v4.02.8 CLI\nUse 'syswarden manual' for the comprehensive SysAdmin documentation, or 'syswarden --help' for standard commands.\n",
-      "after": "SYSWARDEN v4.04.1 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
+      "after": "SYSWARDEN v4.04.2 CLI\nUse 'syswarden manual' for the built-in operator reference, or 'syswarden --help' for command help.\n"
     },
     {
       "case": "help:syswarden",

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -20,7 +20,7 @@ import release_gate
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOURCE_CANDIDATE_VERSION = "v4.04.1"
+SOURCE_CANDIDATE_VERSION = "v4.04.2"
 STABLE_PUBLIC_VERSION = "v4.03.3"
 REPORT = REPO_ROOT / (
     f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{STABLE_PUBLIC_VERSION}.md"
@@ -108,7 +108,7 @@ class DocumentationGateTest(unittest.TestCase):
             [],
         )
         errors = documentation_gate.validate_public_version_order(
-            SOURCE_CANDIDATE_VERSION, "v4.04.2"
+            SOURCE_CANDIDATE_VERSION, "v4.04.3"
         )
         self.assertTrue(any("cannot be newer" in error for error in errors))
 

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -3053,8 +3053,8 @@ v4032_to_v4033_upgrade_selected() {
         [ "$(installed_version 2>/dev/null || true)" = 4.03.2 ]
 }
 
-v4033_to_v4041_upgrade_selected() {
-    v4033_to_v4041_transition_selected && \
+v4033_to_v4042_upgrade_selected() {
+    v4033_to_v4042_transition_selected && \
         [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]
 }
 
@@ -3097,7 +3097,7 @@ attest_v4032_previous_webtui_retirement() {
 }
 
 attest_v4033_previous_webtui_retirement() {
-    v4033_to_v4041_upgrade_selected || return 1
+    v4033_to_v4042_upgrade_selected || return 1
     attest_previous_webtui_retirement "$@"
 }
 
@@ -3445,10 +3445,10 @@ v4032_to_v4033_transition_selected() {
         [ "${EXPECTED_CANDIDATE_VERSION}" = 4.03.3 ]
 }
 
-v4033_to_v4041_transition_selected() {
+v4033_to_v4042_transition_selected() {
     [ "${SCENARIO}" = upgrade-rollback ] && \
         [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \
-        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.1 ]
+        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.2 ]
 }
 
 expected_systemd_enablement_prefix() {
@@ -3460,7 +3460,7 @@ expected_systemd_enablement_prefix() {
             if v4028_to_v4032_transition_selected; then
                 printf '%s\n' /etc/systemd/system
             elif v4032_to_v4033_transition_selected || \
-                 v4033_to_v4041_transition_selected; then
+                 v4033_to_v4042_transition_selected; then
                 printf '%s\n' ..
             else
                 return 1
@@ -3858,7 +3858,7 @@ probe_postinstall_contract() {
         probe_seeded_operator_listener_preservation "${label}" || mark_postinstall_failure operator-listener
     elif [ "${actual_version}" = "${EXPECTED_PREVIOUS_VERSION}" ]; then
         if v4032_to_v4033_upgrade_selected || \
-           v4033_to_v4041_upgrade_selected; then
+           v4033_to_v4042_upgrade_selected; then
             attest_previous_webtui_retirement || \
                 mark_postinstall_failure previous-webtui-retirement
         else
@@ -4227,7 +4227,7 @@ quiesce_previous_webtui_runtime() {
         attest_v4032_previous_webtui_retirement || return 1
         return 0
     fi
-    if v4033_to_v4041_upgrade_selected; then
+    if v4033_to_v4042_upgrade_selected; then
         attest_v4033_previous_webtui_retirement || return 1
         return 0
     fi
@@ -4587,7 +4587,7 @@ seed_live_legacy_webtui_process() {
         *) return 0 ;;
     esac
     if v4032_to_v4033_upgrade_selected || \
-       v4033_to_v4041_upgrade_selected; then
+       v4033_to_v4042_upgrade_selected; then
         return 0
     fi
     /opt/syswarden/bin/syswarden-cli web-tui \
@@ -5039,7 +5039,7 @@ expected_upgrade_rollback_token_contract() {
     if v4028_to_v4032_transition_selected; then
         printf '%s\n' historical-webtui-credential
     elif v4032_to_v4033_transition_selected || \
-         v4033_to_v4041_transition_selected; then
+         v4033_to_v4042_transition_selected; then
         printf '%s\n' byte-exact
     else
         return 1

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -8133,7 +8133,7 @@ probe
                 for label in upgrade_labels
             ),
             *(
-                ("upgrade-rollback", "4.03.3", "4.04.1", label, "..")
+                ("upgrade-rollback", "4.03.3", "4.04.2", label, "..")
                 for label in upgrade_labels
             ),
             ("remove", "4.03.2", "4.03.3", "fresh", ".."),
@@ -9813,7 +9813,7 @@ assert_all_state_preserved "$1"
         self.assertIn("if v4028_to_v4032_transition_selected; then", contract)
         self.assertIn(
             "elif v4032_to_v4033_transition_selected || \\\n"
-            "         v4033_to_v4041_transition_selected; then",
+            "         v4033_to_v4042_transition_selected; then",
             contract,
         )
         self.assertIn("historical-webtui-credential", contract)
@@ -9876,7 +9876,7 @@ assert_all_state_preserved "$1"
             (
                 "upgrade-rollback",
                 "4.03.3",
-                "4.04.1",
+                "4.04.2",
                 family,
                 "rollback",
                 "byte-exact",
@@ -10199,7 +10199,7 @@ assert_preserved rollback token "$1" "$2" 640
         )
         self.assertIn(
             "if v4032_to_v4033_upgrade_selected || \\\n"
-            "           v4033_to_v4041_upgrade_selected; then\n"
+            "           v4033_to_v4042_upgrade_selected; then\n"
             "            attest_previous_webtui_retirement || \\\n"
             "                mark_postinstall_failure previous-webtui-retirement\n"
             "        else",
@@ -10343,19 +10343,19 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
                     0,
                 )
 
-    def test_v4033_to_v4041_previous_webtui_absence_is_exact_and_fail_closed(
+    def test_v4033_to_v4042_previous_webtui_absence_is_exact_and_fail_closed(
         self,
     ) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT
         transition_start = source.index(
-            "v4033_to_v4041_transition_selected() {"
+            "v4033_to_v4042_transition_selected() {"
         )
         transition_end = source.index(
             "\n}\n\nexpected_systemd_enablement_prefix() {",
             transition_start,
         ) + 2
         transition = source[transition_start:transition_end]
-        selector_start = source.index("v4033_to_v4041_upgrade_selected() {")
+        selector_start = source.index("v4033_to_v4042_upgrade_selected() {")
         selector_end = source.index(
             "\n}\n\nattest_previous_webtui_retirement() {",
             selector_start,
@@ -10376,12 +10376,12 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
         self.assertIn(
             '[ "${SCENARIO}" = upgrade-rollback ] && \\\n'
             '        [ "${EXPECTED_PREVIOUS_VERSION}" = 4.03.3 ] && \\\n'
-            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.1 ]',
+            '        [ "${EXPECTED_CANDIDATE_VERSION}" = 4.04.2 ]',
             transition,
         )
         self.assertIn(
-            "v4033_to_v4041_upgrade_selected() {\n"
-            "    v4033_to_v4041_transition_selected && \\\n"
+            "v4033_to_v4042_upgrade_selected() {\n"
+            "    v4033_to_v4042_transition_selected && \\\n"
             '        [ "$(installed_version 2>/dev/null || true)" = 4.03.3 ]\n'
             "}",
             selector,
@@ -10393,7 +10393,7 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
         self.assertIn("syswarden_verify_no_exact_webtui_process \\", common)
         self.assertIn("for previous_webtui_port in 62027 62028", common)
         self.assertIn(
-            "if v4033_to_v4041_upgrade_selected; then\n"
+            "if v4033_to_v4042_upgrade_selected; then\n"
             "        attest_v4033_previous_webtui_retirement || return 1\n"
             "        return 0\n"
             "    fi",
@@ -10409,7 +10409,7 @@ attest_v4032_previous_webtui_retirement "${TEST_ROOT}" "${TEST_ROOT}/proc"
 installed_version() {
     printf '%s\n' "${TEST_INSTALLED_VERSION}"
 }
-v4033_to_v4041_upgrade_selected
+v4033_to_v4042_upgrade_selected
 '''
         )
 
@@ -10418,7 +10418,7 @@ v4033_to_v4041_upgrade_selected
                 **os.environ,
                 "SCENARIO": "upgrade-rollback",
                 "EXPECTED_PREVIOUS_VERSION": "4.03.3",
-                "EXPECTED_CANDIDATE_VERSION": "4.04.1",
+                "EXPECTED_CANDIDATE_VERSION": "4.04.2",
                 "TEST_INSTALLED_VERSION": "4.03.3",
             }
             environment.update(overrides or {})
@@ -10634,7 +10634,7 @@ v4033_to_v4041_upgrade_selected
 
         exact_skip = (
             "if v4032_to_v4033_upgrade_selected || \\\n"
-            "       v4033_to_v4041_upgrade_selected; then\n"
+            "       v4033_to_v4042_upgrade_selected; then\n"
             "        return 0\n"
             "    fi"
         )
@@ -10733,7 +10733,7 @@ seed_live_legacy_webtui_process
                 current = run_case(
                     family=family,
                     previous="4.03.3",
-                    candidate="4.04.1",
+                    candidate="4.04.2",
                     installed="4.03.3",
                 )
                 self.assertEqual(current.returncode, 0, current.stderr)

--- a/scripts/ci/package_qualification_matrix.json
+++ b/scripts/ci/package_qualification_matrix.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "matrix_id": "syswarden-package-qualification/v1",
-  "target_release": "v4.04.1",
+  "target_release": "v4.04.2",
   "architecture": {
     "oci_platform": "linux/amd64",
     "kernel": "x86_64",

--- a/scripts/ci/package_qualification_matrix.py
+++ b/scripts/ci/package_qualification_matrix.py
@@ -634,8 +634,8 @@ def validate_document(document: object) -> dict[str, Any]:
         raise QualificationMatrixError("schema_version must equal integer 1")
     if matrix["matrix_id"] != "syswarden-package-qualification/v1":
         raise QualificationMatrixError("matrix_id does not match the v1 contract")
-    if matrix["target_release"] != "v4.04.1":
-        raise QualificationMatrixError("target_release must equal v4.04.1")
+    if matrix["target_release"] != "v4.04.2":
+        raise QualificationMatrixError("target_release must equal v4.04.2")
     _require_exact_mapping(matrix["architecture"], EXPECTED_ARCHITECTURE, "architecture")
     _validate_package_sources(matrix["package_sources"])
     _validate_budgets(matrix["budgets"])

--- a/scripts/ci/package_qualification_matrix_test.py
+++ b/scripts/ci/package_qualification_matrix_test.py
@@ -39,7 +39,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
     def test_repository_matrix_is_the_exact_frozen_contract(self) -> None:
         document = self.canonical
         self.assertEqual(document["schema_version"], 1)
-        self.assertEqual(document["target_release"], "v4.04.1")
+        self.assertEqual(document["target_release"], "v4.04.2")
         self.assertEqual(document["architecture"], matrix.EXPECTED_ARCHITECTURE)
         self.assertEqual(
             tuple(cell["id"] for cell in document["cells"]),
@@ -72,7 +72,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
         for arguments in (
             (),
             ("--check", str(matrix.DEFAULT_MATRIX)),
-            ("--expected-target-release", "v4.04.1"),
+            ("--expected-target-release", "v4.04.2"),
         ):
             with self.subTest(arguments=arguments):
                 stdout = io.StringIO()
@@ -81,7 +81,7 @@ class PackageQualificationMatrixTests(unittest.TestCase):
                     result = matrix.main(arguments)
                 self.assertEqual(result, 0, stderr.getvalue())
                 self.assertEqual(stderr.getvalue(), "")
-                self.assertIn("8 AMD64 cells for v4.04.1", stdout.getvalue())
+                self.assertIn("8 AMD64 cells for v4.04.2", stdout.getvalue())
                 self.assertRegex(stdout.getvalue(), r"sha256=[0-9a-f]{64}\n$")
 
     def test_cli_rejects_a_target_release_mismatch(self) -> None:

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import json
 import os
+import shlex
 import stat
 import subprocess
 import tarfile
@@ -18,6 +19,7 @@ from pathlib import Path
 from unittest import mock
 
 import release_gate
+import release_qualification_adapter
 
 
 REPOSITORY = Path(__file__).resolve().parents[2]
@@ -51,6 +53,30 @@ def workflow_step_scripts(workflow: str, step_name: str) -> list[str]:
     if not scripts:
         raise AssertionError(f"workflow step {step_name} is missing")
     return scripts
+
+
+def continued_shell_commands(script: str, needle: str) -> list[list[str]]:
+    """Return tokenized shell commands, including their continued lines."""
+    lines = script.splitlines()
+    commands: list[list[str]] = []
+    for start, line in enumerate(lines):
+        if needle not in line:
+            continue
+        fragments: list[str] = []
+        index = start
+        while True:
+            fragment = lines[index].strip()
+            continued = fragment.endswith("\\")
+            if continued:
+                fragment = fragment[:-1].rstrip()
+            fragments.append(fragment)
+            if not continued:
+                break
+            index += 1
+            if index >= len(lines):
+                raise AssertionError(f"unterminated shell command containing {needle}")
+        commands.append(shlex.split(" ".join(fragments)))
+    return commands
 
 
 def run_environment_gate(
@@ -2120,6 +2146,82 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         self.assertIn("release_payload/assets/*", release_creation)
         self.assertNotIn("syswarden-release-qualification", release_creation)
 
+    def test_release_manager_adapter_calls_match_the_live_cli_contract(self) -> None:
+        workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
+        needle = "python3 scripts/ci/release_qualification_adapter.py verify"
+        commands = continued_shell_commands(workflow, needle)
+        self.assertEqual(len(commands), 2)
+
+        parser = release_qualification_adapter.build_parser()
+        subparsers = next(
+            action
+            for action in parser._actions
+            if "verify" in (getattr(action, "choices", None) or {})
+        )
+        verify_parser = subparsers.choices["verify"]
+        known_options = {
+            option
+            for action in verify_parser._actions
+            for option in action.option_strings
+            if option.startswith("--")
+        }
+        required_options = {
+            option
+            for action in verify_parser._actions
+            if action.required
+            for option in action.option_strings
+            if option.startswith("--")
+        }
+        expected_arguments = {
+            "--repo-root": "${GITHUB_WORKSPACE}",
+            "--expected-sha": "${RELEASE_SHA}",
+            "--expected-version": "${RELEASE_TAG}",
+            "--candidate-packages-dir": "${QUALIFICATION_ROOT}/packages/candidate",
+            "--previous-packages-dir": "${QUALIFICATION_ROOT}/packages/previous",
+            "--nft-raw": "${QUALIFICATION_ROOT}/raw/nftables-raw.json",
+            "--package-raw": "${QUALIFICATION_ROOT}/raw/package-lifecycle-raw.json",
+            "--package-amd64-shard": (
+                "${QUALIFICATION_ROOT}/raw/package-lifecycle-amd64.json"
+            ),
+            "--qualification-matrix": (
+                "${GITHUB_WORKSPACE}/scripts/ci/package_qualification_matrix.json"
+            ),
+            "--expected-repository": "${GITHUB_REPOSITORY}",
+            "--expected-workflow-run-id": "${QUALIFICATION_RUN_ID}",
+            "--expected-workflow-run-attempt": "1",
+            "--expected-candidate-run-id": "${candidate_run_id}",
+            "--expected-candidate-artifact-id": "${candidate_artifact_id}",
+            "--expected-candidate-artifact-name": "${candidate_artifact_name}",
+            "--expected-previous-release-id": "${previous_release_id}",
+            "--max-age-seconds": "172800",
+            "--max-report-skew-seconds": "0",
+            "--nft-envelope": "${QUALIFICATION_ROOT}/bound/nftables-bound.json",
+            "--package-envelope": (
+                "${QUALIFICATION_ROOT}/bound/package-lifecycle-bound.json"
+            ),
+        }
+
+        for command in commands:
+            with self.subTest(command=" ".join(command)):
+                verify_index = command.index("verify")
+                argument_tokens = command[verify_index + 1 :]
+                self.assertEqual(len(argument_tokens) % 2, 0)
+                provided_arguments: dict[str, str] = {}
+                for option, value in zip(
+                    argument_tokens[0::2], argument_tokens[1::2], strict=True
+                ):
+                    self.assertTrue(option.startswith("--"), option)
+                    self.assertIn(option, known_options)
+                    self.assertNotIn(option, provided_arguments)
+                    self.assertTrue(value, option)
+                    self.assertFalse(value.startswith("--"), option)
+                    provided_arguments[option] = value
+                self.assertEqual(
+                    required_options - set(provided_arguments),
+                    set(),
+                )
+                self.assertEqual(provided_arguments, expected_arguments)
+
     def test_release_manager_executes_schema_v2_context_contract(self) -> None:
         workflow = RELEASE_MANAGER_WORKFLOW.read_text(encoding="utf-8")
         validate = workflow.split("  validate-and-stage:", 1)[1].split(
@@ -2127,7 +2229,7 @@ printf 'gh\\n' >> "${FAKE_LOG}"
         )[0]
         privileged = workflow.split("  attest-and-publish:", 1)[1]
         repository = "duggytuxy/syswarden"
-        release_tag = "v4.04.1"
+        release_tag = "v4.04.2"
         release_sha = "a" * 40
         previous_tag = "v4.03.3"
         previous_commit_sha = "cdd66600a1505bae1f1e754dea096ee71e9cee82"
@@ -2141,7 +2243,7 @@ printf 'gh\\n' >> "${FAKE_LOG}"
             "candidate_package_workflow": "package.yml",
             "candidate_package_run_id": 101,
             "candidate_package_artifact_id": 102,
-            "candidate_package_artifact_name": "syswarden-packages-4.04.1",
+            "candidate_package_artifact_name": "syswarden-packages-4.04.2",
             "previous_release_id": 103,
             "previous_package_asset_ids": [
                 {"id": 1, "name": "SHA256SUMS.txt"},

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -61,14 +61,14 @@ def replace_snapshot_identity_maps(
 
 
 class AdapterFixture:
-    version = "v4.04.1"
+    version = "v4.04.2"
     previous_version = "v4.03.3"
     repository = "duggytuxy/syswarden"
     workflow_run_id = 1001
     workflow_run_attempt = 1
     candidate_run_id = 900
     candidate_artifact_id = 901
-    candidate_artifact_name = "syswarden-packages-4.04.1"
+    candidate_artifact_name = "syswarden-packages-4.04.2"
     previous_release_id = 377680978
 
     def __init__(self, root: Path) -> None:
@@ -93,7 +93,7 @@ class AdapterFixture:
         self.now = datetime.now(UTC).replace(microsecond=0)
         self._make_repository()
         self.commit = self._git("rev-parse", "HEAD")
-        self._make_package_set(self.candidate, "4.04.1", b"candidate")
+        self._make_package_set(self.candidate, "4.04.2", b"candidate")
         self._make_package_set(self.previous, "4.03.3", b"previous")
         self._make_raw_reports()
 

--- a/scripts/ci/release_qualification_gate_test.py
+++ b/scripts/ci/release_qualification_gate_test.py
@@ -24,7 +24,7 @@ import package_qualification_matrix as qualification_matrix
 
 
 class QualificationFixture:
-    version = "v4.04.1"
+    version = "v4.04.2"
     previous_version = "v4.03.3"
 
     def __init__(self, root: Path, *, profile: str = "release") -> None:

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -902,7 +902,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
     def test_three_packages_and_eight_native_matrix_cells_are_exact(self) -> None:
         catalog = self.package_qualification_matrix
         cells = catalog["cells"]
-        self.assertEqual(catalog["target_release"], "v4.04.1")
+        self.assertEqual(catalog["target_release"], "v4.04.2")
         self.assertEqual(
             catalog["architecture"],
             package_qualification_matrix.EXPECTED_ARCHITECTURE,

--- a/src/core/syswarden-cli/cmd/install.go
+++ b/src/core/syswarden-cli/cmd/install.go
@@ -153,7 +153,7 @@ var installCmd = &cobra.Command{
 			return installStageError("legacy shell completion reconciliation failed", err)
 		}
 
-		fmt.Println("[SYSWARDEN] v4.04.1 native installation complete.")
+		fmt.Println("[SYSWARDEN] v4.04.2 native installation complete.")
 		return nil
 	},
 }

--- a/src/core/syswarden-cli/config/default.go
+++ b/src/core/syswarden-cli/config/default.go
@@ -1,7 +1,7 @@
 package config
 
 const DefaultConfig = `# ==============================================================================
-# Version=v4.04.1
+# Version=v4.04.2
 # SYSWARDEN UNATTENDED INSTALLATION CONFIGURATION
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/core/syswarden-cli/pkg/integration/webhook.go
+++ b/src/core/syswarden-cli/pkg/integration/webhook.go
@@ -63,7 +63,7 @@ func SetupWebhooks() error {
 					Description: "Native Go Webhook integration established.",
 					Color:       3066993, // Green
 					Fields: []EmbedField{
-						{Name: "Version", Value: "v4.04.1", Inline: true},
+						{Name: "Version", Value: "v4.04.2", Inline: true},
 						{Name: "NODE", Value: hostname, Inline: true},
 						{Name: "Status", Value: "Active", Inline: true},
 					},

--- a/src/core/syswarden-cli/pkg/system/upgrade.go
+++ b/src/core/syswarden-cli/pkg/system/upgrade.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-var Version = "v4.04.1"
+var Version = "v4.04.2"
 
 const (
 	latestReleaseAPI             = "https://api.github.com/repos/duggytuxy/syswarden/releases/latest"

--- a/src/core/syswarden-core/webhook/discord.go
+++ b/src/core/syswarden-core/webhook/discord.go
@@ -240,7 +240,7 @@ func SendBanAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.2 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -280,7 +280,7 @@ func SendDetectedAlert(ip, jail, action string) {
 					{Name: "NODE", Value: hostname, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.2 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -399,7 +399,7 @@ func SendComplianceAlert(msg, status string) {
 					{Name: "Status", Value: status, Inline: true},
 				},
 				Footer: EmbedFooter{
-					Text: "SYSWARDEN v4.04.1 - Advanced Agentic Defense",
+					Text: "SYSWARDEN v4.04.2 - Advanced Agentic Defense",
 				},
 				Timestamp: time.Now().UTC().Format(time.RFC3339),
 			},

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 const DataFile = "/var/lib/syswarden/ui/data.json"
-const SysWardenVersion = "v4.04.1"
+const SysWardenVersion = "v4.04.2"
 const haPeerCABundleFile = "/etc/syswarden/ha-ca.pem"
 const haModularConfigDirectory = "/etc/syswarden/config"
 const maxTUIHAResponseBytes = 1024 * 1024


### PR DESCRIPTION
## Summary

- pass the frozen qualification matrix to both release-manager adapter verification stages
- validate each publisher command against the live parser and the exact 20 option/value bindings
- advance the candidate from v4.04.1 to v4.04.2 as a Patch while retaining v4.03.3 as the public qualification baseline
- carry the complete unpublished v4.04.0 and v4.04.1 scope into the v4.04.2 release notes

## Root cause

The qualification adapter made qualification-matrix mandatory, but its two release-manager consumers were not updated. Existing tests checked only a hand-maintained subset of the command contract, so the omission reached the tag-bound publisher and failed closed before staging or publication.

## Security and provenance

- v4.04.0 and v4.04.1 remain signed, immutable and unpublished
- no failed-run evidence, packages or tags are reused
- v4.04.2 requires a new exact qualification, signed annotated tag and protected publisher sequence
- the adapter continues to bind the matrix bytes to the exact release commit and frozen v4.03.3 baseline

## Validation

- exact replay of the failed v4.04.1 adapter verification with the corrected argument: passed
- Python CI suite: 617 passed, 8 expected sandbox skips
- Go CLI, Core and TUI suites: passed
- documentation truth gate against the current public wiki: passed
- version contract: v4.04.1 to v4.04.2 Patch passed
- six negative publisher contract mutations rejected: missing, duplicate, valueless, unknown, positional and empty-value cases
- independent diff and recovery review: no blocking finding

Failed publisher run: https://github.com/duggytuxy/syswarden/actions/runs/33627502079
