### PR TITLE
Security : attest native signing environment protection

### DIFF
--- a/.github/workflows/native-package-signing.yml
+++ b/.github/workflows/native-package-signing.yml
@@ -72,6 +72,59 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate Exact Native Signing Environment Protection
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          environment_name="syswarden-native-package-signing-v4100"
+          environment_json="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/environments/${environment_name}")"
+          required_boolean() {
+            local field=${1:?field is required}
+            jq -er --arg field "${field}" '
+              .deployment_branch_policy[$field] |
+              if type == "boolean" then tostring
+              else error("deployment_branch_policy." + $field + " must be boolean") end
+            ' <<< "${environment_json}"
+          }
+          top_level_boolean() {
+            local field=${1:?field is required}
+            jq -er --arg field "${field}" '
+              .[$field] |
+              if type == "boolean" then tostring
+              else error($field + " must be boolean") end
+            ' <<< "${environment_json}"
+          }
+          reviewer_rule_count="$(jq '[.protection_rules[]? | select(.type == "required_reviewers")] | length' <<< "${environment_json}")"
+          reviewer_entry_count="$(jq '[.protection_rules[]? | select(.type == "required_reviewers") | .reviewers[]?] | length' <<< "${environment_json}")"
+          owner_reviewer_count="$(jq --arg owner "${REPOSITORY_OWNER}" '[.protection_rules[]? | select(.type == "required_reviewers") | .reviewers[]? | select(.type == "User" and .reviewer.login == $owner)] | length' <<< "${environment_json}")"
+          prevent_self_review="$(jq -er '[.protection_rules[]? | select(.type == "required_reviewers") | .prevent_self_review] | if length == 1 and .[0] == false then "false" else error("reviewer rule must allow owner approval") end' <<< "${environment_json}")"
+          if [[ "$(jq -r '.name // ""' <<< "${environment_json}")" != "${environment_name}" || \
+                "${reviewer_rule_count}" != "1" || \
+                "${reviewer_entry_count}" != "1" || \
+                "${owner_reviewer_count}" != "1" || \
+                "${prevent_self_review}" != "false" || \
+                "$(jq '[.protection_rules[]? | select(.type == "branch_policy")] | length' <<< "${environment_json}")" != "1" || \
+                "$(jq '[.protection_rules[]?] | length' <<< "${environment_json}")" != "2" || \
+                "$(required_boolean protected_branches)" != "false" || \
+                "$(required_boolean custom_branch_policies)" != "true" || \
+                "$(top_level_boolean can_admins_bypass)" != "false" ]]; then
+            echo "ERROR: native signing requires the exact reviewed main-only protected environment." >&2
+            exit 1
+          fi
+          policies_json="$(gh api --paginate --slurp --method GET \
+            "repos/${GITHUB_REPOSITORY}/environments/${environment_name}/deployment-branch-policies" \
+            -f per_page=100)"
+          if [[ "$(jq -r '.[0].total_count' <<< "${policies_json}")" != "1" || \
+                "$(jq '[.[] | .branch_policies[]?] | length' <<< "${policies_json}")" != "1" || \
+                "$(jq '[.[] | .branch_policies[]? | select(.name == "main" and .type == "branch")] | length' <<< "${policies_json}")" != "1" ]]; then
+            echo "ERROR: native signing environment must allow only the main branch." >&2
+            exit 1
+          fi
+
       - name: Validate Protected Manual Context
         shell: bash
         env:

--- a/changelog.md
+++ b/changelog.md
@@ -33,8 +33,10 @@
 - **Native package-signing foundation:** Add explicit non-publishing bootstrap
   and qualified-policy paths for RPM OpenPGP signatures, APK RSA256 signatures
   and detached DEB OpenPGP signatures. Seal the selected key identities into
-  immutable bundle provenance and isolate each family's protected secrets and
-  cleanup.
+  immutable bundle provenance, isolate each family's protected secrets and
+  cleanup, and fail closed if the dedicated signing environment no longer has
+  the exact owner review, main-only branch policy or administrator-bypass
+  protection required by the release contract.
 - **Package-owned RHEL 9+ profile:** Add a separate opt-in RPM profile where
   the package owns flat systemd assets, presets and scriptlets while Go remains
   runtime-only. The profile does not configure firewalld, change SELinux

--- a/scripts/ci/native_package_signing_workflow_test.py
+++ b/scripts/ci/native_package_signing_workflow_test.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import subprocess
+import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -36,6 +40,31 @@ def literal_run_blocks(workflow: str) -> list[str]:
             index += 1
         blocks.append("\n".join(body))
     return blocks
+
+
+def named_literal_run_block(workflow: str, step_name: str) -> str:
+    lines = workflow.splitlines()
+    marker = f"      - name: {step_name}"
+    try:
+        index = lines.index(marker) + 1
+    except ValueError as exc:
+        raise AssertionError(f"workflow step not found: {step_name}") from exc
+    while index < len(lines) and not re.match(r"^        run:\s*\|\s*$", lines[index]):
+        if lines[index].startswith("      - name:"):
+            raise AssertionError(f"workflow step has no literal run block: {step_name}")
+        index += 1
+    if index == len(lines):
+        raise AssertionError(f"workflow step has no literal run block: {step_name}")
+    indentation = len(lines[index]) - len(lines[index].lstrip())
+    body: list[str] = []
+    index += 1
+    while index < len(lines):
+        candidate = lines[index]
+        if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indentation:
+            break
+        body.append(candidate)
+        index += 1
+    return textwrap.dedent("\n".join(body))
 
 
 class NativePackageSigningWorkflowTests(unittest.TestCase):
@@ -67,6 +96,177 @@ class NativePackageSigningWorkflowTests(unittest.TestCase):
         )
         for deterministic_environment in ("LANG: C", "LC_ALL: C", "TZ: UTC"):
             self.assertIn(deterministic_environment, self.workflow)
+
+    def test_exact_environment_contract_is_attested_before_checkout_or_secrets(self) -> None:
+        gate_name = "Validate Exact Native Signing Environment Protection"
+        gate = self.workflow.index(f"      - name: {gate_name}")
+        first_step = self.workflow.index("      - name:", self.workflow.index("    steps:"))
+        checkout = self.workflow.index("      - name: Checkout Exact Candidate Source")
+        first_secret = self.workflow.index("${{ secrets.")
+        self.assertEqual(gate, first_step)
+        self.assertLess(gate, checkout)
+        self.assertLess(gate, first_secret)
+        for contract in (
+            'environment_name="syswarden-native-package-signing-v4100"',
+            'reviewer_rule_count="$(jq',
+            'reviewer_entry_count="$(jq',
+            'owner_reviewer_count="$(jq',
+            'prevent_self_review="$(jq',
+            '"${reviewer_rule_count}" != "1"',
+            '"${reviewer_entry_count}" != "1"',
+            '"${owner_reviewer_count}" != "1"',
+            '"${prevent_self_review}" != "false"',
+            '$(required_boolean protected_branches)" != "false"',
+            '$(required_boolean custom_branch_policies)" != "true"',
+            '$(top_level_boolean can_admins_bypass)" != "false"',
+            "deployment-branch-policies",
+            '.name == "main" and .type == "branch"',
+        ):
+            self.assertIn(contract, self.workflow)
+
+    def test_environment_gate_accepts_only_the_exact_reviewed_contract(self) -> None:
+        gate = named_literal_run_block(
+            self.workflow, "Validate Exact Native Signing Environment Protection"
+        )
+        valid_environment = {
+            "name": "syswarden-native-package-signing-v4100",
+            "can_admins_bypass": False,
+            "protection_rules": [
+                {
+                    "type": "required_reviewers",
+                    "prevent_self_review": False,
+                    "reviewers": [
+                        {
+                            "type": "User",
+                            "reviewer": {"login": "duggytuxy"},
+                        }
+                    ],
+                },
+                {"type": "branch_policy"},
+            ],
+            "deployment_branch_policy": {
+                "protected_branches": False,
+                "custom_branch_policies": True,
+            },
+        }
+        valid_policies = {
+            "total_count": 1,
+            "branch_policies": [{"name": "main", "type": "branch"}],
+        }
+
+        def run_gate(
+            environment: dict[str, Any], policies: dict[str, Any]
+        ) -> subprocess.CompletedProcess[str]:
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                environment_path = root / "environment.json"
+                policies_path = root / "policies.json"
+                environment_path.write_text(json.dumps(environment), encoding="utf-8")
+                policies_path.write_text(json.dumps(policies), encoding="utf-8")
+                gh = root / "gh"
+                gh.write_text(
+                    """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+environment_endpoint = (
+    "repos/duggytuxy/syswarden/environments/"
+    "syswarden-native-package-signing-v4100"
+)
+policy_endpoint = environment_endpoint + "/deployment-branch-policies"
+endpoints = [argument for argument in sys.argv[1:] if argument.startswith("repos/")]
+if endpoints == [environment_endpoint]:
+    document = json.loads(Path(os.environ["TEST_ENVIRONMENT_JSON"]).read_text())
+elif endpoints == [policy_endpoint] and "--paginate" in sys.argv and "--slurp" in sys.argv:
+    document = [json.loads(Path(os.environ["TEST_POLICIES_JSON"]).read_text())]
+else:
+    raise SystemExit("unexpected gh api request: " + repr(sys.argv[1:]))
+print(json.dumps(document, separators=(",", ":")))
+""",
+                    encoding="utf-8",
+                )
+                gh.chmod(0o700)
+                environment_variables = os.environ.copy()
+                environment_variables.update(
+                    {
+                        "GH_TOKEN": "test-token",
+                        "GITHUB_REPOSITORY": "duggytuxy/syswarden",
+                        "PATH": f"{root}:{environment_variables['PATH']}",
+                        "REPOSITORY_OWNER": "duggytuxy",
+                        "TEST_ENVIRONMENT_JSON": str(environment_path),
+                        "TEST_POLICIES_JSON": str(policies_path),
+                    }
+                )
+                return subprocess.run(
+                    ["bash", "-c", gate],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    env=environment_variables,
+                )
+
+        result = run_gate(valid_environment, valid_policies)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        mutations: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+        def mutated_environment() -> dict[str, Any]:
+            return json.loads(json.dumps(valid_environment))
+
+        def mutated_policies() -> dict[str, Any]:
+            return json.loads(json.dumps(valid_policies))
+
+        environment = mutated_environment()
+        environment["name"] = "syswarden-release-qualification"
+        mutations.append(("wrong environment name", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["can_admins_bypass"] = True
+        mutations.append(("administrator bypass", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["protection_rules"][0]["prevent_self_review"] = True
+        mutations.append(("self review forbidden", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["protection_rules"][0]["reviewers"][0]["reviewer"][
+            "login"
+        ] = "other"
+        mutations.append(("reviewer is not owner", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["protection_rules"][0]["reviewers"].append(
+            {"type": "User", "reviewer": {"login": "other"}}
+        )
+        mutations.append(("multiple reviewers", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["deployment_branch_policy"]["protected_branches"] = True
+        mutations.append(("protected branches enabled", environment, mutated_policies()))
+
+        environment = mutated_environment()
+        environment["deployment_branch_policy"]["custom_branch_policies"] = False
+        mutations.append(("custom policies disabled", environment, mutated_policies()))
+
+        policies = mutated_policies()
+        policies["branch_policies"][0]["name"] = "release/*"
+        mutations.append(("non-main policy", mutated_environment(), policies))
+
+        policies = mutated_policies()
+        policies["branch_policies"][0]["type"] = "tag"
+        mutations.append(("tag policy", mutated_environment(), policies))
+
+        policies = mutated_policies()
+        policies["total_count"] = 2
+        policies["branch_policies"].append({"name": "release/*", "type": "branch"})
+        mutations.append(("multiple policies", mutated_environment(), policies))
+
+        for label, environment, policies in mutations:
+            with self.subTest(mutation=label):
+                result = run_gate(environment, policies)
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_permissions_cannot_publish_or_attest(self) -> None:
         self.assertGreaterEqual(self.workflow.count("contents: read"), 2)


### PR DESCRIPTION
## Summary

- fail closed when the dedicated native signing environment drifts from the reviewed owner-only, main-only protection contract
- require administrator bypass to remain disabled before any signing secret is available
- add executable adversarial tests for reviewer and deployment policy mutations
- record the protection in the v4.10.0 candidate changelog

## Validation

- 85 native signing gate, bundle and workflow tests passed
- 50 documentation contract tests passed
- the documentation truth gate passed against the current remote wiki
- git diff --check passed

## Release boundary

This change does not qualify, tag or publish v4.10.0. Production signing keys remain absent and the native signature policy remains non-publishing.
