### PR TITLE
Fix : bind the exact v4.10.0 changelog follow-up

### DIFF
--- a/scripts/versionctl/command.go
+++ b/scripts/versionctl/command.go
@@ -12,12 +12,12 @@ import (
 )
 
 type application struct {
-	git                   gitClient
-	out                   io.Writer
-	getenv                func(string) string
-	releaseResetPolicy    *changelogResetPolicy
-	releaseRewritePolicy  *changelogRewritePolicy
-	releaseFollowupPolicy *changelogFollowupPolicy
+	git                     gitClient
+	out                     io.Writer
+	getenv                  func(string) string
+	releaseResetPolicy      *changelogResetPolicy
+	releaseRewritePolicy    *changelogRewritePolicy
+	releaseFollowupPolicies []changelogFollowupPolicy
 }
 
 func run(args []string, stdout, stderr io.Writer) error {
@@ -181,12 +181,12 @@ func (app application) runValidateRelease(args []string, stderr io.Writer) error
 				return fmt.Errorf("release follow-up %s uses %s but preserves version %s", currentRef, bump, currentVersion)
 			}
 			if !bytes.Equal(currentChangelog, parentChangelog) {
-				followupPolicy := approvedChangelogFollowup
-				if app.releaseFollowupPolicy != nil {
-					followupPolicy = *app.releaseFollowupPolicy
+				followupPolicies := approvedChangelogFollowups
+				if len(app.releaseFollowupPolicies) > 0 {
+					followupPolicies = app.releaseFollowupPolicies
 				}
-				if err := validateChangelogFollowupException(
-					followupPolicy,
+				if err := validateChangelogFollowupExceptions(
+					followupPolicies,
 					currentRef,
 					parentRef,
 					parentVersion,

--- a/scripts/versionctl/release_test.go
+++ b/scripts/versionctl/release_test.go
@@ -114,13 +114,17 @@ func validateReleaseFixtureWithRewritePolicy(repo, tag string, policy changelogR
 }
 
 func validateReleaseFixtureWithFollowupPolicy(repo, tag string, policy changelogFollowupPolicy) (string, error) {
+	return validateReleaseFixtureWithFollowupPolicies(repo, tag, []changelogFollowupPolicy{policy})
+}
+
+func validateReleaseFixtureWithFollowupPolicies(repo, tag string, policies []changelogFollowupPolicy) (string, error) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	app := application{
-		git:                   realGit{},
-		out:                   stdout,
-		getenv:                os.Getenv,
-		releaseFollowupPolicy: &policy,
+		git:                     realGit{},
+		out:                     stdout,
+		getenv:                  os.Getenv,
+		releaseFollowupPolicies: policies,
 	}
 	err := app.run([]string{"validate-release", "--repo", repo, "--tag", tag}, stderr)
 	return stdout.String() + stderr.String(), err
@@ -303,6 +307,58 @@ func TestValidateReleaseAcceptsOnlyTheInjectedDigestBoundFollowup(t *testing.T) 
 		t.Fatalf("validate approved follow-up: %v\n%s", err, output)
 	}
 	if !strings.Contains(output, "2 non-versioning follow-up commit(s)") {
+		t.Fatalf("unexpected validation output: %s", output)
+	}
+	after := string(runTestGit(t, repo, "status", "--porcelain=v1"))
+	if before != after || after != "" {
+		t.Fatalf("validate-release changed repository status: before=%q after=%q", before, after)
+	}
+}
+
+func TestValidateReleaseAcceptsTwoSequentialSealedFollowups(t *testing.T) {
+	repo := newReleaseHistoryRepository(t, "v4.03.3")
+	writeReleaseTransition(t, repo, "v4.10.0")
+	commitReleaseFixture(t, repo, "Major : prepare release")
+
+	commitFollowup := func(subject, oldText, newText string) changelogFollowupPolicy {
+		t.Helper()
+		base := readTestRepoFile(t, repo, changelogPath)
+		candidate := bytes.Replace(base, []byte(oldText), []byte(newText), 1)
+		if bytes.Equal(base, candidate) {
+			t.Fatalf("test fixture did not change %q", oldText)
+		}
+		writeReleaseTestFile(t, repo, changelogPath, candidate)
+		commitReleaseFixture(t, repo, subject)
+		return changelogFollowupPolicy{
+			CommitSHA:       strings.TrimSpace(string(runTestGit(t, repo, "rev-parse", "HEAD"))),
+			ParentSHA:       strings.TrimSpace(string(runTestGit(t, repo, "rev-parse", "HEAD^"))),
+			Version:         "v4.10.0",
+			Subject:         subject,
+			BaseSHA256:      fmt.Sprintf("%x", sha256.Sum256(base)),
+			CandidateSHA256: fmt.Sprintf("%x", sha256.Sum256(candidate)),
+		}
+	}
+	first := commitFollowup(
+		"Security : attest native signing environment protection (#157)",
+		"Validate the version contract",
+		"Attest the native signing environment",
+	)
+	second := commitFollowup(
+		"Fix : sign the exact APK control stream (#161)",
+		"Attest the native signing environment",
+		"Sign the exact APK control stream",
+	)
+
+	writeReleaseTestFile(t, repo, "qualification.txt", []byte("qualified\n"))
+	commitReleaseFixture(t, repo, "Qualification : preserve the sealed changelog")
+	tagReleaseFixture(t, repo, "v4.10.0")
+
+	before := string(runTestGit(t, repo, "status", "--porcelain=v1"))
+	output, err := validateReleaseFixtureWithFollowupPolicies(repo, "v4.10.0", []changelogFollowupPolicy{first, second})
+	if err != nil {
+		t.Fatalf("validate sequential approved follow-ups: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "3 non-versioning follow-up commit(s)") {
 		t.Fatalf("unexpected validation output: %s", output)
 	}
 	after := string(runTestGit(t, repo, "status", "--porcelain=v1"))

--- a/scripts/versionctl/repository.go
+++ b/scripts/versionctl/repository.go
@@ -57,6 +57,13 @@ const (
 	approvedChangelogFollowupSubject       = "Security : attest native signing environment protection (#157)"
 	approvedChangelogFollowupBaseHash      = "04102be314ebbbbd06073caf86dc3cda7d690defbf0b8f014ad7714dc6c4b73c"
 	approvedChangelogFollowupCandidateHash = "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902"
+
+	approvedChangelogFollowupPR161Commit        = "06aaf5cffd5892b228be71fc27a6ed50888c2687"
+	approvedChangelogFollowupPR161Parent        = "360e8189c812e26f47b1beffd3d5dc86d188a449"
+	approvedChangelogFollowupPR161Version       = "v4.10.0"
+	approvedChangelogFollowupPR161Subject       = "Fix : sign the exact APK control stream (#161)"
+	approvedChangelogFollowupPR161BaseHash      = "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902"
+	approvedChangelogFollowupPR161CandidateHash = "637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281"
 )
 
 type changelogResetPolicy struct {
@@ -110,6 +117,23 @@ var approvedChangelogFollowup = changelogFollowupPolicy{
 	Subject:         approvedChangelogFollowupSubject,
 	BaseSHA256:      approvedChangelogFollowupBaseHash,
 	CandidateSHA256: approvedChangelogFollowupCandidateHash,
+}
+
+// approvedChangelogFollowupPR161 is a single-use exception for the exact
+// PR161 APK control-stream correction. It extends no general permission to
+// edit an active release changelog after its version transition.
+var approvedChangelogFollowupPR161 = changelogFollowupPolicy{
+	CommitSHA:       approvedChangelogFollowupPR161Commit,
+	ParentSHA:       approvedChangelogFollowupPR161Parent,
+	Version:         approvedChangelogFollowupPR161Version,
+	Subject:         approvedChangelogFollowupPR161Subject,
+	BaseSHA256:      approvedChangelogFollowupPR161BaseHash,
+	CandidateSHA256: approvedChangelogFollowupPR161CandidateHash,
+}
+
+var approvedChangelogFollowups = []changelogFollowupPolicy{
+	approvedChangelogFollowup,
+	approvedChangelogFollowupPR161,
 }
 
 type snapshot map[string][]byte
@@ -423,6 +447,48 @@ func validateChangelogFollowupException(
 		return errors.New("approved changelog follow-up candidate digest does not match")
 	}
 	return nil
+}
+
+func validateChangelogFollowupExceptions(
+	policies []changelogFollowupPolicy,
+	commitSHA, parentSHA string,
+	parentVersion, currentVersion Version,
+	message string,
+	base, candidate []byte,
+) error {
+	if len(policies) == 0 {
+		return errors.New("no approved changelog follow-up policies are configured")
+	}
+
+	matching := -1
+	identities := make(map[string]struct{}, len(policies))
+	for index, policy := range policies {
+		if !fullGitSHA.MatchString(policy.CommitSHA) || !fullGitSHA.MatchString(policy.ParentSHA) {
+			return errors.New("approved changelog follow-up policy contains an invalid Git identity")
+		}
+		identity := policy.CommitSHA + "\x00" + policy.ParentSHA
+		if _, exists := identities[identity]; exists {
+			return errors.New("approved changelog follow-up policies contain a duplicate Git identity")
+		}
+		identities[identity] = struct{}{}
+		if commitSHA == policy.CommitSHA && parentSHA == policy.ParentSHA {
+			matching = index
+		}
+	}
+	if matching < 0 {
+		return errors.New("commit and parent do not match an approved changelog follow-up")
+	}
+
+	return validateChangelogFollowupException(
+		policies[matching],
+		commitSHA,
+		parentSHA,
+		parentVersion,
+		currentVersion,
+		message,
+		base,
+		candidate,
+	)
 }
 
 func commitMessageSubject(message string) string {

--- a/scripts/versionctl/repository_test.go
+++ b/scripts/versionctl/repository_test.go
@@ -184,6 +184,80 @@ func TestApprovedChangelogFollowupRemainsBoundToPR157(t *testing.T) {
 	}
 }
 
+func TestApprovedChangelogFollowupRemainsBoundToPR161(t *testing.T) {
+	t.Parallel()
+	want := changelogFollowupPolicy{
+		CommitSHA:       "06aaf5cffd5892b228be71fc27a6ed50888c2687",
+		ParentSHA:       "360e8189c812e26f47b1beffd3d5dc86d188a449",
+		Version:         "v4.10.0",
+		Subject:         "Fix : sign the exact APK control stream (#161)",
+		BaseSHA256:      "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902",
+		CandidateSHA256: "637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281",
+	}
+	if approvedChangelogFollowupPR161 != want {
+		t.Fatalf("approved PR161 follow-up policy = %#v, want %#v", approvedChangelogFollowupPR161, want)
+	}
+	if len(approvedChangelogFollowups) != 2 ||
+		approvedChangelogFollowups[0] != approvedChangelogFollowup ||
+		approvedChangelogFollowups[1] != approvedChangelogFollowupPR161 {
+		t.Fatalf("approved changelog follow-up inventory = %#v", approvedChangelogFollowups)
+	}
+}
+
+func TestChangelogFollowupExceptionsSelectExactlyOneSealedIdentity(t *testing.T) {
+	t.Parallel()
+	base := validChangelog("v4.10.0")
+	candidate := bytes.Replace(base, []byte("Validate the version contract"), []byte("Sign the exact APK control stream"), 1)
+	version, _ := parseVersion("v4.10.0")
+	target := changelogFollowupPolicy{
+		CommitSHA:       strings.Repeat("3", 40),
+		ParentSHA:       strings.Repeat("4", 40),
+		Version:         version.String(),
+		Subject:         "Fix : sign the exact APK control stream (#161)",
+		BaseSHA256:      fmt.Sprintf("%x", sha256.Sum256(base)),
+		CandidateSHA256: fmt.Sprintf("%x", sha256.Sum256(candidate)),
+	}
+	other := target
+	other.CommitSHA = strings.Repeat("1", 40)
+	other.ParentSHA = strings.Repeat("2", 40)
+	other.Subject = "Security : attest native signing environment protection (#157)"
+
+	validate := func(policies []changelogFollowupPolicy, commitSHA, parentSHA string) error {
+		return validateChangelogFollowupExceptions(
+			policies,
+			commitSHA,
+			parentSHA,
+			version,
+			version,
+			target.Subject,
+			base,
+			candidate,
+		)
+	}
+	if err := validate([]changelogFollowupPolicy{other, target}, target.CommitSHA, target.ParentSHA); err != nil {
+		t.Fatalf("second exact sealed policy was rejected: %v", err)
+	}
+	if err := validate(nil, target.CommitSHA, target.ParentSHA); err == nil {
+		t.Fatal("empty policy inventory was accepted")
+	}
+	if err := validate([]changelogFollowupPolicy{other}, target.CommitSHA, target.ParentSHA); err == nil {
+		t.Fatal("unapproved identity was accepted")
+	}
+	if err := validate([]changelogFollowupPolicy{target, target}, target.CommitSHA, target.ParentSHA); err == nil {
+		t.Fatal("duplicate policy identity was accepted")
+	}
+	malformed := other
+	malformed.CommitSHA = "HEAD"
+	if err := validate([]changelogFollowupPolicy{malformed, target}, target.CommitSHA, target.ParentSHA); err == nil {
+		t.Fatal("malformed unrelated policy was accepted")
+	}
+	mutated := target
+	mutated.CandidateSHA256 = strings.Repeat("0", 64)
+	if err := validate([]changelogFollowupPolicy{other, mutated}, target.CommitSHA, target.ParentSHA); err == nil {
+		t.Fatal("wrong candidate digest was accepted")
+	}
+}
+
 func fixtureSnapshot(version string) snapshot {
 	contents := make(snapshot, len(versionTargets))
 	for _, item := range versionTargets {


### PR DESCRIPTION
## Summary

- bind the PR161 changelog update to its exact commit, parent, v4.10.0 version, subject, and before/after SHA-256 digests
- preserve the existing single-use PR157 exception while selecting exactly one sealed follow-up policy
- keep future non-versioning changelog changes fail-closed
- add a full release-chain regression covering two sequential sealed follow-ups

## Verification

- versionctl unit suite: pass
- versionctl race suite: pass
- go vet: pass
- real v4.04.3 to v4.10.0 release-chain validation: pass
- commit version contract: pass
- Gitleaks worktree scan: pass
- changelog.md, README.md, and version targets: unchanged

This PR repairs the forward release contract only. It does not rerun or rewrite the historical failed Auto-Versioning run and does not publish packages.