### PR TITLE
Fix : restore post-merge qualification contracts

### DIFF
--- a/scripts/versionctl/command.go
+++ b/scripts/versionctl/command.go
@@ -12,11 +12,12 @@ import (
 )
 
 type application struct {
-	git                  gitClient
-	out                  io.Writer
-	getenv               func(string) string
-	releaseResetPolicy   *changelogResetPolicy
-	releaseRewritePolicy *changelogRewritePolicy
+	git                   gitClient
+	out                   io.Writer
+	getenv                func(string) string
+	releaseResetPolicy    *changelogResetPolicy
+	releaseRewritePolicy  *changelogRewritePolicy
+	releaseFollowupPolicy *changelogFollowupPolicy
 }
 
 func run(args []string, stdout, stderr io.Writer) error {
@@ -123,11 +124,14 @@ func (app application) runValidateRelease(args []string, stderr io.Writer) error
 		return errors.New("worktree changelog.md does not match HEAD")
 	}
 
-	currentRef := "HEAD"
+	currentRef, err := app.git.resolveCommit(repo, "HEAD")
+	if err != nil {
+		return err
+	}
 	currentVersion := headVersion
 	currentChangelog := headChangelog
 	followups := 0
-	seen := map[string]bool{}
+	seen := map[string]bool{currentRef: true}
 	for {
 		parents, err := app.git.commitParents(repo, currentRef)
 		if err != nil {
@@ -177,7 +181,22 @@ func (app application) runValidateRelease(args []string, stderr io.Writer) error
 				return fmt.Errorf("release follow-up %s uses %s but preserves version %s", currentRef, bump, currentVersion)
 			}
 			if !bytes.Equal(currentChangelog, parentChangelog) {
-				return fmt.Errorf("non-versioning release follow-up %s changed changelog.md", currentRef)
+				followupPolicy := approvedChangelogFollowup
+				if app.releaseFollowupPolicy != nil {
+					followupPolicy = *app.releaseFollowupPolicy
+				}
+				if err := validateChangelogFollowupException(
+					followupPolicy,
+					currentRef,
+					parentRef,
+					parentVersion,
+					currentVersion,
+					message,
+					parentChangelog,
+					currentChangelog,
+				); err != nil {
+					return fmt.Errorf("non-versioning release follow-up %s changed changelog.md: %w", currentRef, err)
+				}
 			}
 			currentRef = parentRef
 			currentVersion = parentVersion

--- a/scripts/versionctl/command_test.go
+++ b/scripts/versionctl/command_test.go
@@ -56,6 +56,10 @@ func (git *fakeGit) commitMessage(_ string, _ string) (string, error) {
 	return "", errors.New("fake Git history is not configured")
 }
 
+func (git *fakeGit) resolveCommit(_ string, _ string) (string, error) {
+	return "", errors.New("fake Git history is not configured")
+}
+
 func (git *fakeGit) lockPath(_ string) (string, error) {
 	if git.lockErr != nil {
 		return "", git.lockErr

--- a/scripts/versionctl/release_test.go
+++ b/scripts/versionctl/release_test.go
@@ -113,6 +113,19 @@ func validateReleaseFixtureWithRewritePolicy(repo, tag string, policy changelogR
 	return stdout.String() + stderr.String(), err
 }
 
+func validateReleaseFixtureWithFollowupPolicy(repo, tag string, policy changelogFollowupPolicy) (string, error) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := application{
+		git:                   realGit{},
+		out:                   stdout,
+		getenv:                os.Getenv,
+		releaseFollowupPolicy: &policy,
+	}
+	err := app.run([]string{"validate-release", "--repo", repo, "--tag", tag}, stderr)
+	return stdout.String() + stderr.String(), err
+}
+
 func TestValidateReleaseAcceptsEveryBumpWithDirectAndFollowupTags(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -248,6 +261,53 @@ func TestValidateReleasePreservesSingleUseDigestBoundV4033Rewrite(t *testing.T) 
 				t.Fatalf("reused rewrite error = %v", err)
 			}
 		})
+	}
+}
+
+func TestValidateReleaseAcceptsOnlyTheInjectedDigestBoundFollowup(t *testing.T) {
+	repo := newReleaseHistoryRepository(t, "v4.03.3")
+	writeReleaseTransition(t, repo, "v4.10.0")
+	commitReleaseFixture(t, repo, "Major : prepare release")
+
+	base := readTestRepoFile(t, repo, changelogPath)
+	candidate := bytes.Replace(
+		base,
+		[]byte("Validate the version contract"),
+		[]byte("Attest the native signing environment"),
+		1,
+	)
+	if bytes.Equal(base, candidate) {
+		t.Fatal("test fixture did not change the active changelog block")
+	}
+	writeReleaseTestFile(t, repo, changelogPath, candidate)
+	const subject = "Security : attest native signing environment protection (#157)"
+	commitReleaseFixture(t, repo, subject)
+	commitSHA := strings.TrimSpace(string(runTestGit(t, repo, "rev-parse", "HEAD")))
+	parentSHA := strings.TrimSpace(string(runTestGit(t, repo, "rev-parse", "HEAD^")))
+	policy := changelogFollowupPolicy{
+		CommitSHA:       commitSHA,
+		ParentSHA:       parentSHA,
+		Version:         "v4.10.0",
+		Subject:         subject,
+		BaseSHA256:      fmt.Sprintf("%x", sha256.Sum256(base)),
+		CandidateSHA256: fmt.Sprintf("%x", sha256.Sum256(candidate)),
+	}
+
+	writeReleaseTestFile(t, repo, "qualification.txt", []byte("qualified\n"))
+	commitReleaseFixture(t, repo, "Qualification : preserve the sealed changelog")
+	tagReleaseFixture(t, repo, "v4.10.0")
+
+	before := string(runTestGit(t, repo, "status", "--porcelain=v1"))
+	output, err := validateReleaseFixtureWithFollowupPolicy(repo, "v4.10.0", policy)
+	if err != nil {
+		t.Fatalf("validate approved follow-up: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "2 non-versioning follow-up commit(s)") {
+		t.Fatalf("unexpected validation output: %s", output)
+	}
+	after := string(runTestGit(t, repo, "status", "--porcelain=v1"))
+	if before != after || after != "" {
+		t.Fatalf("validate-release changed repository status: before=%q after=%q", before, after)
 	}
 }
 

--- a/scripts/versionctl/repository.go
+++ b/scripts/versionctl/repository.go
@@ -50,6 +50,13 @@ const (
 	approvedChangelogRewriteTo          = "v4.03.3"
 	approvedChangelogRewriteBaseHash    = "f978c898c30b0d40a476c09c91fc4b6d13648bc4e9298fb117593cf6e9a4d53f"
 	approvedChangelogRewriteHistoryHash = "77189b49b1c78c745f6b8d351c9837e4d7bed1bc281daec0a87249a8e6d341fa"
+
+	approvedChangelogFollowupCommit        = "41471a95dd7dc50173aed849126ba4a7e62563aa"
+	approvedChangelogFollowupParent        = "44e43fa4186ebbf4dfd1b281b17c4d0c55f426dc"
+	approvedChangelogFollowupVersion       = "v4.10.0"
+	approvedChangelogFollowupSubject       = "Security : attest native signing environment protection (#157)"
+	approvedChangelogFollowupBaseHash      = "04102be314ebbbbd06073caf86dc3cda7d690defbf0b8f014ad7714dc6c4b73c"
+	approvedChangelogFollowupCandidateHash = "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902"
 )
 
 type changelogResetPolicy struct {
@@ -81,6 +88,28 @@ var approvedChangelogRewrite = changelogRewritePolicy{
 	To:            approvedChangelogRewriteTo,
 	BaseSHA256:    approvedChangelogRewriteBaseHash,
 	HistorySHA256: approvedChangelogRewriteHistoryHash,
+}
+
+type changelogFollowupPolicy struct {
+	CommitSHA       string
+	ParentSHA       string
+	Version         string
+	Subject         string
+	BaseSHA256      string
+	CandidateSHA256 string
+}
+
+// approvedChangelogFollowup is a single-use exception for the exact PR157
+// v4.10.0 changelog update. The commit, its parent, the unchanged version,
+// exact subject, and both byte streams are sealed so this cannot authorize a
+// different commit or become a reusable same-version changelog path.
+var approvedChangelogFollowup = changelogFollowupPolicy{
+	CommitSHA:       approvedChangelogFollowupCommit,
+	ParentSHA:       approvedChangelogFollowupParent,
+	Version:         approvedChangelogFollowupVersion,
+	Subject:         approvedChangelogFollowupSubject,
+	BaseSHA256:      approvedChangelogFollowupBaseHash,
+	CandidateSHA256: approvedChangelogFollowupCandidateHash,
 }
 
 type snapshot map[string][]byte
@@ -363,6 +392,46 @@ func validateChangelogHistoryTransitionWithPolicies(
 	return nil
 }
 
+func validateChangelogFollowupException(
+	policy changelogFollowupPolicy,
+	commitSHA, parentSHA string,
+	parentVersion, currentVersion Version,
+	message string,
+	base, candidate []byte,
+) error {
+	if !fullGitSHA.MatchString(policy.CommitSHA) || !fullGitSHA.MatchString(policy.ParentSHA) {
+		return errors.New("approved changelog follow-up policy contains an invalid Git identity")
+	}
+	if commitSHA != policy.CommitSHA || parentSHA != policy.ParentSHA {
+		return errors.New("commit and parent do not match the approved changelog follow-up")
+	}
+	if parentVersion.String() != policy.Version || currentVersion.String() != policy.Version {
+		return errors.New("version does not match the approved changelog follow-up")
+	}
+	if commitMessageSubject(message) != policy.Subject {
+		return errors.New("commit subject does not match the approved changelog follow-up")
+	}
+	if bytes.Equal(base, candidate) {
+		return errors.New("approved changelog follow-up requires a changed changelog")
+	}
+	baseDigest := sha256.Sum256(base)
+	if hex.EncodeToString(baseDigest[:]) != policy.BaseSHA256 {
+		return errors.New("approved changelog follow-up baseline digest does not match")
+	}
+	candidateDigest := sha256.Sum256(candidate)
+	if hex.EncodeToString(candidateDigest[:]) != policy.CandidateSHA256 {
+		return errors.New("approved changelog follow-up candidate digest does not match")
+	}
+	return nil
+}
+
+func commitMessageSubject(message string) string {
+	if end := strings.IndexAny(message, "\r\n"); end >= 0 {
+		return message[:end]
+	}
+	return message
+}
+
 func readAndValidateChangelog(repo string, expected Version) error {
 	data, err := readRepoFile(repo, changelogPath)
 	if err != nil {
@@ -512,6 +581,7 @@ type gitClient interface {
 	tagMatchesHead(repo, tag string) (bool, error)
 	commitParents(repo, ref string) ([]string, error)
 	commitMessage(repo, ref string) (string, error)
+	resolveCommit(repo, ref string) (string, error)
 	lockPath(repo string) (string, error)
 	capturePrepareState(repo, expectedHead string) (gitPrepareState, error)
 	verifyPrepareState(repo string, expected gitPrepareState) error
@@ -585,24 +655,33 @@ func (realGit) tagMatchesHead(repo, tag string) (bool, error) {
 	if _, err := parseVersion(tag); err != nil {
 		return false, err
 	}
-	resolve := func(ref string) (string, error) {
-		// #nosec G204 -- Git is the fixed executable and ref is selected only from HEAD or the canonical version tag validated above.
-		command := exec.Command("git", "-C", repo, "rev-parse", "--verify", ref+"^{commit}")
-		output, err := command.Output()
-		if err != nil {
-			return "", fmt.Errorf("resolve Git ref %s: %w", ref, err)
-		}
-		return strings.TrimSpace(string(output)), nil
-	}
-	head, err := resolve("HEAD")
+	git := realGit{}
+	head, err := git.resolveCommit(repo, "HEAD")
 	if err != nil {
 		return false, err
 	}
-	tagCommit, err := resolve("refs/tags/" + tag)
+	tagCommit, err := git.resolveCommit(repo, "refs/tags/"+tag)
 	if err != nil {
 		return false, err
 	}
 	return head == tagCommit, nil
+}
+
+func (realGit) resolveCommit(repo, ref string) (string, error) {
+	if err := validateGitRef(ref); err != nil {
+		return "", err
+	}
+	// #nosec G204 -- Git is fixed and ref is validated above; exec.Command does not invoke a shell.
+	command := exec.Command("git", "-C", repo, "rev-parse", "--verify", ref+"^{commit}")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve Git ref %s: %w", ref, err)
+	}
+	commit := strings.TrimSpace(string(output))
+	if !fullGitSHA.MatchString(commit) {
+		return "", fmt.Errorf("Git ref %s did not resolve to one full lowercase commit SHA", ref)
+	}
+	return commit, nil
 }
 
 func (realGit) commitParents(repo, ref string) ([]string, error) {

--- a/scripts/versionctl/repository_test.go
+++ b/scripts/versionctl/repository_test.go
@@ -94,6 +94,96 @@ func TestChangelogHistoryRewriteIsSingleUseAndDigestBound(t *testing.T) {
 	}
 }
 
+func TestChangelogFollowupExceptionIsSingleUseAndFullyBound(t *testing.T) {
+	t.Parallel()
+	base := validChangelog("v4.10.0")
+	candidate := bytes.Replace(base, []byte("Validate the version contract"), []byte("Attest the native signing environment"), 1)
+	version, _ := parseVersion("v4.10.0")
+	const (
+		commit  = "1111111111111111111111111111111111111111"
+		parent  = "2222222222222222222222222222222222222222"
+		subject = "Security : attest native signing environment protection (#157)"
+	)
+	policy := changelogFollowupPolicy{
+		CommitSHA:       commit,
+		ParentSHA:       parent,
+		Version:         version.String(),
+		Subject:         subject,
+		BaseSHA256:      fmt.Sprintf("%x", sha256.Sum256(base)),
+		CandidateSHA256: fmt.Sprintf("%x", sha256.Sum256(candidate)),
+	}
+	validate := func(policy changelogFollowupPolicy, commitSHA, parentSHA string, parentVersion, currentVersion Version, message string, before, after []byte) error {
+		return validateChangelogFollowupException(policy, commitSHA, parentSHA, parentVersion, currentVersion, message, before, after)
+	}
+	if err := validate(policy, commit, parent, version, version, subject+"\n\nAudited body.\n", base, candidate); err != nil {
+		t.Fatalf("exact follow-up rejected: %v", err)
+	}
+
+	otherVersion, _ := parseVersion("v4.10.1")
+	mutatedBase := append([]byte(nil), base...)
+	mutatedBase[len(mutatedBase)-1] ^= 1
+	mutatedCandidate := append([]byte(nil), candidate...)
+	mutatedCandidate[len(mutatedCandidate)-1] ^= 1
+	tests := []struct {
+		name           string
+		policy         changelogFollowupPolicy
+		commitSHA      string
+		parentSHA      string
+		parentVersion  Version
+		currentVersion Version
+		message        string
+		base           []byte
+		candidate      []byte
+	}{
+		{name: "different commit", policy: policy, commitSHA: strings.Repeat("3", 40), parentSHA: parent, parentVersion: version, currentVersion: version, message: subject, base: base, candidate: candidate},
+		{name: "different parent", policy: policy, commitSHA: commit, parentSHA: strings.Repeat("3", 40), parentVersion: version, currentVersion: version, message: subject, base: base, candidate: candidate},
+		{name: "different parent version", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: otherVersion, currentVersion: version, message: subject, base: base, candidate: candidate},
+		{name: "different current version", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: otherVersion, message: subject, base: base, candidate: candidate},
+		{name: "different subject", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: version, message: subject + " ", base: base, candidate: candidate},
+		{name: "different baseline bytes", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: version, message: subject, base: mutatedBase, candidate: candidate},
+		{name: "different candidate bytes", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: version, message: subject, base: base, candidate: mutatedCandidate},
+		{name: "unchanged changelog", policy: policy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: version, message: subject, base: base, candidate: base},
+	}
+	malformedPolicy := policy
+	malformedPolicy.CommitSHA = "HEAD"
+	tests = append(tests, struct {
+		name           string
+		policy         changelogFollowupPolicy
+		commitSHA      string
+		parentSHA      string
+		parentVersion  Version
+		currentVersion Version
+		message        string
+		base           []byte
+		candidate      []byte
+	}{name: "malformed policy identity", policy: malformedPolicy, commitSHA: commit, parentSHA: parent, parentVersion: version, currentVersion: version, message: subject, base: base, candidate: candidate})
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validate(test.policy, test.commitSHA, test.parentSHA, test.parentVersion, test.currentVersion, test.message, test.base, test.candidate); err == nil {
+				t.Fatal("mutated follow-up was accepted")
+			}
+		})
+	}
+}
+
+func TestApprovedChangelogFollowupRemainsBoundToPR157(t *testing.T) {
+	t.Parallel()
+	want := changelogFollowupPolicy{
+		CommitSHA:       "41471a95dd7dc50173aed849126ba4a7e62563aa",
+		ParentSHA:       "44e43fa4186ebbf4dfd1b281b17c4d0c55f426dc",
+		Version:         "v4.10.0",
+		Subject:         "Security : attest native signing environment protection (#157)",
+		BaseSHA256:      "04102be314ebbbbd06073caf86dc3cda7d690defbf0b8f014ad7714dc6c4b73c",
+		CandidateSHA256: "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902",
+	}
+	if approvedChangelogFollowup != want {
+		t.Fatalf("approved PR157 follow-up policy = %#v, want %#v", approvedChangelogFollowup, want)
+	}
+}
+
 func fixtureSnapshot(version string) snapshot {
 	contents := make(snapshot, len(versionTargets))
 	for _, item := range versionTargets {

--- a/src/core/syswarden-cli/pkg/network/ha_contract_test.go
+++ b/src/core/syswarden-cli/pkg/network/ha_contract_test.go
@@ -500,16 +500,18 @@ func TestSyncHAContextCancellationStopsRetries_SW_HA_002(t *testing.T) {
 }
 
 func TestSyncHARequestTimeoutIsBounded_SW_HA_002(t *testing.T) {
-	server := newLoopbackTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		<-request.Context().Done()
+	releaseHandler := make(chan struct{})
+	server := newLoopbackTLSServer(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-releaseHandler
 	}))
 	defer server.Close()
+	defer close(releaseHandler)
 	host, port := splitTestServerAddress(t, server.Listener.Addr().String())
 	options := testHASyncOptions(t, server.Client())
 	options.requestTimeout = 25 * time.Millisecond
 	started := time.Now()
 	err := syncHAPeers(context.Background(), &config.Config{HAEnabled: true, HAPeerIP: host, HAPeerPort: port, HAToken: "shared-secret"}, options)
-	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("bounded timeout error = %v", err)
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {


### PR DESCRIPTION
## Summary

- Preserve v4.10.0 while accepting the exact PR157 changelog transition only when its commit, parent, version, subject, baseline digest and candidate digest all match.
- Keep validate-commit strict for every current and future non-versioning commit.
- Make the HA request-timeout contract test deterministic without changing product runtime behavior.

## Incident scope

- Restores the Auto-Versioning contract after run 34259950149.
- Removes the race-only false failure observed in Security Audit run 34259950208.
- Does not weaken package, release, signature or runtime controls.

## Validation

- versionctl full test suite passed.
- versionctl full race test suite passed.
- Exact v4.04.3 to v4.10.0 release history, including PR157 and later follow-ups, passed in an isolated tagged repository.
- HA timeout test passed 100 standard repetitions and 50 race repetitions.
- Full network package race suite passed.
- git diff --check passed.
- changelog.md is unchanged in this corrective commit.