### PR TITLE
Docs : publish v4.04.2 release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ certification product.
 Current source version: **v4.04.2**.
 
 The latest qualified, stable public release is
-[v4.03.3](https://github.com/duggytuxy/syswarden/releases/tag/v4.03.3).
+[v4.04.2](https://github.com/duggytuxy/syswarden/releases/tag/v4.04.2).
 
 ## Features
 

--- a/scripts/ci/documentation_contract.json
+++ b/scripts/ci/documentation_contract.json
@@ -1,6 +1,13 @@
 {
   "schema_version": 1,
-  "stable_public_version": "v4.03.3",
+  "stable_public_version": "v4.04.2",
+  "public_report_version": "v4.03.3",
+  "operational_wiki_baseline_version": "v4.03.3",
+  "current_operational_wiki_pages": [
+    "Deployment-Tutorial.md",
+    "RHEL-9-Image-Extensions.md",
+    "Use-cases.md"
+  ],
   "cli_baseline": {
     "version": "v4.02.8",
     "commit": "371d353e871fedb410b08f0618a1ae6aa2f7fedc",
@@ -95,7 +102,9 @@
   ],
   "required_wiki_phrases": {
     "Home.md": [
-      "The {stable_public_version} contract targets three candidate Linux packages:",
+      "{stable_public_version} is the latest qualified, stable public release.",
+      "The {stable_public_version} release is public, stable, non-draft and non-prerelease.",
+      "The {stable_public_version} public release contains three Linux packages:",
       "The complete public Release contains exactly ten assets: the three packages,",
       "No package, updater or qualification route exists outside this AMD64/x86_64 Linux matrix.",
       "The optional RHEL-compatible image staging extension is additive",

--- a/scripts/ci/documentation_gate.py
+++ b/scripts/ci/documentation_gate.py
@@ -76,6 +76,13 @@ REQUIRED_OPERATIONAL_WIKI_PAGES = frozenset(
         "RHEL-9-Image-Extensions.md",
     }
 )
+CURRENT_OPERATIONAL_WIKI_PAGES = frozenset(
+    {
+        "Deployment-Tutorial.md",
+        "RHEL-9-Image-Extensions.md",
+        "Use-cases.md",
+    }
+)
 FRENCH_RE = re.compile(
     r"[àâçéèêëîïôùûüÿœ]|\b(?:aucune|ceci|cliquez|doit|français|"
     r"installation\s+sécurisée|mise\s+à\s+jour|paramètres|pré-requis|"
@@ -464,6 +471,86 @@ def stable_public_version(contract: dict[str, object]) -> str:
     return value
 
 
+def public_report_version(contract: dict[str, object]) -> str:
+    """Return the immutable detailed public-report release or fail closed."""
+
+    value = contract.get("public_report_version")
+    if not isinstance(value, str) or VERSION_RE.fullmatch(value) is None:
+        raise DocumentationGateError(
+            "documentation contract public_report_version must be a canonical "
+            "version such as v4.03.3"
+        )
+    return value
+
+
+def operational_wiki_baseline_version(contract: dict[str, object]) -> str:
+    """Return the reviewed operational-wiki baseline or fail closed."""
+
+    value = contract.get("operational_wiki_baseline_version")
+    if not isinstance(value, str) or VERSION_RE.fullmatch(value) is None:
+        raise DocumentationGateError(
+            "documentation contract operational_wiki_baseline_version must be a "
+            "canonical version such as v4.03.3"
+        )
+    return value
+
+
+def current_operational_wiki_pages(
+    contract: dict[str, object],
+) -> frozenset[str]:
+    """Return the exact reviewed Current operational page inventory."""
+
+    value = contract.get("current_operational_wiki_pages")
+    if not isinstance(value, list) or not value:
+        raise DocumentationGateError(
+            "documentation contract current_operational_wiki_pages must be a "
+            "non-empty list"
+        )
+    if not all(isinstance(page, str) and page for page in value):
+        raise DocumentationGateError(
+            "documentation contract current_operational_wiki_pages must contain "
+            "non-empty string names"
+        )
+    if len(value) != len(set(value)):
+        raise DocumentationGateError(
+            "documentation contract current_operational_wiki_pages contains duplicates"
+        )
+    invalid = sorted(
+        page
+        for page in value
+        if not page.endswith(".md")
+        or "/" in page
+        or "\\" in page
+        or Path(page).name != page
+    )
+    if invalid:
+        raise DocumentationGateError(
+            "documentation contract current_operational_wiki_pages must contain "
+            f"flat .md names; invalid={invalid}"
+        )
+    pages = frozenset(value)
+    if pages != CURRENT_OPERATIONAL_WIKI_PAGES:
+        raise DocumentationGateError(
+            "documentation contract current_operational_wiki_pages differs from "
+            "the reviewed exact set; "
+            f"expected={sorted(CURRENT_OPERATIONAL_WIKI_PAGES)}, "
+            f"actual={sorted(pages)}"
+        )
+    required_phrases = contract.get("required_wiki_phrases")
+    if not isinstance(required_phrases, dict):
+        raise DocumentationGateError(
+            "documentation contract required_wiki_phrases must be an object before "
+            "current operational pages can be validated"
+        )
+    missing = pages - set(required_phrases)
+    if missing:
+        raise DocumentationGateError(
+            "current operational wiki pages are missing required phrase contracts: "
+            f"{sorted(missing)}"
+        )
+    return pages
+
+
 def version_components(version: str) -> tuple[int, int, int]:
     """Return numeric version components for an already canonical version."""
 
@@ -490,6 +577,32 @@ def validate_public_version_order(
             f"source={source_candidate_version}"
         ]
     return []
+
+
+def validate_documentation_version_order(
+    source_candidate_version: str,
+    stable_version: str,
+    report_version: str,
+    operational_wiki_version: str,
+) -> list[str]:
+    """Reject any report or wiki baseline newer than the stable release."""
+
+    errors = validate_public_version_order(source_candidate_version, stable_version)
+    try:
+        stable_components = version_components(stable_version)
+        baselines = (
+            ("public_report_version", report_version),
+            ("operational_wiki_baseline_version", operational_wiki_version),
+        )
+        for key, value in baselines:
+            if version_components(value) > stable_components:
+                errors.append(
+                    f"documentation contract {key} cannot be newer than "
+                    f"stable_public_version; {key}={value}, stable={stable_version}"
+                )
+    except DocumentationGateError as exc:
+        errors.append(str(exc))
+    return errors
 
 
 def extract_fenced_blocks(text: str, label: str, errors: list[str]) -> list[tuple[str, str]]:
@@ -861,18 +974,14 @@ def validate_active_public_surfaces(
     known_commands: set[str],
     known_config_keys: set[str],
     forbidden_phrases: Iterable[str],
-    source_candidate_version: str,
 ) -> list[str]:
-    """Validate candidate surfaces and the exact stable public release record."""
+    """Validate candidate surfaces and the immutable detailed release record."""
 
     errors: list[str] = []
     try:
-        public_version = stable_public_version(contract)
+        report_version = public_report_version(contract)
     except DocumentationGateError as exc:
         return [str(exc)]
-    errors.extend(
-        validate_public_version_order(source_candidate_version, public_version)
-    )
     surface = contract.get("active_surface_contract")
     report_contract = contract.get("public_report_contract")
     if not isinstance(surface, dict):
@@ -911,11 +1020,11 @@ def validate_active_public_surfaces(
             )
             report_path = report_contract.get("path")
             expected_report_path = (
-                f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{public_version}.md"
+                f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{report_version}.md"
             )
             if report_path != expected_report_path:
                 errors.append(
-                    "public report path is not bound to stable_public_version; "
+                    "public report path is not bound to public_report_version; "
                     f"expected={expected_report_path!r}, actual={report_path!r}"
                 )
             expected_reports = [report_path] if isinstance(report_path, str) else []
@@ -938,7 +1047,7 @@ def validate_active_public_surfaces(
                 known_commands,
                 known_config_keys,
                 [*forbidden_phrases, *CURRENT_SURFACE_RETIRED_TERMS],
-                public_version,
+                report_version,
                 None,
             )
         )
@@ -952,14 +1061,14 @@ def validate_active_public_surfaces(
                 require_phrases(
                     report,
                     required,
-                    public_version,
+                    report_version,
                     report_relative,
-                    stable_public_version_value=public_version,
+                    stable_public_version_value=report_version,
                 )
             )
 
         expected_assets = report_contract.get("expected_assets")
-        release_assets = release_gate.expected_release_assets(public_version)
+        release_assets = release_gate.expected_release_assets(report_version)
         if not isinstance(expected_assets, list) or not all(
             isinstance(asset, str) and asset for asset in expected_assets
         ):
@@ -1035,10 +1144,10 @@ def validate_active_public_surfaces(
 
     package_count = surface.get("package_count")
     asset_count = surface.get("public_asset_count")
-    release_version = public_version.removeprefix("v")
+    release_version = report_version.removeprefix("v")
     if package_count != 3 or len(release_gate.package_names(release_version)) != 3:
         errors.append("active surface package count must equal the three-package release gate")
-    if asset_count != 10 or len(release_gate.expected_release_assets(public_version)) != 10:
+    if asset_count != 10 or len(release_gate.expected_release_assets(report_version)) != 10:
         errors.append("active surface asset count must equal the ten-asset release gate")
     return errors
 
@@ -1279,6 +1388,9 @@ def load_contract(repo_root: Path) -> dict[str, object]:
     if not isinstance(contract, dict) or contract.get("schema_version") != 1:
         raise DocumentationGateError("unsupported documentation contract schema")
     stable_public_version(contract)
+    public_report_version(contract)
+    operational_wiki_baseline_version(contract)
+    current_operational_wiki_pages(contract)
     return contract
 
 
@@ -1403,13 +1515,22 @@ def validate_wiki(
     known_commands: set[str],
     known_config_keys: set[str],
     forbidden_phrases: Iterable[str],
-    version: str,
+    stable_version: str,
+    operational_baseline_version: str,
+    current_operational_pages: frozenset[str],
     required_phrases: object,
 ) -> list[str]:
     errors: list[str] = []
     markdown_records = [record for record in records if record.path.endswith(".md")]
     if not markdown_records:
         return [f"wiki contains no Markdown pages: {wiki_root}"]
+    markdown_paths = {record.path for record in markdown_records}
+    missing_current_pages = current_operational_pages - markdown_paths
+    if missing_current_pages:
+        errors.append(
+            "wiki inventory is missing reviewed Current operational pages: "
+            f"{sorted(missing_current_pages)}"
+        )
     home_path = wiki_root / "Home.md"
     if not home_path.is_file():
         errors.append(f"wiki Home.md is missing: {wiki_root}")
@@ -1427,6 +1548,23 @@ def validate_wiki(
         )
         if status_match is None:
             errors.append(f"{path}: missing reviewed wiki status banner")
+        required_current = (
+            record.path == "Home.md" or record.path in current_operational_pages
+        )
+        if (
+            status_match is not None
+            and status_match.group(1) == "Current"
+            and not required_current
+        ):
+            errors.append(
+                f"{path}: unreviewed page must not declare Status: Current"
+            )
+        if (
+            required_current
+            and status_match is not None
+            and status_match.group(1) != "Current"
+        ):
+            errors.append(f"{path}: reviewed page must declare Status: Current")
         baseline_match = re.search(
             r"^> Documentation baseline: (v[0-9]+\.[0-9]{2}\.[0-9]+)\s*$",
             text,
@@ -1434,16 +1572,22 @@ def validate_wiki(
         )
         if baseline_match is None:
             errors.append(f"{path}: missing canonical documentation baseline banner")
-            document_version = version
+            document_version = (
+                stable_version
+                if record.path == "Home.md"
+                else operational_baseline_version
+            )
         else:
             document_version = baseline_match.group(1)
-            if (
-                status_match is not None
-                and status_match.group(1) == "Current"
-                and document_version != version
-            ):
+            expected_current_version = (
+                stable_version
+                if record.path == "Home.md"
+                else operational_baseline_version
+            )
+            if required_current and document_version != expected_current_version:
                 errors.append(
-                    f"{path}: current page baseline {document_version} does not match {version}"
+                    f"{path}: current page baseline {document_version} does not match "
+                    f"{expected_current_version}"
                 )
         errors.extend(
             validate_markdown(
@@ -1510,6 +1654,9 @@ def validate_repository(
     contract = load_contract(repo_root)
     version = source_version(repo_root)
     public_version = stable_public_version(contract)
+    report_version = public_report_version(contract)
+    operational_wiki_version = operational_wiki_baseline_version(contract)
+    current_wiki_pages = current_operational_wiki_pages(contract)
     source_commands = cobra_commands(repo_root)
     snapshot_records = snapshot_command_records(repo_root)
     baseline_metadata = contract.get("cli_baseline", {})
@@ -1525,7 +1672,14 @@ def validate_repository(
     commands = snapshots
     config_keys = config_schema(repo_root)
     errors: list[str] = []
-    errors.extend(validate_public_version_order(version, public_version))
+    errors.extend(
+        validate_documentation_version_order(
+            version,
+            public_version,
+            report_version,
+            operational_wiki_version,
+        )
+    )
     errors.extend(validate_cli_baseline_metadata(repo_root, contract, version))
     expected_snapshot_commands = source_commands | {"completion", "help"}
     if expected_snapshot_commands != snapshots:
@@ -1578,7 +1732,7 @@ def validate_repository(
         )
     errors.extend(
         validate_package_source_contract(
-            repo_root, package_platform_contract, public_version
+            repo_root, package_platform_contract, operational_wiki_version
         )
     )
 
@@ -1667,7 +1821,6 @@ def validate_repository(
             commands,
             config_keys,
             forbidden,
-            version,
         )
     )
 
@@ -1709,6 +1862,8 @@ def validate_repository(
                 config_keys,
                 current_forbidden,
                 public_version,
+                operational_wiki_version,
+                current_wiki_pages,
                 wiki_required,
             )
         )

--- a/scripts/ci/documentation_gate_test.py
+++ b/scripts/ci/documentation_gate_test.py
@@ -21,14 +21,41 @@ import release_gate
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SOURCE_CANDIDATE_VERSION = "v4.04.2"
-STABLE_PUBLIC_VERSION = "v4.03.3"
+STABLE_PUBLIC_VERSION = "v4.04.2"
+PUBLIC_REPORT_VERSION = "v4.03.3"
+OPERATIONAL_WIKI_BASELINE_VERSION = "v4.03.3"
 REPORT = REPO_ROOT / (
-    f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{STABLE_PUBLIC_VERSION}.md"
+    f"docs/reports/PUBLIC_RELEASE_READINESS_REPORT_{PUBLIC_REPORT_VERSION}.md"
 )
 ARCHIVE_DIGEST = "a6ebcab7a81769c52147be710622995779cedf9523270cf08cf03e275501cde5"
 
 
 class DocumentationGateTest(unittest.TestCase):
+    @staticmethod
+    def _write_current_wiki_shell(
+        wiki_root: Path,
+        stable_version: str,
+        operational_version: str,
+    ) -> None:
+        links = "\n".join(
+            f"- [{page.removesuffix('.md')}]({page.removesuffix('.md')})"
+            for page in sorted(documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES)
+        )
+        (wiki_root / "Home.md").write_text(
+            "# Home\n\n"
+            "> Status: Current\n"
+            f"> Documentation baseline: {stable_version}\n\n"
+            f"{links}\n",
+            encoding="utf-8",
+        )
+        for page in documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES:
+            (wiki_root / page).write_text(
+                f"# {page.removesuffix('.md')}\n\n"
+                "> Status: Current\n"
+                f"> Documentation baseline: {operational_version}\n",
+                encoding="utf-8",
+            )
+
     def test_repository_truth_gate_passes(self) -> None:
         records, errors = documentation_gate.validate_repository(REPO_ROOT)
         self.assertEqual(errors, [])
@@ -45,6 +72,44 @@ class DocumentationGateTest(unittest.TestCase):
         errors = documentation_gate.validate_wiki_phrase_contract(changed)
         self.assertTrue(any("missing required operational wiki pages" in error for error in errors))
 
+    def test_current_operational_wiki_page_inventory_fails_closed(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        self.assertEqual(
+            documentation_gate.current_operational_wiki_pages(contract),
+            documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+        )
+        mutations = {
+            "absent": None,
+            "duplicate": [
+                *contract["current_operational_wiki_pages"],
+                contract["current_operational_wiki_pages"][0],
+            ],
+            "incomplete": contract["current_operational_wiki_pages"][:-1],
+        }
+        for name, value in mutations.items():
+            changed = json.loads(json.dumps(contract))
+            if value is None:
+                changed.pop("current_operational_wiki_pages")
+            else:
+                changed["current_operational_wiki_pages"] = value
+            with self.subTest(name=name), self.assertRaises(
+                documentation_gate.DocumentationGateError
+            ):
+                documentation_gate.current_operational_wiki_pages(changed)
+
+    def test_home_release_status_contract_is_explicit(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        required = contract["required_wiki_phrases"]["Home.md"]
+        self.assertIn(
+            "{stable_public_version} is the latest qualified, stable public release.",
+            required,
+        )
+        self.assertIn(
+            "The {stable_public_version} release is public, stable, non-draft and "
+            "non-prerelease.",
+            required,
+        )
+
     def test_current_version_and_release_status_are_explicit(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
         self.assertEqual(
@@ -52,6 +117,13 @@ class DocumentationGateTest(unittest.TestCase):
         )
         self.assertEqual(
             documentation_gate.stable_public_version(contract), STABLE_PUBLIC_VERSION
+        )
+        self.assertEqual(
+            documentation_gate.public_report_version(contract), PUBLIC_REPORT_VERSION
+        )
+        self.assertEqual(
+            documentation_gate.operational_wiki_baseline_version(contract),
+            OPERATIONAL_WIKI_BASELINE_VERSION,
         )
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         changelog = (REPO_ROOT / "changelog.md").read_text(encoding="utf-8")
@@ -100,6 +172,27 @@ class DocumentationGateTest(unittest.TestCase):
             ):
                 documentation_gate.stable_public_version(changed)
 
+    def test_historical_documentation_versions_fail_closed(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        getters = (
+            ("public_report_version", documentation_gate.public_report_version),
+            (
+                "operational_wiki_baseline_version",
+                documentation_gate.operational_wiki_baseline_version,
+            ),
+        )
+        for key, getter in getters:
+            for invalid in (None, "", "4.03.3", "v4.3.3", "v4.03"):
+                changed = json.loads(json.dumps(contract))
+                if invalid is None:
+                    changed.pop(key)
+                else:
+                    changed[key] = invalid
+                with self.subTest(key=key, invalid=invalid), self.assertRaises(
+                    documentation_gate.DocumentationGateError
+                ):
+                    getter(changed)
+
     def test_stable_public_version_cannot_lead_the_source_candidate(self) -> None:
         self.assertEqual(
             documentation_gate.validate_public_version_order(
@@ -112,7 +205,113 @@ class DocumentationGateTest(unittest.TestCase):
         )
         self.assertTrue(any("cannot be newer" in error for error in errors))
 
-    def test_readme_accepts_only_the_candidate_and_bound_stable_versions(self) -> None:
+    def test_historical_baselines_cannot_lead_the_stable_release(self) -> None:
+        self.assertEqual(
+            documentation_gate.validate_documentation_version_order(
+                SOURCE_CANDIDATE_VERSION,
+                STABLE_PUBLIC_VERSION,
+                PUBLIC_REPORT_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+            ),
+            [],
+        )
+        for report_version, wiki_version, key in (
+            ("v4.04.3", OPERATIONAL_WIKI_BASELINE_VERSION, "public_report_version"),
+            (PUBLIC_REPORT_VERSION, "v4.04.3", "operational_wiki_baseline_version"),
+        ):
+            errors = documentation_gate.validate_documentation_version_order(
+                SOURCE_CANDIDATE_VERSION,
+                STABLE_PUBLIC_VERSION,
+                report_version,
+                wiki_version,
+            )
+            self.assertTrue(any(key in error for error in errors), errors)
+
+    def test_distinct_stable_report_and_operational_wiki_versions_stay_separate(
+        self,
+    ) -> None:
+        stable_version = "v4.05.0"
+        report_version = "v4.03.3"
+        operational_version = "v4.04.0"
+        self.assertEqual(
+            documentation_gate.validate_documentation_version_order(
+                stable_version,
+                stable_version,
+                report_version,
+                operational_version,
+            ),
+            [],
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            self._write_current_wiki_shell(
+                wiki_root,
+                stable_version,
+                operational_version,
+            )
+            common = (
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                set(),
+                set(),
+                [],
+                stable_version,
+                operational_version,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+                {},
+            )
+            self.assertEqual(documentation_gate.validate_wiki(*common), [])
+
+            home = wiki_root / "Home.md"
+            home.write_text(
+                home.read_text(encoding="utf-8").replace(
+                    f"> Documentation baseline: {stable_version}",
+                    f"> Documentation baseline: {report_version}",
+                ),
+                encoding="utf-8",
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                *common[2:],
+            )
+            self.assertTrue(
+                any(
+                    f"current page baseline {report_version} does not match "
+                    f"{stable_version}" in error
+                    for error in errors
+                ),
+                errors,
+            )
+
+            self._write_current_wiki_shell(
+                wiki_root,
+                stable_version,
+                operational_version,
+            )
+            deployment = wiki_root / "Deployment-Tutorial.md"
+            deployment.write_text(
+                deployment.read_text(encoding="utf-8").replace(
+                    f"> Documentation baseline: {operational_version}",
+                    f"> Documentation baseline: {report_version}",
+                ),
+                encoding="utf-8",
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                *common[2:],
+            )
+            self.assertTrue(
+                any(
+                    f"current page baseline {report_version} does not match "
+                    f"{operational_version}" in error
+                    for error in errors
+                ),
+                errors,
+            )
+
+    def test_readme_binds_the_source_and_stable_release(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
         readme_path = REPO_ROOT / "README.md"
         readme = readme_path.read_text(encoding="utf-8")
@@ -125,15 +324,14 @@ class DocumentationGateTest(unittest.TestCase):
             SOURCE_CANDIDATE_VERSION,
             None,
         )
-        errors = documentation_gate.validate_markdown(
-            *common, (STABLE_PUBLIC_VERSION,)
-        )
+        errors = documentation_gate.validate_markdown(*common)
         self.assertFalse(any("non-current version" in error for error in errors))
 
-        errors = documentation_gate.validate_markdown(*common)
+        stale_common = (common[0], common[1] + "\nThe v4.03.3 release is current.\n", *common[2:])
+        errors = documentation_gate.validate_markdown(*stale_common)
         self.assertTrue(
             any(
-                f"non-current version {STABLE_PUBLIC_VERSION}" in error
+                f"non-current version {PUBLIC_REPORT_VERSION}" in error
                 for error in errors
             )
         )
@@ -186,18 +384,19 @@ class DocumentationGateTest(unittest.TestCase):
                 documentation_gate.cobra_commands(REPO_ROOT),
                 documentation_gate.config_schema(REPO_ROOT),
                 contract["forbidden_phrases"],
-                SOURCE_CANDIDATE_VERSION,
             ),
             [],
         )
 
-    def test_public_release_contract_is_three_packages_and_ten_assets(self) -> None:
+    def test_detailed_release_report_contract_is_three_packages_and_ten_assets(
+        self,
+    ) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
-        stable_version = documentation_gate.stable_public_version(contract)
+        report_version = documentation_gate.public_report_version(contract)
         expected_packages = release_gate.package_names(
-            stable_version.removeprefix("v")
+            report_version.removeprefix("v")
         )
-        expected_assets = release_gate.expected_release_assets(stable_version)
+        expected_assets = release_gate.expected_release_assets(report_version)
         self.assertEqual(len(expected_packages), 3)
         self.assertEqual(len(expected_assets), 10)
         self.assertEqual(
@@ -481,31 +680,41 @@ class DocumentationGateTest(unittest.TestCase):
             documentation_gate.cobra_commands(REPO_ROOT),
             documentation_gate.config_schema(REPO_ROOT),
             changed["forbidden_phrases"],
-            SOURCE_CANDIDATE_VERSION,
         )
         self.assertTrue(any("exact release gate" in error for error in errors))
 
-    def test_stable_version_mutation_breaks_report_assets_and_matrix(self) -> None:
+    def test_stable_release_does_not_rebind_the_historical_report(self) -> None:
+        contract = documentation_gate.load_contract(REPO_ROOT)
+        errors = documentation_gate.validate_active_public_surfaces(
+            REPO_ROOT,
+            contract,
+            documentation_gate.cobra_commands(REPO_ROOT),
+            documentation_gate.config_schema(REPO_ROOT),
+            contract["forbidden_phrases"],
+        )
+        self.assertEqual(errors, [])
+
+    def test_historical_baseline_mutations_break_their_bound_surfaces(self) -> None:
         contract = documentation_gate.load_contract(REPO_ROOT)
         changed = json.loads(json.dumps(contract))
-        changed["stable_public_version"] = SOURCE_CANDIDATE_VERSION
+        changed["public_report_version"] = STABLE_PUBLIC_VERSION
         errors = documentation_gate.validate_active_public_surfaces(
             REPO_ROOT,
             changed,
             documentation_gate.cobra_commands(REPO_ROOT),
             documentation_gate.config_schema(REPO_ROOT),
             changed["forbidden_phrases"],
-            SOURCE_CANDIDATE_VERSION,
         )
         self.assertTrue(
             any("report path is not bound" in error for error in errors), errors
         )
         self.assertTrue(any("exact release gate" in error for error in errors), errors)
 
+        changed["operational_wiki_baseline_version"] = STABLE_PUBLIC_VERSION
         matrix_errors = documentation_gate.validate_package_source_contract(
             REPO_ROOT,
             changed["package_platform_contract"],
-            SOURCE_CANDIDATE_VERSION,
+            documentation_gate.operational_wiki_baseline_version(changed),
         )
         self.assertTrue(
             any("package table contract" in error for error in matrix_errors),
@@ -517,7 +726,7 @@ class DocumentationGateTest(unittest.TestCase):
         package_contract = contract["package_platform_contract"]
         self.assertEqual(
             documentation_gate.validate_package_source_contract(
-                REPO_ROOT, package_contract, STABLE_PUBLIC_VERSION
+                REPO_ROOT, package_contract, OPERATIONAL_WIKI_BASELINE_VERSION
             ),
             [],
         )
@@ -550,7 +759,7 @@ class DocumentationGateTest(unittest.TestCase):
         changed = json.loads(json.dumps(package_contract))
         changed["artifacts"][0]["architecture"] = "s390x"
         errors = documentation_gate.validate_package_source_contract(
-            REPO_ROOT, changed, STABLE_PUBLIC_VERSION
+            REPO_ROOT, changed, OPERATIONAL_WIKI_BASELINE_VERSION
         )
         self.assertTrue(any("naming/architecture mismatch" in error for error in errors))
 
@@ -577,7 +786,6 @@ class DocumentationGateTest(unittest.TestCase):
                 documentation_gate.cobra_commands(REPO_ROOT),
                 documentation_gate.config_schema(REPO_ROOT),
                 contract["forbidden_phrases"],
-                SOURCE_CANDIDATE_VERSION,
             )
         self.assertTrue(any("retired platform" in error for error in errors))
 
@@ -902,10 +1110,14 @@ class DocumentationGateTest(unittest.TestCase):
     def test_version_specific_wiki_page_keeps_its_canonical_baseline(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             wiki_root = Path(directory)
+            self._write_current_wiki_shell(wiki_root, "v4.03.3", "v4.03.3")
             (wiki_root / "Home.md").write_text(
                 "# Home\n\n"
                 "> Status: Current\n"
                 "> Documentation baseline: v4.03.3\n\n"
+                "[Deployment](Deployment-Tutorial)\n"
+                "[RHEL image extensions](RHEL-9-Image-Extensions)\n"
+                "[Use cases](Use-cases)\n"
                 "[Historical migration](Migration-v4.02.8-to-v4.03.2)\n"
                 "[Version-specific current migration](Migration-v4.03.2-to-v4.03.3)\n",
                 encoding="utf-8",
@@ -929,6 +1141,8 @@ class DocumentationGateTest(unittest.TestCase):
                 set(),
                 [],
                 "v4.03.3",
+                "v4.03.3",
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
                 {},
             )
         self.assertEqual(errors, [])
@@ -949,6 +1163,8 @@ class DocumentationGateTest(unittest.TestCase):
                 set(),
                 [],
                 "v4.03.3",
+                "v4.03.3",
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
                 {},
             )
         self.assertTrue(
@@ -958,13 +1174,13 @@ class DocumentationGateTest(unittest.TestCase):
             )
         )
 
-    def test_current_wiki_remains_bound_to_the_stable_public_version(self) -> None:
+    def test_wiki_home_remains_bound_to_the_stable_public_version(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             wiki_root = Path(directory)
             (wiki_root / "Home.md").write_text(
                 "# Home\n\n"
                 "> Status: Current\n"
-                f"> Documentation baseline: {SOURCE_CANDIDATE_VERSION}\n",
+                f"> Documentation baseline: {PUBLIC_REPORT_VERSION}\n",
                 encoding="utf-8",
             )
             errors = documentation_gate.validate_wiki(
@@ -974,12 +1190,200 @@ class DocumentationGateTest(unittest.TestCase):
                 set(),
                 [],
                 STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
                 {},
             )
         self.assertTrue(
             any(
-                f"current page baseline {SOURCE_CANDIDATE_VERSION} does not match "
+                f"current page baseline {PUBLIC_REPORT_VERSION} does not match "
                 f"{STABLE_PUBLIC_VERSION}" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_wiki_home_archive_and_old_baseline_are_both_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            self._write_current_wiki_shell(
+                wiki_root,
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+            )
+            home = wiki_root / "Home.md"
+            home.write_text(
+                home.read_text(encoding="utf-8")
+                .replace("> Status: Current", "> Status: Archive")
+                .replace(
+                    f"> Documentation baseline: {STABLE_PUBLIC_VERSION}",
+                    f"> Documentation baseline: {PUBLIC_REPORT_VERSION}",
+                ),
+                encoding="utf-8",
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                set(),
+                set(),
+                [],
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+                {},
+            )
+        self.assertTrue(
+            any("Home.md: reviewed page must declare Status: Current" in error for error in errors),
+            errors,
+        )
+        self.assertTrue(
+            any(
+                f"current page baseline {PUBLIC_REPORT_VERSION} does not match "
+                f"{STABLE_PUBLIC_VERSION}" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_wiki_home_rejects_stale_current_claims_but_allows_bounded_history(
+        self,
+    ) -> None:
+        stale = "v4.03.3 is the current stable public release.\n"
+        errors = documentation_gate.validate_markdown(
+            Path("Home.md"),
+            stale,
+            set(),
+            set(),
+            [],
+            STABLE_PUBLIC_VERSION,
+            None,
+        )
+        self.assertTrue(
+            any(
+                f"non-current version {PUBLIC_REPORT_VERSION}" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+        for bounded in (
+            "The historical v4.03.3 readiness report remains immutable.\n",
+            "The version-specific v4.03.3 migration remains available.\n",
+        ):
+            with self.subTest(bounded=bounded):
+                errors = documentation_gate.validate_markdown(
+                    Path("Home.md"),
+                    bounded,
+                    set(),
+                    set(),
+                    [],
+                    STABLE_PUBLIC_VERSION,
+                    None,
+                )
+                self.assertFalse(
+                    any("non-current version" in error for error in errors),
+                    errors,
+                )
+
+    def test_non_home_current_page_uses_the_operational_wiki_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            self._write_current_wiki_shell(
+                wiki_root,
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                set(),
+                set(),
+                [],
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+                {},
+            )
+        self.assertEqual(errors, [])
+
+    def test_operational_page_archive_and_stable_baseline_are_both_rejected(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            self._write_current_wiki_shell(
+                wiki_root,
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+            )
+            deployment = wiki_root / "Deployment-Tutorial.md"
+            deployment.write_text(
+                "# Deployment\n\n"
+                "> Status: Archive\n"
+                f"> Documentation baseline: {STABLE_PUBLIC_VERSION}\n",
+                encoding="utf-8",
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                set(),
+                set(),
+                [],
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+                {},
+            )
+        self.assertTrue(
+            any(
+                "Deployment-Tutorial.md: reviewed page must declare Status: Current"
+                in error
+                for error in errors
+            ),
+            errors,
+        )
+        self.assertTrue(
+            any(
+                f"current page baseline {STABLE_PUBLIC_VERSION} does not match "
+                f"{OPERATIONAL_WIKI_BASELINE_VERSION}" in error
+                for error in errors
+            ),
+            errors,
+        )
+
+    def test_unreviewed_extra_page_cannot_declare_current_status(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wiki_root = Path(directory)
+            self._write_current_wiki_shell(
+                wiki_root,
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+            )
+            home = wiki_root / "Home.md"
+            home.write_text(
+                home.read_text(encoding="utf-8") + "- [Extra](Extra)\n",
+                encoding="utf-8",
+            )
+            (wiki_root / "Extra.md").write_text(
+                "# Extra\n\n"
+                "> Status: Current\n"
+                "> Documentation baseline: v9.99.9\n",
+                encoding="utf-8",
+            )
+            errors = documentation_gate.validate_wiki(
+                wiki_root,
+                documentation_gate.inventory(wiki_root, "test wiki"),
+                set(),
+                set(),
+                [],
+                STABLE_PUBLIC_VERSION,
+                OPERATIONAL_WIKI_BASELINE_VERSION,
+                documentation_gate.CURRENT_OPERATIONAL_WIKI_PAGES,
+                {},
+            )
+        self.assertTrue(
+            any(
+                "Extra.md: unreviewed page must not declare Status: Current" in error
                 for error in errors
             ),
             errors,


### PR DESCRIPTION
## Summary

- Update only the stable public release link in README.md from v4.03.3 to v4.04.2.
- Bind the documentation contract to stable release v4.04.2 while preserving the immutable v4.03.3 detailed report and reviewed v4.03.3 operational wiki baselines.
- Fail closed on stale or unreviewed Current wiki status and baseline drift.

The wiki Home page was published separately at commit 593e3ae to reflect the exact v4.04.2 release status. Historical and version-specific procedures remain unchanged.

## Validation

- 49 documentation gate tests passed.
- Full README, manual and seven-page wiki truth gate passed.
- External HTTPS link validation passed.
- Versioning validation confirms that this non-versioning commit preserves v4.04.2.
- Git diff checks passed.