### PR TITLE
Fix : scope runtime provenance to each lifecycle container

### DIFF
--- a/scripts/ci/release_qualification_adapter.py
+++ b/scripts/ci/release_qualification_adapter.py
@@ -209,6 +209,27 @@ def _sha256(value: Any, label: str) -> str:
     return result
 
 
+def _portable_runtime_file_identity(
+    value: Any, label: str
+) -> tuple[str, int, int, str]:
+    """Return identity fields that remain meaningful across filesystems.
+
+    Runtime evidence retains the complete ``device:inode:mode:uid:gid|sha256``
+    identity. Device and inode are instance-local filesystem coordinates, so
+    only mode, ownership, and content digest may be compared across independent
+    lifecycle containers.
+    """
+    identity = _string(value, label)
+    match = re.fullmatch(
+        r"[0-9]+:[0-9]+:([0-9a-f]{4}):([0-9]+):([0-9]+)\|([0-9a-f]{64})",
+        identity,
+    )
+    if match is None:
+        _fail(f"{label} must be a complete runtime file identity")
+    mode, uid, gid, digest = match.groups()
+    return mode, int(uid), int(gid), digest
+
+
 def _inside(path: Path, root: Path) -> bool:
     return path == root or root in path.parents
 
@@ -2183,22 +2204,58 @@ def _derive_platform_lifecycle_claims(
         for boot in scenario["boots"]
         for phase in ("pre_exec", "post_exec")
     ]
-    cron_provenance = {
-        (
-            snapshot["cron_executable_path"],
-            snapshot["cron_executable_identity"],
-            snapshot["cron_fragment_path"],
-            snapshot["cron_fragment_identity"],
-            tuple(snapshot["cron_dropin_paths"]),
-            snapshot["cron_package_name"],
-            snapshot["cron_package_version"],
-            snapshot["cron_package_architecture"],
-            snapshot["cron_fragment_package_name"],
-            snapshot["cron_fragment_package_version"],
-            snapshot["cron_fragment_package_architecture"],
-        )
-        for snapshot in runtime_snapshots
-    }
+    cron_provenance: set[tuple[Any, ...]] = set()
+    complete_cron_provenance = True
+    try:
+        for scenario_index, scenario in enumerate(platform["scenarios"]):
+            scenario_provenance: set[tuple[Any, ...]] = set()
+            for boot_index, boot in enumerate(scenario["boots"]):
+                for phase in ("pre_exec", "post_exec"):
+                    snapshot = boot[phase]
+                    label = (
+                        f"platform.scenarios[{scenario_index}].boots[{boot_index}]"
+                        f".{phase}"
+                    )
+                    exact_provenance = (
+                        snapshot["cron_executable_path"],
+                        snapshot["cron_executable_identity"],
+                        snapshot["cron_fragment_path"],
+                        snapshot["cron_fragment_identity"],
+                        tuple(snapshot["cron_dropin_paths"]),
+                        snapshot["cron_package_name"],
+                        snapshot["cron_package_version"],
+                        snapshot["cron_package_architecture"],
+                        snapshot["cron_fragment_package_name"],
+                        snapshot["cron_fragment_package_version"],
+                        snapshot["cron_fragment_package_architecture"],
+                    )
+                    scenario_provenance.add(exact_provenance)
+                    cron_provenance.add(
+                        (
+                            snapshot["cron_executable_path"],
+                            _portable_runtime_file_identity(
+                                snapshot["cron_executable_identity"],
+                                f"{label}.cron_executable_identity",
+                            ),
+                            snapshot["cron_fragment_path"],
+                            _portable_runtime_file_identity(
+                                snapshot["cron_fragment_identity"],
+                                f"{label}.cron_fragment_identity",
+                            ),
+                            tuple(snapshot["cron_dropin_paths"]),
+                            snapshot["cron_package_name"],
+                            snapshot["cron_package_version"],
+                            snapshot["cron_package_architecture"],
+                            snapshot["cron_fragment_package_name"],
+                            snapshot["cron_fragment_package_version"],
+                            snapshot["cron_fragment_package_architecture"],
+                        )
+                    )
+            if len(scenario_provenance) != 1:
+                complete_cron_provenance = False
+    except (AdapterError, KeyError, TypeError, ValueError):
+        complete_cron_provenance = False
+        cron_provenance.clear()
     removal_check = (
         "remove.final-removal.purge-equivalent"
         if spec.family == "rpm"
@@ -2222,6 +2279,7 @@ def _derive_platform_lifecycle_claims(
             and snapshot["capture_count"] == 2
             for snapshot in runtime_snapshots
         )
+        and complete_cron_provenance
         and len(cron_provenance) == 1
         and manager_boundary,
         "active_postinstall": all(

--- a/scripts/ci/release_qualification_adapter_test.py
+++ b/scripts/ci/release_qualification_adapter_test.py
@@ -60,6 +60,44 @@ def replace_snapshot_identity_maps(
                 boot[phase]["pid1_gid_map"] = copy.deepcopy(gid_map)
 
 
+def rewrite_runtime_file_identity(
+    value: str,
+    *,
+    device: int | None = None,
+    inode: int | None = None,
+    mode: str | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
+    sha256: str | None = None,
+) -> str:
+    metadata, digest = value.split("|", 1)
+    fields = metadata.split(":")
+    if len(fields) != 5:
+        raise AssertionError(f"unexpected runtime file identity: {value}")
+    original_device, original_inode, original_mode, original_uid, original_gid = fields
+    return "{}:{}:{}:{}:{}|{}".format(
+        original_device if device is None else device,
+        original_inode if inode is None else inode,
+        original_mode if mode is None else mode,
+        original_uid if uid is None else uid,
+        original_gid if gid is None else gid,
+        digest if sha256 is None else sha256,
+    )
+
+
+def mutate_scenario_runtime_snapshots(
+    platform: dict[str, Any],
+    scenario_name: str,
+    mutation: Any,
+) -> None:
+    scenario = next(
+        item for item in platform["scenarios"] if item["name"] == scenario_name
+    )
+    for boot in scenario["boots"]:
+        for phase in ("pre_exec", "post_exec"):
+            mutation(boot[phase])
+
+
 class AdapterFixture:
     version = "v4.04.2"
     previous_version = "v4.03.3"
@@ -462,6 +500,21 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                 adapter.run_build(args)
             else:
                 adapter.run_verify(args)
+
+    def lifecycle_claim_platform(
+        self, cell_id: str = "DEB-13"
+    ) -> tuple[dict[str, Any], package_lifecycle_lab.PlatformSpec]:
+        report = self.fixture.load_raw("package-lifecycle-raw.json")
+        platform = copy.deepcopy(
+            next(item for item in report["platforms"] if item["cell_id"] == cell_id)
+        )
+        spec = next(
+            item
+            for item in package_lifecycle_lab.DEFAULT_PLATFORMS
+            if item.cell_id == platform["cell_id"]
+            and item.architecture == platform["architecture_id"]
+        )
+        return platform, spec
 
     def test_nft_source_bindings_match_the_lab_exactly(self) -> None:
         self.assertEqual(
@@ -1545,6 +1598,163 @@ class ReleaseQualificationAdapterTests(unittest.TestCase):
                     changed_platform, spec
                 )
                 self.assertFalse(changed[claim])
+
+    def test_active_service_manager_accepts_container_local_device_and_inode(
+        self,
+    ) -> None:
+        platform, spec = self.lifecycle_claim_platform()
+
+        for scenario_index, scenario in enumerate(platform["scenarios"], start=1):
+            device = 700 + scenario_index
+            inode_offset = scenario_index * 100_000
+
+            def rewrite_snapshot(
+                snapshot: dict[str, Any],
+                *,
+                scenario_device: int = device,
+                scenario_inode_offset: int = inode_offset,
+            ) -> None:
+                for key in (
+                    "cron_executable_identity",
+                    "cron_fragment_identity",
+                ):
+                    original = snapshot[key]
+                    inode = int(original.split("|", 1)[0].split(":")[1])
+                    snapshot[key] = rewrite_runtime_file_identity(
+                        original,
+                        device=scenario_device,
+                        inode=inode + scenario_inode_offset,
+                    )
+
+            mutate_scenario_runtime_snapshots(
+                platform,
+                scenario["name"],
+                rewrite_snapshot,
+            )
+
+        claims = adapter._derive_platform_lifecycle_claims(platform, spec)
+        self.assertTrue(claims["active_service_manager"])
+        self.assertTrue(all(claims.values()))
+
+    def test_active_service_manager_rejects_identity_drift_inside_scenario(
+        self,
+    ) -> None:
+        platform, spec = self.lifecycle_claim_platform()
+        scenario = next(
+            item
+            for item in platform["scenarios"]
+            if item["name"] == "upgrade-rollback"
+        )
+        snapshot = scenario["boots"][0]["post_exec"]
+        for key in ("cron_executable_identity", "cron_fragment_identity"):
+            original = snapshot[key]
+            metadata = original.split("|", 1)[0].split(":")
+            snapshot[key] = rewrite_runtime_file_identity(
+                original,
+                device=int(metadata[0]) + 1,
+                inode=int(metadata[1]) + 1,
+            )
+
+        claims = adapter._derive_platform_lifecycle_claims(platform, spec)
+        self.assertFalse(claims["active_service_manager"])
+
+    def test_active_service_manager_rejects_cross_scenario_stable_drift(
+        self,
+    ) -> None:
+        platform, spec = self.lifecycle_claim_platform()
+        stable_mutations = {
+            "executable-mode": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_executable_identity"], mode="81ec"
+                ),
+            ),
+            "executable-uid": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_executable_identity"], uid=1
+                ),
+            ),
+            "executable-gid": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_executable_identity"], gid=1
+                ),
+            ),
+            "executable-sha256": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_executable_identity"], sha256="f" * 64
+                ),
+            ),
+            "fragment-mode": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_fragment_identity"], mode="81a0"
+                ),
+            ),
+            "fragment-uid": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_fragment_identity"], uid=1
+                ),
+            ),
+            "fragment-gid": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_fragment_identity"], gid=1
+                ),
+            ),
+            "fragment-sha256": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_identity",
+                rewrite_runtime_file_identity(
+                    snapshot["cron_fragment_identity"], sha256="e" * 64
+                ),
+            ),
+            "malformed-executable-identity": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_identity", "malformed"
+            ),
+            "executable-path": lambda snapshot: snapshot.__setitem__(
+                "cron_executable_path", "/usr/local/sbin/cron"
+            ),
+            "fragment-path": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_path", "/etc/systemd/system/cron.service"
+            ),
+            "drop-in-paths": lambda snapshot: snapshot.__setitem__(
+                "cron_dropin_paths",
+                ["/etc/systemd/system/cron.service.d/unexpected.conf"],
+            ),
+            "package-name": lambda snapshot: snapshot.__setitem__(
+                "cron_package_name", "cron-other"
+            ),
+            "package-version": lambda snapshot: snapshot.__setitem__(
+                "cron_package_version", "3.0pl1-198"
+            ),
+            "package-architecture": lambda snapshot: snapshot.__setitem__(
+                "cron_package_architecture", "arm64"
+            ),
+            "fragment-package-name": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_package_name", "cron-other"
+            ),
+            "fragment-package-version": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_package_version", "3.0pl1-198"
+            ),
+            "fragment-package-architecture": lambda snapshot: snapshot.__setitem__(
+                "cron_fragment_package_architecture", "arm64"
+            ),
+        }
+        for name, mutation in stable_mutations.items():
+            with self.subTest(stable_drift=name):
+                changed_platform = copy.deepcopy(platform)
+                mutate_scenario_runtime_snapshots(
+                    changed_platform,
+                    "remove",
+                    mutation,
+                )
+                claims = adapter._derive_platform_lifecycle_claims(
+                    changed_platform, spec
+                )
+                self.assertFalse(claims["active_service_manager"])
 
     def test_raw_v5_matrix_engine_helper_cleanup_and_native_records_are_exact(self) -> None:
         original = self.fixture.load_raw("package-lifecycle-raw.json")


### PR DESCRIPTION
## Summary

- Preserve complete device and inode identity checks inside each lifecycle scenario and container.
- Compare portable file identity across independent containers using path, mode, UID, GID and SHA-256.
- Keep cron drop-ins and package name, version and architecture provenance fail-closed.
- Reject malformed identities and any stable provenance drift.

## Root cause

The protected v4.04.2 qualification run completed all eight native AMD64 lifecycle cells successfully. Its evidence adapter then rejected the Debian 13 active_service_manager claim because independent Podman overlay containers received device IDs 93, 92 and 79. The earlier v4.04.1 run happened to receive device ID 86 for all three scenarios, which hid this nondeterministic assumption.

Device and inode identify a file only within one filesystem instance. They remain strictly bound within each scenario. Cross-container comparison now retains every portable security property.

Failed qualification: https://github.com/duggytuxy/syswarden/actions/runs/33631900941

## Verification

- 3 focused provenance regression tests passed.
- All 33 release qualification adapter tests passed.
- All 434 Package workflow validator tests passed, with 8 local UNIX socket cases skipped only because the sandbox forbids socket binding.
- Versionctl tests passed.
- Commit validation confirms a non-versioning follow-up that preserves v4.04.2.

README.md, changelog.md and managed version targets are unchanged.