### PR TITLE
Security : bind v4.10.0 qualification to the exact signed bootstrap

### DIFF
--- a/.github/workflows/candidate-update-bundle.yml
+++ b/.github/workflows/candidate-update-bundle.yml
@@ -269,7 +269,7 @@ jobs:
             echo "ERROR: requested native signing run is not one successful exact-main attempt." >&2
             exit 1
           fi
-          expected_name="syswarden-native-signed-packages-${version}-${REQUESTED_RUN_ID}-1-${RELEASE_SHA}"
+          expected_name="syswarden-native-signed-packages-qualified-${version}-${REQUESTED_RUN_ID}-1-${RELEASE_SHA}"
           artifacts="$(gh api --paginate --slurp --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${REQUESTED_RUN_ID}/artifacts" -f per_page=100)"
           if [[ "$(jq '[.[] | .artifacts[]?] | length' <<< "${artifacts}")" != "1" ]]; then

--- a/.github/workflows/native-package-signing.yml
+++ b/.github/workflows/native-package-signing.yml
@@ -42,12 +42,36 @@ on:
         options:
           - bootstrap-qualification
           - qualified-policy
+      bootstrap_release_sha:
+        description: Exact distinct ancestor SHA used by the successful bootstrap run, required only for qualified policy
+        required: false
+        type: string
+      bootstrap_signing_run_id:
+        description: Exact successful bootstrap native-signing run ID, required only for qualified policy
+        required: false
+        type: string
+      bootstrap_signed_artifact_id:
+        description: Exact immutable bootstrap signed-bundle artifact ID, required only for qualified policy
+        required: false
+        type: string
+      bootstrap_policy_sha256:
+        description: Exact SHA-256 of the committed foundation policy, required only for qualified policy
+        required: false
+        type: string
       authorization:
         description: Enter SIGN-NATIVE-PACKAGES-NO-PUBLISH
         required: true
         type: string
 
 env:
+  APPROVED_BOOTSTRAP_ARTIFACT_DIGEST: sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3
+  APPROVED_BOOTSTRAP_ARTIFACT_ID: "10088398939"
+  APPROVED_BOOTSTRAP_ARTIFACT_NAME: syswarden-native-signed-packages-4.10.0-34292701745-1-9598861f1be80a651658bf3ca8c10424bd70db6c
+  APPROVED_BOOTSTRAP_ARTIFACT_SIZE: "63065295"
+  APPROVED_BOOTSTRAP_RELEASE_SHA: 9598861f1be80a651658bf3ca8c10424bd70db6c
+  APPROVED_BOOTSTRAP_REPOSITORY: duggytuxy/syswarden
+  APPROVED_BOOTSTRAP_RUN_ID: "34292701745"
+  FOUNDATION_POLICY_SHA256: 6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   LANG: C
   LC_ALL: C
@@ -135,6 +159,7 @@ jobs:
           EVENT_REF: ${{ github.ref }}
           EVENT_REF_NAME: ${{ github.ref_name }}
           EVENT_REF_TYPE: ${{ github.ref_type }}
+          EVENT_REPOSITORY: ${{ github.repository }}
           EVENT_SHA: ${{ github.sha }}
           EVENT_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           RELEASE_SHA: ${{ inputs.release_sha }}
@@ -148,6 +173,10 @@ jobs:
           APK_KEY_ID: ${{ inputs.apk_key_id }}
           DEB_KEY_ID: ${{ inputs.deb_key_id }}
           QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
+          BOOTSTRAP_RELEASE_SHA: ${{ inputs.bootstrap_release_sha }}
+          BOOTSTRAP_SIGNING_RUN_ID: ${{ inputs.bootstrap_signing_run_id }}
+          BOOTSTRAP_SIGNED_ARTIFACT_ID: ${{ inputs.bootstrap_signed_artifact_id }}
+          BOOTSTRAP_POLICY_SHA256: ${{ inputs.bootstrap_policy_sha256 }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
@@ -192,7 +221,29 @@ jobs:
             }
           done
           case "${QUALIFICATION_MODE}" in
-            bootstrap-qualification|qualified-policy) ;;
+            bootstrap-qualification)
+              if [[ -n "${BOOTSTRAP_RELEASE_SHA}" || \
+                    -n "${BOOTSTRAP_SIGNING_RUN_ID}" || \
+                    -n "${BOOTSTRAP_SIGNED_ARTIFACT_ID}" || \
+                    -n "${BOOTSTRAP_POLICY_SHA256}" ]]; then
+                echo "ERROR: bootstrap mode cannot claim a prior bootstrap qualification." >&2
+                exit 1
+              fi
+              ;;
+            qualified-policy)
+              if [[ ! "${BOOTSTRAP_RELEASE_SHA}" =~ ^[0-9a-f]{40}$ || \
+                    "${BOOTSTRAP_RELEASE_SHA}" == "${RELEASE_SHA}" || \
+                    ! "${BOOTSTRAP_SIGNING_RUN_ID}" =~ ^[1-9][0-9]*$ || \
+                    ! "${BOOTSTRAP_SIGNED_ARTIFACT_ID}" =~ ^[1-9][0-9]*$ || \
+                    "${BOOTSTRAP_POLICY_SHA256}" != "${FOUNDATION_POLICY_SHA256}" || \
+                    "${EVENT_REPOSITORY}" != "${APPROVED_BOOTSTRAP_REPOSITORY}" || \
+                    "${BOOTSTRAP_RELEASE_SHA}" != "${APPROVED_BOOTSTRAP_RELEASE_SHA}" || \
+                    "${BOOTSTRAP_SIGNING_RUN_ID}" != "${APPROVED_BOOTSTRAP_RUN_ID}" || \
+                    "${BOOTSTRAP_SIGNED_ARTIFACT_ID}" != "${APPROVED_BOOTSTRAP_ARTIFACT_ID}" ]]; then
+                echo "ERROR: qualified mode requires the exact reviewed Phase A bootstrap." >&2
+                exit 1
+              fi
+              ;;
             *) echo "ERROR: native signing qualification mode is invalid." >&2; exit 1 ;;
           esac
 
@@ -217,12 +268,13 @@ jobs:
           rhel_unsigned_dir="${signing_root}/rhel-package-owned-unsigned"
           rhel_signed_dir="${signing_root}/rhel-package-owned-signed"
           apk_work_dir="${signing_root}/apk-work"
+          bootstrap_dir="${signing_root}/bootstrap-bundle"
           proof_dir="${signing_root}/proof"
           secret_dir="${signing_root}/private"
           install -d -m 0700 \
             "${unsigned_dir}" "${signed_dir}" \
             "${rhel_unsigned_dir}" "${rhel_signed_dir}" "${apk_work_dir}" \
-            "${proof_dir}" "${secret_dir}"
+            "${bootstrap_dir}" "${proof_dir}" "${secret_dir}"
           {
             printf 'SIGNING_ROOT=%s\n' "${signing_root}"
             printf 'UNSIGNED_DIR=%s\n' "${unsigned_dir}"
@@ -230,11 +282,13 @@ jobs:
             printf 'RHEL_UNSIGNED_DIR=%s\n' "${rhel_unsigned_dir}"
             printf 'RHEL_SIGNED_DIR=%s\n' "${rhel_signed_dir}"
             printf 'APK_WORK_DIR=%s\n' "${apk_work_dir}"
+            printf 'BOOTSTRAP_DIR=%s\n' "${bootstrap_dir}"
             printf 'PROOF_DIR=%s\n' "${proof_dir}"
             printf 'SECRET_DIR=%s\n' "${secret_dir}"
           } >> "${GITHUB_ENV}"
           printf 'unsigned_dir=%s\n' "${unsigned_dir}" >> "${GITHUB_OUTPUT}"
           printf 'rhel_unsigned_dir=%s\n' "${rhel_unsigned_dir}" >> "${GITHUB_OUTPUT}"
+          printf 'bootstrap_dir=%s\n' "${bootstrap_dir}" >> "${GITHUB_OUTPUT}"
 
       - name: Validate Source and Signature Policy Foundation
         shell: bash
@@ -311,6 +365,151 @@ jobs:
           [[ "${source_date_epoch}" =~ ^[1-9][0-9]*$ ]]
           printf 'SIGNING_DATE=%s\n' "${as_of}" >> "${GITHUB_ENV}"
           printf 'SOURCE_DATE_EPOCH=%s\n' "${source_date_epoch}" >> "${GITHUB_ENV}"
+
+      - name: Resolve Exact Prior Bootstrap Run and Artifact
+        if: ${{ inputs.qualification_mode == 'qualified-policy' }}
+        id: bootstrap
+        shell: bash
+        env:
+          BOOTSTRAP_RELEASE_SHA: ${{ inputs.bootstrap_release_sha }}
+          REQUESTED_ARTIFACT_ID: ${{ inputs.bootstrap_signed_artifact_id }}
+          REQUESTED_RUN_ID: ${{ inputs.bootstrap_signing_run_id }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          expected_name="syswarden-native-signed-packages-${version}-${REQUESTED_RUN_ID}-1-${BOOTSTRAP_RELEASE_SHA}"
+          if [[ "${GITHUB_REPOSITORY}" != "${APPROVED_BOOTSTRAP_REPOSITORY}" || \
+                "${BOOTSTRAP_RELEASE_SHA}" != "${APPROVED_BOOTSTRAP_RELEASE_SHA}" || \
+                "${REQUESTED_RUN_ID}" != "${APPROVED_BOOTSTRAP_RUN_ID}" || \
+                "${REQUESTED_ARTIFACT_ID}" != "${APPROVED_BOOTSTRAP_ARTIFACT_ID}" || \
+                "${expected_name}" != "${APPROVED_BOOTSTRAP_ARTIFACT_NAME}" ]]; then
+            echo "ERROR: requested bootstrap identity is not the exact reviewed Phase A result." >&2
+            exit 1
+          fi
+          run_json="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${REQUESTED_RUN_ID}")"
+          if [[ "$(jq -r '.id | tostring' <<< "${run_json}")" != "${REQUESTED_RUN_ID}" || \
+                "$(jq -r '.path // ""' <<< "${run_json}")" != ".github/workflows/native-package-signing.yml" || \
+                "$(jq -r '.head_sha // ""' <<< "${run_json}")" != "${BOOTSTRAP_RELEASE_SHA}" || \
+                "$(jq -r '.head_branch // ""' <<< "${run_json}")" != "main" || \
+                "$(jq -r '.event // ""' <<< "${run_json}")" != "workflow_dispatch" || \
+                "$(jq -r '.run_attempt | tostring' <<< "${run_json}")" != "1" || \
+                "$(jq -r '.status // ""' <<< "${run_json}")" != "completed" || \
+                "$(jq -r '.conclusion // ""' <<< "${run_json}")" != "success" || \
+                "$(jq -r '.actor.login // ""' <<< "${run_json}")" != "${REPOSITORY_OWNER}" || \
+                "$(jq -r '.triggering_actor.login // ""' <<< "${run_json}")" != "${REPOSITORY_OWNER}" ]]; then
+            echo "ERROR: requested bootstrap run is not the exact successful owner-dispatched attempt 1." >&2
+            exit 1
+          fi
+          artifacts="$(gh api --paginate --slurp --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${REQUESTED_RUN_ID}/artifacts" \
+            -f per_page=100)"
+          if [[ "$(jq '[.[] | .artifacts[]?] | length' <<< "${artifacts}")" != "1" ]]; then
+            echo "ERROR: bootstrap signing run must expose exactly one artifact." >&2
+            exit 1
+          fi
+          match="$(jq --arg name "${expected_name}" \
+            --arg sha "${BOOTSTRAP_RELEASE_SHA}" \
+            --argjson run "${REQUESTED_RUN_ID}" \
+            --argjson id "${REQUESTED_ARTIFACT_ID}" '[
+              .[] | .artifacts[]? | select(
+                .id == $id and .name == $name and .expired == false and
+                .workflow_run.id == $run and .workflow_run.head_sha == $sha and
+                .workflow_run.head_branch == "main"
+              )
+            ]' <<< "${artifacts}")"
+          artifact_digest="$(jq -r '.[0].digest // ""' <<< "${match}")"
+          artifact_size="$(jq -r '.[0].size_in_bytes | tostring' <<< "${match}")"
+          if [[ "$(jq 'length' <<< "${match}")" != "1" || \
+                ! "${artifact_size}" =~ ^[1-9][0-9]*$ || \
+                ! "${artifact_digest}" =~ ^sha256:[0-9a-f]{64}$ || \
+                "${artifact_size}" != "${APPROVED_BOOTSTRAP_ARTIFACT_SIZE}" || \
+                "${artifact_digest}" != "${APPROVED_BOOTSTRAP_ARTIFACT_DIGEST}" ]]; then
+            echo "ERROR: requested bootstrap artifact is not the exact reviewed Phase A artifact." >&2
+            exit 1
+          fi
+          {
+            printf 'artifact_digest=%s\n' "${artifact_digest}"
+            printf 'artifact_name=%s\n' "${expected_name}"
+            printf 'artifact_size=%s\n' "${artifact_size}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Download Exact Prior Bootstrap Artifact by ID
+        if: ${{ inputs.qualification_mode == 'qualified-policy' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ inputs.bootstrap_signed_artifact_id }}
+          path: ${{ steps.workspace.outputs.bootstrap_dir }}
+          merge-multiple: true
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.bootstrap_signing_run_id }}
+
+      - name: Validate Exact Bootstrap Policy Transition and Bundle
+        if: ${{ inputs.qualification_mode == 'qualified-policy' }}
+        shell: bash
+        env:
+          BOOTSTRAP_ARTIFACT_DIGEST: ${{ steps.bootstrap.outputs.artifact_digest }}
+          BOOTSTRAP_ARTIFACT_NAME: ${{ steps.bootstrap.outputs.artifact_name }}
+          BOOTSTRAP_ARTIFACT_SIZE: ${{ steps.bootstrap.outputs.artifact_size }}
+          BOOTSTRAP_POLICY_SHA256: ${{ inputs.bootstrap_policy_sha256 }}
+          BOOTSTRAP_RELEASE_SHA: ${{ inputs.bootstrap_release_sha }}
+          BOOTSTRAP_SIGNING_RUN_ID: ${{ inputs.bootstrap_signing_run_id }}
+          BOOTSTRAP_SIGNED_ARTIFACT_ID: ${{ inputs.bootstrap_signed_artifact_id }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          test "${BOOTSTRAP_RELEASE_SHA}" != "${RELEASE_SHA}"
+          git cat-file -e "${BOOTSTRAP_RELEASE_SHA}^{commit}"
+          git merge-base --is-ancestor "${BOOTSTRAP_RELEASE_SHA}" "${RELEASE_SHA}"
+          policy_path="scripts/ci/native_package_signature_policy_v4100.json"
+          bootstrap_policy="${SIGNING_ROOT}/bootstrap-policy.json"
+          test ! -e "${bootstrap_policy}"
+          policy_object="${BOOTSTRAP_RELEASE_SHA}:${policy_path}"
+          policy_size="$(git cat-file -s "${policy_object}")"
+          if [[ ! "${policy_size}" =~ ^[1-9][0-9]*$ || "${policy_size}" -gt 131072 ]]; then
+            echo "ERROR: bootstrap policy object has an invalid size." >&2
+            exit 1
+          fi
+          git cat-file blob "${policy_object}" > "${bootstrap_policy}"
+          chmod 0600 "${bootstrap_policy}"
+          PYTHONDONTWRITEBYTECODE=1 python3 - \
+            "${BOOTSTRAP_DIR}" "${bootstrap_policy}" "${policy_path}" <<'PY'
+          import os
+          import sys
+          from pathlib import Path
+
+          from scripts.ci import native_package_signature_gate as gate
+          from scripts.ci import native_package_signing_bundle as bundle
+
+          bootstrap_bundle, bootstrap_policy, qualified_policy = map(Path, sys.argv[1:])
+          foundation_bytes = bundle.regular_bytes(
+              bootstrap_policy, bundle.MAX_JSON_BYTES, "bootstrap signature policy"
+          )
+          qualified = gate.load_json(qualified_policy, "qualified signature policy")
+          day = gate.parse_day(os.environ["SIGNING_DATE"], "signing date")
+          bundle.validate_bootstrap_binding(
+              bundle_root=bootstrap_bundle,
+              release=os.environ["RELEASE_TAG"],
+              repository=os.environ["GITHUB_REPOSITORY"],
+              foundation_release_sha=os.environ["BOOTSTRAP_RELEASE_SHA"],
+              foundation_policy_bytes=foundation_bytes,
+              foundation_policy_sha256=os.environ["BOOTSTRAP_POLICY_SHA256"],
+              qualified_policy=qualified,
+              qualified_release_sha=os.environ["RELEASE_SHA"],
+              signing_run_id=int(os.environ["BOOTSTRAP_SIGNING_RUN_ID"]),
+              artifact_id=int(os.environ["BOOTSTRAP_SIGNED_ARTIFACT_ID"]),
+              artifact_name=os.environ["BOOTSTRAP_ARTIFACT_NAME"],
+              artifact_size=int(os.environ["BOOTSTRAP_ARTIFACT_SIZE"]),
+              artifact_digest=os.environ["BOOTSTRAP_ARTIFACT_DIGEST"],
+              day=day,
+          )
+          PY
+          printf 'BOOTSTRAP_POLICY_PATH=%s\n' "${bootstrap_policy}" >> "${GITHUB_ENV}"
 
       - name: Resolve Exact Unsigned Package Run and Artifact
         id: unsigned
@@ -1040,6 +1239,13 @@ jobs:
         shell: bash
         env:
           APK_SIGNER_IMAGE: ${{ vars.SYSWARDEN_APK_SIGNER_IMAGE }}
+          BOOTSTRAP_ARTIFACT_DIGEST: ${{ steps.bootstrap.outputs.artifact_digest }}
+          BOOTSTRAP_ARTIFACT_NAME: ${{ steps.bootstrap.outputs.artifact_name }}
+          BOOTSTRAP_ARTIFACT_SIZE: ${{ steps.bootstrap.outputs.artifact_size }}
+          BOOTSTRAP_POLICY_SHA256: ${{ inputs.bootstrap_policy_sha256 }}
+          BOOTSTRAP_RELEASE_SHA: ${{ inputs.bootstrap_release_sha }}
+          BOOTSTRAP_SIGNING_RUN_ID: ${{ inputs.bootstrap_signing_run_id }}
+          BOOTSTRAP_SIGNED_ARTIFACT_ID: ${{ inputs.bootstrap_signed_artifact_id }}
           QUALIFICATION_MODE: ${{ inputs.qualification_mode }}
           RELEASE_SHA: ${{ inputs.release_sha }}
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -1055,9 +1261,22 @@ jobs:
           set -euo pipefail
           bundle_root="${SIGNING_ROOT}/bundle"
           bootstrap_args=()
+          prior_bootstrap_args=()
           if [[ "${QUALIFICATION_MODE}" == "bootstrap-qualification" ]]; then
             bootstrap_args+=(--bootstrap-qualification)
-          elif [[ "${QUALIFICATION_MODE}" != "qualified-policy" ]]; then
+          elif [[ "${QUALIFICATION_MODE}" == "qualified-policy" ]]; then
+            prior_bootstrap_args+=(
+              --bootstrap-bundle "${BOOTSTRAP_DIR}"
+              --bootstrap-release-sha "${BOOTSTRAP_RELEASE_SHA}"
+              --bootstrap-policy "${BOOTSTRAP_POLICY_PATH}"
+              --bootstrap-policy-sha256 "${BOOTSTRAP_POLICY_SHA256}"
+              --bootstrap-signing-run-id "${BOOTSTRAP_SIGNING_RUN_ID}"
+              --bootstrap-signed-artifact-id "${BOOTSTRAP_SIGNED_ARTIFACT_ID}"
+              --bootstrap-signed-artifact-name "${BOOTSTRAP_ARTIFACT_NAME}"
+              --bootstrap-signed-artifact-size "${BOOTSTRAP_ARTIFACT_SIZE}"
+              --bootstrap-signed-artifact-digest "${BOOTSTRAP_ARTIFACT_DIGEST}"
+            )
+          else
             echo "ERROR: native signing qualification mode is invalid." >&2
             exit 1
           fi
@@ -1087,13 +1306,23 @@ jobs:
             --deb-signature "${PROOF_DIR}/syswarden_${RELEASE_TAG#v}_amd64.deb.asc" \
             --deb-verification "${PROOF_DIR}/deb-verification.json" \
             "${bootstrap_args[@]}" \
+            "${prior_bootstrap_args[@]}" \
             --output "${bundle_root}"
+          verify_args=()
+          if [[ "${QUALIFICATION_MODE}" == "bootstrap-qualification" ]]; then
+            verify_args+=(--mode bootstrap)
+          fi
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/native_package_signing_bundle.py verify \
-            --bundle "${bundle_root}" --release "${RELEASE_TAG}" --release-sha "${RELEASE_SHA}"
+            --bundle "${bundle_root}" --release "${RELEASE_TAG}" \
+            --release-sha "${RELEASE_SHA}" "${verify_args[@]}"
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/repository_state.py \
             --repository "${GITHUB_WORKSPACE}" verify \
             --snapshot "${SIGNING_ROOT}/repository-state.json"
-          artifact_name="syswarden-native-signed-packages-${RELEASE_TAG#v}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"
+          if [[ "${QUALIFICATION_MODE}" == "bootstrap-qualification" ]]; then
+            artifact_name="syswarden-native-signed-packages-${RELEASE_TAG#v}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"
+          else
+            artifact_name="syswarden-native-signed-packages-qualified-${RELEASE_TAG#v}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"
+          fi
           printf 'artifact_name=%s\n' "${artifact_name}" >> "${GITHUB_OUTPUT}"
           printf 'bundle_root=%s\n' "${bundle_root}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/native-release-evidence.yml
+++ b/.github/workflows/native-release-evidence.yml
@@ -524,7 +524,7 @@ jobs:
           }
           if set(descriptor) != expected_top:
               raise SystemExit("candidate descriptor top-level fields are not exact")
-          expected_native_name = f"syswarden-native-signed-packages-{version}-{provenance['signing_run']['id']}-1-{release_sha}"
+          expected_native_name = f"syswarden-native-signed-packages-qualified-{version}-{provenance['signing_run']['id']}-1-{release_sha}"
           if not (
               descriptor["schema_version"] == 1
               and descriptor["profile"] == "syswarden-candidate-update-bundle/v1"
@@ -596,7 +596,7 @@ jobs:
           test "$(jq -er '.source.native_signing_run_id | tostring' "${candidate_descriptor}")" = \
             "$(jq -er '.signing_run.id | tostring' "${signing_provenance}")"
           test "$(jq -er '.source.native_signing_artifact_name' "${candidate_descriptor}")" = \
-            "syswarden-native-signed-packages-${candidate_version}-$(jq -er '.signing_run.id' "${signing_provenance}")-1-${RELEASE_SHA}"
+            "syswarden-native-signed-packages-qualified-${candidate_version}-$(jq -er '.signing_run.id' "${signing_provenance}")-1-${RELEASE_SHA}"
           declared_native_run_id="$(jq -er '.source.native_signing_run_id | tostring' \
             "${candidate_descriptor}")"
           declared_native_artifact_id="$(jq -er '.source.native_signing_artifact_id | tostring' \

--- a/.github/workflows/release-manager.yml
+++ b/.github/workflows/release-manager.yml
@@ -837,7 +837,7 @@ jobs:
             .native_signing_artifact_id > 0 and
             (.native_signing_artifact_name | type) == "string" and
             .native_signing_artifact_name ==
-              ("syswarden-native-signed-packages-" + ($release_tag | ltrimstr("v")) + "-" +
+              ("syswarden-native-signed-packages-qualified-" + ($release_tag | ltrimstr("v")) + "-" +
                (.native_signing_run_id | tostring) + "-1-" + $release_sha) and
             (.native_signing_artifact_digest | type) == "string" and
             (.native_signing_artifact_digest | test("^sha256:[0-9a-f]{64}$")) and
@@ -1513,7 +1513,7 @@ jobs:
             .native_signing_artifact_id > 0 and
             (.native_signing_artifact_name | type) == "string" and
             .native_signing_artifact_name ==
-              ("syswarden-native-signed-packages-" + ($release_tag | ltrimstr("v")) + "-" +
+              ("syswarden-native-signed-packages-qualified-" + ($release_tag | ltrimstr("v")) + "-" +
                (.native_signing_run_id | tostring) + "-1-" + $release_sha) and
             (.native_signing_artifact_digest | type) == "string" and
             (.native_signing_artifact_digest | test("^sha256:[0-9a-f]{64}$")) and

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -568,7 +568,7 @@ jobs:
             echo "ERROR: native package signing is not one completed successful attempt-1 run." >&2
             exit 1
           fi
-          artifact_name="syswarden-native-signed-packages-${version}-${run_id}-1-${RELEASE_SHA}"
+          artifact_name="syswarden-native-signed-packages-qualified-${version}-${run_id}-1-${RELEASE_SHA}"
           artifacts_json="$(gh api --paginate --slurp --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
             -f per_page=100)"

--- a/scripts/ci/candidate_update_bundle_workflow_test.py
+++ b/scripts/ci/candidate_update_bundle_workflow_test.py
@@ -169,7 +169,7 @@ class CandidateUpdateBundleWorkflowTests(unittest.TestCase):
             ".run_attempt == 1",
             '.status == "completed"',
             '.conclusion == "success"',
-            'expected_name="syswarden-native-signed-packages-${version}-${REQUESTED_RUN_ID}-1-${RELEASE_SHA}"',
+            'expected_name="syswarden-native-signed-packages-qualified-${version}-${REQUESTED_RUN_ID}-1-${RELEASE_SHA}"',
             '"repos/${GITHUB_REPOSITORY}/actions/runs/${REQUESTED_RUN_ID}/artifacts"',
             "[.[] | .artifacts[]?] | length",
             '.id == $id and .name == $name',

--- a/scripts/ci/native_package_signature_v4100.md
+++ b/scripts/ci/native_package_signature_v4100.md
@@ -2,8 +2,12 @@
 
 Status: the protected signing foundation and fail-closed publication
 integration are implemented. Three distinct candidate production public identities are
-enrolled under the non-publishing foundation policy. Bootstrap evidence,
-policy promotion, normal native proof and publication approval remain pending.
+enrolled under the non-publishing foundation policy. Phase 1 bootstrap
+qualification succeeded, and the exact immutable result recorded below is the
+foundation evidence for phase 2. The committed policy remains non-qualified
+until a distinct phase 2 `qualified-policy` run validates the permitted policy
+transition. Policy promotion, normal native proof and publication approval
+remain pending.
 No workflow in this foundation creates a private key.
 
 The offline gate binds one package byte stream to an exact release inventory
@@ -30,8 +34,9 @@ OpenPGP key. APK verification uses a private temporary key directory containing
 only the selected RSA public key. DEB verification uses isolated `gpgv` with a
 temporary keyring derived only from the selected OpenPGP public key. The
 repository policy contains exactly one candidate production public identity per
-package family, but remains intentionally non-qualified and non-publishing until phase
-1 succeeds. The APK signer is pinned to the
+package family. Phase 1 has succeeded, but the policy remains intentionally
+non-qualified and non-publishing until the separate reviewed phase 2 policy
+commit and `qualified-policy` run complete. The APK signer is pinned to the
 AMD64 manifest of the official Alpine Linux 3.24 build-base image at
 `docker.io/alpinelinux/build-base@sha256:31d2a020ccd2058e6ab47940428bd0b7dc83e37b66880891f9ed903a12ea668b`.
 It was reviewed as an offline runtime containing `abuild-sign`, `apk`, OpenSSL
@@ -72,6 +77,39 @@ signed bundle must be rebuilt from the new exact `main` SHA. A fresh
 `qualified-policy` run emits
 `native-signatures-verified-not-release-qualified`. Bootstrap package bytes and
 bootstrap evidence are never reused as phase 2 release evidence.
+
+Phase 2 is machine-bound to the reviewed phase 1 result. Its dispatch inputs
+must match the following immutable identity, which is also pinned independently
+in the workflow and bundle verifier:
+
+| Field | Exact value |
+| --- | --- |
+| Repository | `duggytuxy/syswarden` |
+| Source SHA | `9598861f1be80a651658bf3ca8c10424bd70db6c` |
+| Signing run | `34292701745`, attempt `1` |
+| Signed artifact ID | `10088398939` |
+| Signed artifact name | `syswarden-native-signed-packages-4.10.0-34292701745-1-9598861f1be80a651658bf3ca8c10424bd70db6c` |
+| Signed artifact size | `63065295` bytes |
+| Signed artifact digest | `sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3` |
+| Foundation policy SHA-256 | `6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d` |
+
+The workflow accepts only a completed successful
+`workflow_dispatch` attempt 1 owned by the repository owner, with one unexpired
+artifact whose ID, canonical bootstrap name, byte size, GitHub digest and source
+SHA all match this identity. The bootstrap SHA must be a distinct Git ancestor
+of the phase 2 SHA.
+The extracted foundation policy must have the immutable SHA-256
+`6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d`,
+matching both the dispatch input and bootstrap provenance.
+The policy transition permits only these changes:
+
+* `status`: `foundation-not-qualified` to `qualified`
+* `deb.implementation`: `implemented-not-qualified` to `qualified`
+* `publishing`: false to true when separately approved, or false to false
+
+Every key record, mechanism, signer image and other field must remain identical.
+The exact bootstrap run, artifact and foundation policy reference is sealed into
+both phase 2 provenance documents.
 
 ## Protected workflow
 
@@ -144,10 +182,13 @@ creation date to equal the qualification date.
 ## Immutable output contract
 
 The unique artifact name includes the release, signing run ID, attempt and
-release SHA. Artifact upload uses the immutable artifact protocol and no
-compression transformation. The workflow also requires the upload action to
-return a positive artifact ID and canonical GitHub SHA-256 digest. Its exact
-layout is:
+release SHA. The immutable Phase 1 workflow uses its historical canonical name,
+`syswarden-native-signed-packages-<version>-<run>-1-<sha>`. Phase 2 uses the
+distinct name
+`syswarden-native-signed-packages-qualified-<version>-<run>-1-<sha>`.
+Artifact upload uses the immutable artifact protocol and no compression
+transformation. The workflow also requires the upload action to return a
+positive artifact ID and canonical GitHub SHA-256 digest. Its exact layout is:
 
 ```text
 packages/
@@ -166,9 +207,11 @@ evidence/
 SIGNED_ARTIFACT_SHA256SUMS.txt
 ```
 
-`native_package_signing_bundle.py verify` recomputes the complete file seal,
-signed package manifest, source artifact binding, package transformations,
-selected-key evidence and release SHA. Phase 1 uses provenance status
+`native_package_signing_bundle.py verify` is qualified-only by default and
+recomputes the complete file seal, signed package manifest, source artifact
+binding, package transformations, selected-key evidence, bootstrap reference
+and release SHA. Phase 1 verification requires the explicit `--mode bootstrap`
+argument. Phase 1 uses provenance status
 `native-signatures-bootstrap-verified-not-release-qualified`; phase 2 uses
 `native-signatures-verified-not-release-qualified`. Both set
 `release_qualified` and `public_release` to false. A signed artifact is not a
@@ -287,7 +330,8 @@ remain mandatory before policy status or publishing approval can change.
 
 Qualification must resolve exactly one successful `qualified-policy` protected
 signing run for the release SHA, require the unique artifact ID and GitHub
-digest, download it by ID, execute `native_package_signing_bundle.py verify`,
+digest, require the canonical `qualified` artifact name, download it by ID,
+execute the default qualified-only `native_package_signing_bundle.py verify`,
 and independently rerun `native_package_signature_gate.py` for RPM, APK and
 DEB with purpose `qualification`. It requires provenance status
 `native-signatures-verified-not-release-qualified` and rejects bootstrap

--- a/scripts/ci/native_package_signing_bundle.py
+++ b/scripts/ci/native_package_signing_bundle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import datetime as dt
 import hashlib
 import io
@@ -37,6 +38,26 @@ QUALIFIED_PROVENANCE_STATUS = "native-signatures-verified-not-release-qualified"
 BOOTSTRAP_PROVENANCE_STATUS = (
     "native-signatures-bootstrap-verified-not-release-qualified"
 )
+BOOTSTRAP_REFERENCE_PROFILE = (
+    "syswarden-native-package-signing-bootstrap-reference/v4.10.0"
+)
+BOOTSTRAP_REPOSITORY = "duggytuxy/syswarden"
+BOOTSTRAP_RELEASE_SHA = "9598861f1be80a651658bf3ca8c10424bd70db6c"
+BOOTSTRAP_SIGNING_RUN_ID = 34292701745
+BOOTSTRAP_SIGNED_ARTIFACT_ID = 10088398939
+BOOTSTRAP_SIGNED_ARTIFACT_NAME = (
+    "syswarden-native-signed-packages-4.10.0-34292701745-1-"
+    "9598861f1be80a651658bf3ca8c10424bd70db6c"
+)
+BOOTSTRAP_SIGNED_ARTIFACT_SIZE = 63065295
+BOOTSTRAP_SIGNED_ARTIFACT_DIGEST = (
+    "sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3"
+)
+FOUNDATION_POLICY_SHA256 = (
+    "6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d"
+)
+QUALIFIED_BUNDLE_MODE = "qualified"
+BOOTSTRAP_BUNDLE_MODE = "bootstrap"
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
 GITHUB_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
@@ -172,6 +193,21 @@ def exact_keys(value: object, keys: set[str], label: str) -> dict[str, Any]:
     if not isinstance(value, dict) or set(value) != keys:
         fail(f"{label} keys are not exact")
     return value
+
+
+def exact_json_equal(left: object, right: object) -> bool:
+    if type(left) is not type(right):
+        return False
+    if type(left) is dict:
+        if set(left) != set(right):
+            return False
+        return all(exact_json_equal(left[key], right[key]) for key in left)
+    if type(left) is list:
+        return len(left) == len(right) and all(
+            exact_json_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return left == right
 
 
 def positive_integer(value: object, label: str) -> int:
@@ -751,6 +787,249 @@ def finalization_provenance_status(
     return BOOTSTRAP_PROVENANCE_STATUS
 
 
+def signed_artifact_name(
+    release: str,
+    mode: str,
+    run_id: int,
+    run_attempt: int,
+    release_sha: str,
+) -> str:
+    if mode not in {QUALIFIED_BUNDLE_MODE, BOOTSTRAP_BUNDLE_MODE}:
+        fail("native signing artifact mode is invalid")
+    positive_integer(run_id, "signing run ID")
+    positive_integer(run_attempt, "signing run attempt")
+    if run_attempt != 1:
+        fail("native signing artifact requires attempt 1")
+    if COMMIT_SHA.fullmatch(release_sha) is None:
+        fail("native signing artifact SHA is malformed")
+    package_names(release)
+    version = release.removeprefix("v")
+    if mode == BOOTSTRAP_BUNDLE_MODE:
+        # Phase A is already immutable. Preserve its exact historical artifact
+        # name so Phase B can consume the evidence that the ancestor produced.
+        return (
+            "syswarden-native-signed-packages-"
+            f"{version}-{run_id}-{run_attempt}-{release_sha}"
+        )
+    return (
+        "syswarden-native-signed-packages-qualified-"
+        f"{version}-{run_id}-{run_attempt}-{release_sha}"
+    )
+
+
+def validate_policy_transition(
+    foundation_policy_bytes: bytes,
+    qualified_policy: dict[str, Any],
+    expected_foundation_policy_sha256: str,
+    day: dt.date,
+) -> str:
+    if SHA256.fullmatch(expected_foundation_policy_sha256) is None:
+        fail("foundation policy SHA-256 is malformed")
+    if expected_foundation_policy_sha256 != FOUNDATION_POLICY_SHA256:
+        fail("foundation policy SHA-256 is not the immutable Phase A digest")
+    actual_foundation_digest = sha256(foundation_policy_bytes)
+    if actual_foundation_digest != expected_foundation_policy_sha256:
+        fail("foundation policy digest differs from the exact approved digest")
+    foundation_policy = signature_gate.decode_json(
+        foundation_policy_bytes, "foundation signature policy"
+    )
+    signature_gate.validate_policy(foundation_policy, day)
+    signature_gate.validate_policy(qualified_policy, day)
+    if (
+        foundation_policy["status"] != "foundation-not-qualified"
+        or foundation_policy["publishing"] is not False
+        or foundation_policy["deb"]["implementation"]
+        != "implemented-not-qualified"
+    ):
+        fail("bootstrap policy is not the exact non-publishing foundation state")
+    if (
+        qualified_policy["status"] != "qualified"
+        or qualified_policy["deb"]["implementation"] != "qualified"
+    ):
+        fail("current policy is not the exact qualified state")
+    expected_qualified = copy.deepcopy(foundation_policy)
+    expected_qualified["status"] = "qualified"
+    expected_qualified["deb"]["implementation"] = "qualified"
+    expected_qualified["publishing"] = qualified_policy["publishing"]
+    if not exact_json_equal(qualified_policy, expected_qualified):
+        fail("qualified policy changes fields outside the approved transition")
+    return actual_foundation_digest
+
+
+def validate_bootstrap_binding(
+    *,
+    bundle_root: Path,
+    release: str,
+    repository: str,
+    foundation_release_sha: str,
+    foundation_policy_bytes: bytes,
+    foundation_policy_sha256: str,
+    qualified_policy: dict[str, Any],
+    qualified_release_sha: str,
+    signing_run_id: int,
+    artifact_id: int,
+    artifact_name: str,
+    artifact_size: int,
+    artifact_digest: str,
+    day: dt.date,
+) -> dict[str, Any]:
+    if REPOSITORY.fullmatch(repository) is None:
+        fail("bootstrap repository identity is malformed")
+    if COMMIT_SHA.fullmatch(foundation_release_sha) is None:
+        fail("bootstrap release SHA is malformed")
+    if foundation_release_sha == qualified_release_sha:
+        fail("bootstrap and qualified release SHAs must be distinct")
+    positive_integer(signing_run_id, "bootstrap signing run ID")
+    positive_integer(artifact_id, "bootstrap signed artifact ID")
+    positive_integer(artifact_size, "bootstrap signed artifact size")
+    if GITHUB_DIGEST.fullmatch(artifact_digest) is None:
+        fail("bootstrap signed artifact digest is malformed")
+    expected_artifact_name = signed_artifact_name(
+        release,
+        BOOTSTRAP_BUNDLE_MODE,
+        signing_run_id,
+        1,
+        foundation_release_sha,
+    )
+    if artifact_name != expected_artifact_name:
+        fail("bootstrap signed artifact name is not canonical")
+    if (
+        repository != BOOTSTRAP_REPOSITORY
+        or foundation_release_sha != BOOTSTRAP_RELEASE_SHA
+        or signing_run_id != BOOTSTRAP_SIGNING_RUN_ID
+        or artifact_id != BOOTSTRAP_SIGNED_ARTIFACT_ID
+        or artifact_name != BOOTSTRAP_SIGNED_ARTIFACT_NAME
+        or artifact_size != BOOTSTRAP_SIGNED_ARTIFACT_SIZE
+        or artifact_digest != BOOTSTRAP_SIGNED_ARTIFACT_DIGEST
+    ):
+        fail("bootstrap evidence is not the exact reviewed Phase A result")
+    policy_digest = validate_policy_transition(
+        foundation_policy_bytes,
+        qualified_policy,
+        foundation_policy_sha256,
+        day,
+    )
+    verify_bundle(
+        bundle_root,
+        release,
+        foundation_release_sha,
+        mode=BOOTSTRAP_BUNDLE_MODE,
+    )
+    provenance = load_json(
+        bundle_root / "evidence" / "NATIVE_SIGNING_PROVENANCE.json",
+        "bootstrap native signing provenance",
+    )
+    signing_run = provenance["signing_run"]
+    if (
+        provenance["repository"] != repository
+        or provenance["policy_sha256"] != policy_digest
+        or provenance["source"]["release_sha"] != foundation_release_sha
+        or signing_run["id"] != signing_run_id
+        or signing_run["attempt"] != 1
+        or signing_run["workflow"]
+        != ".github/workflows/native-package-signing.yml"
+        or signing_run["workflow_sha"] != foundation_release_sha
+    ):
+        fail("bootstrap bundle differs from the exact prior signing run")
+    return {
+        "artifact": {
+            "digest": artifact_digest,
+            "id": artifact_id,
+            "name": artifact_name,
+            "size": artifact_size,
+        },
+        "policy_sha256": policy_digest,
+        "profile": BOOTSTRAP_REFERENCE_PROFILE,
+        "repository": repository,
+        "release_sha": foundation_release_sha,
+        "schema_version": 1,
+        "signing_run": {
+            "attempt": 1,
+            "id": signing_run_id,
+            "workflow": ".github/workflows/native-package-signing.yml",
+            "workflow_sha": foundation_release_sha,
+        },
+    }
+
+
+def validate_bootstrap_reference(
+    reference: object,
+    release: str,
+    qualified_release_sha: str,
+    repository: str,
+) -> dict[str, Any]:
+    checked = exact_keys(
+        reference,
+        {
+            "artifact",
+            "policy_sha256",
+            "profile",
+            "repository",
+            "release_sha",
+            "schema_version",
+            "signing_run",
+        },
+        "bootstrap qualification reference",
+    )
+    if (
+        type(checked["schema_version"]) is not int
+        or checked["schema_version"] != 1
+        or checked["profile"] != BOOTSTRAP_REFERENCE_PROFILE
+        or not isinstance(checked["repository"], str)
+        or REPOSITORY.fullmatch(checked["repository"]) is None
+        or checked["repository"] != repository
+        or checked["repository"] != BOOTSTRAP_REPOSITORY
+        or not isinstance(checked["release_sha"], str)
+        or COMMIT_SHA.fullmatch(checked["release_sha"]) is None
+        or checked["release_sha"] == qualified_release_sha
+        or checked["release_sha"] != BOOTSTRAP_RELEASE_SHA
+        or not isinstance(checked["policy_sha256"], str)
+        or SHA256.fullmatch(checked["policy_sha256"]) is None
+        or checked["policy_sha256"] != FOUNDATION_POLICY_SHA256
+    ):
+        fail("bootstrap qualification reference identity is invalid")
+    signing_run = exact_keys(
+        checked["signing_run"],
+        {"attempt", "id", "workflow", "workflow_sha"},
+        "bootstrap signing run reference",
+    )
+    if (
+        type(signing_run["attempt"]) is not int
+        or signing_run["attempt"] != 1
+        or signing_run["workflow"]
+        != ".github/workflows/native-package-signing.yml"
+        or signing_run["workflow_sha"] != checked["release_sha"]
+        or signing_run["id"] != BOOTSTRAP_SIGNING_RUN_ID
+    ):
+        fail("bootstrap signing run reference is invalid")
+    positive_integer(signing_run["id"], "bootstrap signing run ID")
+    artifact = exact_keys(
+        checked["artifact"],
+        {"digest", "id", "name", "size"},
+        "bootstrap signed artifact reference",
+    )
+    positive_integer(artifact["id"], "bootstrap signed artifact ID")
+    positive_integer(artifact["size"], "bootstrap signed artifact size")
+    if (
+        not isinstance(artifact["digest"], str)
+        or GITHUB_DIGEST.fullmatch(artifact["digest"]) is None
+        or artifact["id"] != BOOTSTRAP_SIGNED_ARTIFACT_ID
+        or artifact["size"] != BOOTSTRAP_SIGNED_ARTIFACT_SIZE
+        or artifact["digest"] != BOOTSTRAP_SIGNED_ARTIFACT_DIGEST
+        or artifact["name"] != BOOTSTRAP_SIGNED_ARTIFACT_NAME
+        or artifact["name"]
+        != signed_artifact_name(
+            release,
+            BOOTSTRAP_BUNDLE_MODE,
+            signing_run["id"],
+            1,
+            checked["release_sha"],
+        )
+    ):
+        fail("bootstrap signed artifact reference is invalid")
+    return checked
+
+
 def finalize(args: argparse.Namespace) -> None:
     release = args.release
     names = package_names(release)
@@ -783,6 +1062,25 @@ def finalize(args: argparse.Namespace) -> None:
     positive_integer(args.source_date_epoch, "source date epoch")
     if OCI_DIGEST.fullmatch(args.signer_image) is None:
         fail("APK signer image must be pinned by SHA-256 digest")
+    bootstrap_fields = (
+        "bootstrap_bundle",
+        "bootstrap_release_sha",
+        "bootstrap_policy",
+        "bootstrap_policy_sha256",
+        "bootstrap_signing_run_id",
+        "bootstrap_signed_artifact_id",
+        "bootstrap_signed_artifact_name",
+        "bootstrap_signed_artifact_size",
+        "bootstrap_signed_artifact_digest",
+    )
+    supplied_bootstrap_fields = {
+        field for field in bootstrap_fields if getattr(args, field) is not None
+    }
+    if args.bootstrap_qualification:
+        if supplied_bootstrap_fields:
+            fail("bootstrap mode cannot claim a prior bootstrap qualification")
+    elif supplied_bootstrap_fields != set(bootstrap_fields):
+        fail("qualified mode requires one complete prior bootstrap qualification")
 
     unsigned = package_set(args.unsigned_packages, release, require_manifest=True)
     signed = package_set(args.signed_packages, release, require_manifest=True)
@@ -842,6 +1140,31 @@ def finalize(args: argparse.Namespace) -> None:
     if policy_document["apk"]["signer_image"] != args.signer_image:
         fail("APK signer image differs from the committed signature policy")
     policy_digest = sha256(policy_bytes)
+    bootstrap_reference: dict[str, Any] | None = None
+    if not args.bootstrap_qualification:
+        if args.bootstrap_signing_run_id == args.signing_run_id:
+            fail("bootstrap and qualified signing run IDs must be distinct")
+        foundation_policy_bytes = regular_bytes(
+            args.bootstrap_policy,
+            MAX_JSON_BYTES,
+            "bootstrap signature policy",
+        )
+        bootstrap_reference = validate_bootstrap_binding(
+            bundle_root=args.bootstrap_bundle,
+            release=release,
+            repository=args.repository,
+            foundation_release_sha=args.bootstrap_release_sha,
+            foundation_policy_bytes=foundation_policy_bytes,
+            foundation_policy_sha256=args.bootstrap_policy_sha256,
+            qualified_policy=policy_document,
+            qualified_release_sha=args.release_sha,
+            signing_run_id=args.bootstrap_signing_run_id,
+            artifact_id=args.bootstrap_signed_artifact_id,
+            artifact_name=args.bootstrap_signed_artifact_name,
+            artifact_size=args.bootstrap_signed_artifact_size,
+            artifact_digest=args.bootstrap_signed_artifact_digest,
+            day=day,
+        )
     rpm_verification = load_json(args.rpm_verification, "RPM verification evidence")
     rhel_rpm_verification = load_json(
         args.rhel_rpm_verification,
@@ -989,6 +1312,8 @@ def finalize(args: argparse.Namespace) -> None:
         },
         "status": provenance_status,
     }
+    if bootstrap_reference is not None:
+        provenance["bootstrap_qualification"] = bootstrap_reference
     write_json(evidence_output / "NATIVE_SIGNING_PROVENANCE.json", provenance)
 
     (
@@ -1047,6 +1372,8 @@ def finalize(args: argparse.Namespace) -> None:
         "status": provenance_status,
         "updater_manifest_included": False,
     }
+    if bootstrap_reference is not None:
+        rhel_provenance["bootstrap_qualification"] = bootstrap_reference
     write_json(
         rhel_evidence_output / "SIGNING_PROVENANCE.json", rhel_provenance
     )
@@ -1080,7 +1407,16 @@ def finalize(args: argparse.Namespace) -> None:
         args.output / "SIGNED_ARTIFACT_SHA256SUMS.txt",
         canonical_manifest(members),
     )
-    verify_bundle(args.output, release, args.release_sha)
+    verify_bundle(
+        args.output,
+        release,
+        args.release_sha,
+        mode=(
+            BOOTSTRAP_BUNDLE_MODE
+            if args.bootstrap_qualification
+            else QUALIFIED_BUNDLE_MODE
+        ),
+    )
 
 
 def expected_bundle_files(release: str) -> tuple[set[str], set[str]]:
@@ -1127,28 +1463,32 @@ def verify_rhel_package_owned_bundle(
         entries["evidence"] / "SIGNING_PROVENANCE.json",
         "RHEL package-owned signing provenance",
     )
+    expected_provenance_keys = {
+        "package_role",
+        "packages",
+        "policy_sha256",
+        "profile",
+        "public_release",
+        "release_qualified",
+        "repository",
+        "rpm_identity",
+        "rpm_signature",
+        "schema_version",
+        "signing_run",
+        "source",
+        "status",
+        "updater_manifest_included",
+    }
+    if standard_provenance["status"] == QUALIFIED_PROVENANCE_STATUS:
+        expected_provenance_keys.add("bootstrap_qualification")
     exact_keys(
         provenance,
-        {
-            "package_role",
-            "packages",
-            "policy_sha256",
-            "profile",
-            "public_release",
-            "release_qualified",
-            "repository",
-            "rpm_identity",
-            "rpm_signature",
-            "schema_version",
-            "signing_run",
-            "source",
-            "status",
-            "updater_manifest_included",
-        },
+        expected_provenance_keys,
         "RHEL package-owned signing provenance",
     )
     if (
-        provenance["schema_version"] != 1
+        type(provenance["schema_version"]) is not int
+        or provenance["schema_version"] != 1
         or provenance["profile"] != RHEL_PACKAGE_OWNED_PROFILE
         or provenance["status"] != standard_provenance["status"]
         or provenance["package_role"] != "rhel-package-owned"
@@ -1157,9 +1497,24 @@ def verify_rhel_package_owned_bundle(
         or provenance["updater_manifest_included"] is not False
         or provenance["policy_sha256"] != standard_provenance["policy_sha256"]
         or provenance["repository"] != standard_provenance["repository"]
-        or provenance["signing_run"] != standard_provenance["signing_run"]
+        or not exact_json_equal(
+            provenance["signing_run"], standard_provenance["signing_run"]
+        )
     ):
         fail("RHEL package-owned signing provenance identity is invalid")
+    if standard_provenance["status"] == QUALIFIED_PROVENANCE_STATUS:
+        reference = validate_bootstrap_reference(
+            provenance["bootstrap_qualification"],
+            release,
+            release_sha,
+            standard_provenance["repository"],
+        )
+        if not exact_json_equal(
+            reference, standard_provenance["bootstrap_qualification"]
+        ):
+            fail(
+                "RHEL package-owned bootstrap reference differs from the standard bundle"
+            )
     identity = exact_keys(
         provenance["rpm_identity"],
         {"architecture", "filename", "name", "release", "version"},
@@ -1276,9 +1631,16 @@ def verify_rhel_package_owned_bundle(
     )
 
 
-def verify_bundle(root: Path, release: str, release_sha: str) -> None:
+def verify_bundle(
+    root: Path,
+    release: str,
+    release_sha: str,
+    mode: str = QUALIFIED_BUNDLE_MODE,
+) -> None:
     if COMMIT_SHA.fullmatch(release_sha) is None:
         fail("expected release SHA is malformed")
+    if mode not in {QUALIFIED_BUNDLE_MODE, BOOTSTRAP_BUNDLE_MODE}:
+        fail("signed bundle verification mode is invalid")
     ensure_real_directory(root, "signed bundle")
     entries = {entry.name: entry for entry in root.iterdir()}
     if set(entries) != {
@@ -1318,35 +1680,47 @@ def verify_bundle(root: Path, release: str, release_sha: str) -> None:
         entries["evidence"] / "NATIVE_SIGNING_PROVENANCE.json",
         "native signing provenance",
     )
+    expected_provenance_keys = {
+        "apk_signature",
+        "deb_signature",
+        "packages",
+        "policy_sha256",
+        "profile",
+        "public_release",
+        "release_qualified",
+        "repository",
+        "rpm_signature",
+        "schema_version",
+        "signer_image",
+        "signing_run",
+        "source",
+        "status",
+    }
+    expected_status = BOOTSTRAP_PROVENANCE_STATUS
+    if mode == QUALIFIED_BUNDLE_MODE:
+        expected_provenance_keys.add("bootstrap_qualification")
+        expected_status = QUALIFIED_PROVENANCE_STATUS
     exact_keys(
         provenance,
-        {
-            "apk_signature",
-            "deb_signature",
-            "packages",
-            "policy_sha256",
-            "profile",
-            "public_release",
-            "release_qualified",
-            "repository",
-            "rpm_signature",
-            "schema_version",
-            "signer_image",
-            "signing_run",
-            "source",
-            "status",
-        },
+        expected_provenance_keys,
         "native signing provenance",
     )
     if (
-        provenance["schema_version"] != 1
+        type(provenance["schema_version"]) is not int
+        or provenance["schema_version"] != 1
         or provenance["profile"] != SCHEMA_PROFILE
-        or provenance["status"]
-        not in {QUALIFIED_PROVENANCE_STATUS, BOOTSTRAP_PROVENANCE_STATUS}
+        or provenance["status"] != expected_status
         or provenance["release_qualified"] is not False
         or provenance["public_release"] is not False
     ):
         fail("native signing provenance identity is invalid")
+    if mode == QUALIFIED_BUNDLE_MODE:
+        validate_bootstrap_reference(
+            provenance["bootstrap_qualification"],
+            release,
+            release_sha,
+            provenance["repository"],
+        )
     if (
         not isinstance(provenance["policy_sha256"], str)
         or SHA256.fullmatch(provenance["policy_sha256"]) is None
@@ -1387,7 +1761,9 @@ def verify_bundle(root: Path, release: str, release_sha: str) -> None:
         "signing run binding",
     )
     if (
-        signing_run["workflow"] != ".github/workflows/native-package-signing.yml"
+        type(signing_run["attempt"]) is not int
+        or signing_run["workflow"]
+        != ".github/workflows/native-package-signing.yml"
         or signing_run["workflow_sha"] != release_sha
         or signing_run["attempt"] != 1
     ):
@@ -1655,6 +2031,15 @@ def main(argv: list[str] | None = None) -> int:
         "--purpose", choices=("qualification", "publishing"), default="qualification"
     )
     final.add_argument("--bootstrap-qualification", action="store_true")
+    final.add_argument("--bootstrap-bundle", type=Path)
+    final.add_argument("--bootstrap-release-sha")
+    final.add_argument("--bootstrap-policy", type=Path)
+    final.add_argument("--bootstrap-policy-sha256")
+    final.add_argument("--bootstrap-signing-run-id", type=int)
+    final.add_argument("--bootstrap-signed-artifact-id", type=int)
+    final.add_argument("--bootstrap-signed-artifact-name")
+    final.add_argument("--bootstrap-signed-artifact-size", type=int)
+    final.add_argument("--bootstrap-signed-artifact-digest")
     final.add_argument("--rpm-proof", required=True, type=Path)
     final.add_argument("--rpm-verification", required=True, type=Path)
     final.add_argument("--rhel-rpm-proof", required=True, type=Path)
@@ -1668,6 +2053,11 @@ def main(argv: list[str] | None = None) -> int:
     verify.add_argument("--bundle", required=True, type=Path)
     verify.add_argument("--release", required=True)
     verify.add_argument("--release-sha", required=True)
+    verify.add_argument(
+        "--mode",
+        choices=(QUALIFIED_BUNDLE_MODE, BOOTSTRAP_BUNDLE_MODE),
+        default=QUALIFIED_BUNDLE_MODE,
+    )
 
     args = parser.parse_args(argv)
     try:
@@ -1682,7 +2072,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "finalize":
             finalize(args)
         else:
-            verify_bundle(args.bundle, args.release, args.release_sha)
+            verify_bundle(args.bundle, args.release, args.release_sha, args.mode)
     except (SigningBundleError, signature_gate.SignatureGateError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/scripts/ci/native_package_signing_bundle_test.py
+++ b/scripts/ci/native_package_signing_bundle_test.py
@@ -8,6 +8,7 @@ import gzip
 import io
 import json
 import os
+import shutil
 import tempfile
 import tarfile
 import unittest
@@ -138,8 +139,39 @@ class NativePackageSigningBundleTests(unittest.TestCase):
             self.deb_fingerprint,
             hashlib.sha256(self.deb_public.read_bytes()).hexdigest(),
         )
+        self.bootstrap_release_sha = bundle.BOOTSTRAP_RELEASE_SHA
+        self.bootstrap_signing_run_id = bundle.BOOTSTRAP_SIGNING_RUN_ID
+        self.bootstrap_signed_artifact_id = bundle.BOOTSTRAP_SIGNED_ARTIFACT_ID
+        self.bootstrap_signed_artifact_size = bundle.BOOTSTRAP_SIGNED_ARTIFACT_SIZE
+        self.bootstrap_signed_artifact_digest = (
+            bundle.BOOTSTRAP_SIGNED_ARTIFACT_DIGEST
+        )
+        self.bootstrap_policy = self.root / "bootstrap-policy.json"
+        foundation = self.policy_document("foundation-not-qualified")
+        foundation["deb"]["implementation"] = "implemented-not-qualified"
+        self.write_json(self.bootstrap_policy, foundation)
+        self.original_foundation_policy_sha256 = bundle.FOUNDATION_POLICY_SHA256
+        bundle.FOUNDATION_POLICY_SHA256 = hashlib.sha256(
+            self.bootstrap_policy.read_bytes()
+        ).hexdigest()
+        self.write_bootstrap_policy(json.loads(json.dumps(foundation)))
+        self.bootstrap_bundle = self.root / "bootstrap-bundle"
+        bootstrap_arguments = list(
+            self.finalize_arguments(
+                self.bootstrap_bundle,
+                include_bootstrap=False,
+                release_sha=self.bootstrap_release_sha,
+                signing_run_id=self.bootstrap_signing_run_id,
+            )
+        )
+        bootstrap_arguments.append("--bootstrap-qualification")
+        if bundle.main(tuple(bootstrap_arguments)) != 0:
+            raise AssertionError("bootstrap bundle fixture could not be created")
+        self.write_policy()
+        self.rewrite_verification_evidence()
 
     def tearDown(self) -> None:
+        bundle.FOUNDATION_POLICY_SHA256 = self.original_foundation_policy_sha256
         self.temporary.cleanup()
 
     @staticmethod
@@ -494,13 +526,21 @@ class NativePackageSigningBundleTests(unittest.TestCase):
             }
         self.write_json(path, document)
 
-    def finalize_arguments(self, output: Path | None = None) -> tuple[str, ...]:
-        return (
+    def finalize_arguments(
+        self,
+        output: Path | None = None,
+        *,
+        include_bootstrap: bool = True,
+        release_sha: str | None = None,
+        signing_run_id: int = 300,
+    ) -> tuple[str, ...]:
+        selected_release_sha = release_sha or self.release_sha
+        arguments = [
             "finalize",
             "--release",
             self.release,
             "--release-sha",
-            self.release_sha,
+            selected_release_sha,
             "--repository",
             "duggytuxy/syswarden",
             "--unsigned-packages",
@@ -526,11 +566,11 @@ class NativePackageSigningBundleTests(unittest.TestCase):
             "--rhel-unsigned-artifact-digest",
             "sha256:" + "6" * 64,
             "--signing-run-id",
-            "300",
+            str(signing_run_id),
             "--signing-run-attempt",
             "1",
             "--signing-workflow-sha",
-            self.release_sha,
+            selected_release_sha,
             "--source-date-epoch",
             "1780000000",
             "--signer-image",
@@ -553,9 +593,62 @@ class NativePackageSigningBundleTests(unittest.TestCase):
             str(self.deb_signature),
             "--deb-verification",
             str(self.deb_verification),
-            "--output",
-            str(output or (self.root / "bundle")),
-        )
+        ]
+        if include_bootstrap:
+            arguments.extend(
+                (
+                    "--bootstrap-bundle",
+                    str(self.bootstrap_bundle),
+                    "--bootstrap-release-sha",
+                    self.bootstrap_release_sha,
+                    "--bootstrap-policy",
+                    str(self.bootstrap_policy),
+                    "--bootstrap-policy-sha256",
+                    hashlib.sha256(self.bootstrap_policy.read_bytes()).hexdigest(),
+                    "--bootstrap-signing-run-id",
+                    str(self.bootstrap_signing_run_id),
+                    "--bootstrap-signed-artifact-id",
+                    str(self.bootstrap_signed_artifact_id),
+                    "--bootstrap-signed-artifact-name",
+                    bundle.signed_artifact_name(
+                        self.release,
+                        bundle.BOOTSTRAP_BUNDLE_MODE,
+                        self.bootstrap_signing_run_id,
+                        1,
+                        self.bootstrap_release_sha,
+                    ),
+                    "--bootstrap-signed-artifact-size",
+                    str(self.bootstrap_signed_artifact_size),
+                    "--bootstrap-signed-artifact-digest",
+                    self.bootstrap_signed_artifact_digest,
+                )
+            )
+        arguments.extend(("--output", str(output or (self.root / "bundle"))))
+        return tuple(arguments)
+
+    @staticmethod
+    def replace_argument(
+        arguments: tuple[str, ...], option: str, value: str
+    ) -> tuple[str, ...]:
+        changed = list(arguments)
+        changed[changed.index(option) + 1] = value
+        return tuple(changed)
+
+    @staticmethod
+    def reseal_bundle(root: Path) -> None:
+        rhel_root = root / bundle.RHEL_PACKAGE_OWNED_DIRECTORY
+        for seal_root in (rhel_root, root):
+            members = {}
+            for child in sorted(seal_root.rglob("*")):
+                if child.is_dir():
+                    continue
+                relative = child.relative_to(seal_root).as_posix()
+                if relative == "SIGNED_ARTIFACT_SHA256SUMS.txt":
+                    continue
+                members[relative] = child.read_bytes()
+            (seal_root / "SIGNED_ARTIFACT_SHA256SUMS.txt").write_bytes(
+                bundle.canonical_manifest(members)
+            )
 
     def test_finalize_and_verify_exact_bundle(self) -> None:
         output = self.root / "bundle"
@@ -580,6 +673,15 @@ class NativePackageSigningBundleTests(unittest.TestCase):
         self.assertEqual(provenance["status"], bundle.QUALIFIED_PROVENANCE_STATUS)
         self.assertFalse(provenance["public_release"])
         self.assertFalse(provenance["release_qualified"])
+        reference = provenance["bootstrap_qualification"]
+        self.assertEqual(reference["release_sha"], self.bootstrap_release_sha)
+        self.assertEqual(reference["signing_run"]["id"], self.bootstrap_signing_run_id)
+        self.assertEqual(
+            reference["artifact"]["id"], self.bootstrap_signed_artifact_id
+        )
+        self.assertEqual(
+            reference["artifact"]["size"], self.bootstrap_signed_artifact_size
+        )
         self.assertTrue(provenance["apk_signature"]["exact_unsigned_suffix"])
         self.assertTrue(provenance["rpm_signature"]["payload_preserved"])
         deb_verification = json.loads(
@@ -604,6 +706,32 @@ class NativePackageSigningBundleTests(unittest.TestCase):
         self.assertEqual(
             rhel_provenance["rpm_signature"]["key"],
             provenance["rpm_signature"]["key"],
+        )
+        self.assertEqual(rhel_provenance["bootstrap_qualification"], reference)
+
+    def test_phase_a_policy_digest_is_immutable(self) -> None:
+        self.assertEqual(
+            self.original_foundation_policy_sha256,
+            "6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d",
+        )
+
+    def test_reviewed_phase_a_bootstrap_identity_is_immutable(self) -> None:
+        self.assertEqual(bundle.BOOTSTRAP_REPOSITORY, "duggytuxy/syswarden")
+        self.assertEqual(
+            bundle.BOOTSTRAP_RELEASE_SHA,
+            "9598861f1be80a651658bf3ca8c10424bd70db6c",
+        )
+        self.assertEqual(bundle.BOOTSTRAP_SIGNING_RUN_ID, 34292701745)
+        self.assertEqual(bundle.BOOTSTRAP_SIGNED_ARTIFACT_ID, 10088398939)
+        self.assertEqual(bundle.BOOTSTRAP_SIGNED_ARTIFACT_SIZE, 63065295)
+        self.assertEqual(
+            bundle.BOOTSTRAP_SIGNED_ARTIFACT_NAME,
+            "syswarden-native-signed-packages-4.10.0-34292701745-1-"
+            "9598861f1be80a651658bf3ca8c10424bd70db6c",
+        )
+        self.assertEqual(
+            bundle.BOOTSTRAP_SIGNED_ARTIFACT_DIGEST,
+            "sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3",
         )
 
     def test_inventory_is_exact_and_bound(self) -> None:
@@ -744,8 +872,8 @@ class NativePackageSigningBundleTests(unittest.TestCase):
 
     def test_explicit_bootstrap_qualification_is_sealed_and_verifiable(self) -> None:
         self.write_bootstrap_policy()
-        output = self.root / "bootstrap-bundle"
-        arguments = list(self.finalize_arguments(output))
+        output = self.root / "bootstrap-bundle-explicit"
+        arguments = list(self.finalize_arguments(output, include_bootstrap=False))
         arguments.append("--bootstrap-qualification")
         self.assertEqual(bundle.main(tuple(arguments)), 0)
         self.assertEqual(
@@ -758,6 +886,8 @@ class NativePackageSigningBundleTests(unittest.TestCase):
                     self.release,
                     "--release-sha",
                     self.release_sha,
+                    "--mode",
+                    "bootstrap",
                 )
             ),
             0,
@@ -768,6 +898,239 @@ class NativePackageSigningBundleTests(unittest.TestCase):
         self.assertEqual(provenance["status"], bundle.BOOTSTRAP_PROVENANCE_STATUS)
         self.assertFalse(provenance["public_release"])
         self.assertFalse(provenance["release_qualified"])
+
+    def test_bundle_verification_is_qualified_only_by_default(self) -> None:
+        self.assertEqual(
+            bundle.main(
+                (
+                    "verify",
+                    "--bundle",
+                    str(self.bootstrap_bundle),
+                    "--release",
+                    self.release,
+                    "--release-sha",
+                    self.bootstrap_release_sha,
+                )
+            ),
+            1,
+        )
+        self.assertEqual(
+            bundle.main(
+                (
+                    "verify",
+                    "--bundle",
+                    str(self.bootstrap_bundle),
+                    "--release",
+                    self.release,
+                    "--release-sha",
+                    self.bootstrap_release_sha,
+                    "--mode",
+                    "bootstrap",
+                )
+            ),
+            0,
+        )
+
+    def test_bundle_provenance_integer_types_fail_closed(self) -> None:
+        cases = (
+            ("evidence/NATIVE_SIGNING_PROVENANCE.json", "signing-attempt"),
+            (
+                "rhel-package-owned/evidence/SIGNING_PROVENANCE.json",
+                "schema-version",
+            ),
+        )
+        for index, (relative, field) in enumerate(cases):
+            with self.subTest(field=field):
+                output = self.root / f"provenance-integer-type-{index}"
+                shutil.copytree(self.bootstrap_bundle, output)
+                path = output / relative
+                document = json.loads(path.read_text(encoding="utf-8"))
+                if field == "signing-attempt":
+                    document["signing_run"]["attempt"] = True
+                else:
+                    document["schema_version"] = True
+                self.write_json(path, document)
+                self.reseal_bundle(output)
+                self.assertEqual(
+                    bundle.main(
+                        (
+                            "verify",
+                            "--bundle",
+                            str(output),
+                            "--release",
+                            self.release,
+                            "--release-sha",
+                            self.bootstrap_release_sha,
+                            "--mode",
+                            "bootstrap",
+                        )
+                    ),
+                    1,
+                )
+
+    def test_qualified_mode_requires_every_exact_bootstrap_binding(self) -> None:
+        bootstrap_options = (
+            "--bootstrap-bundle",
+            "--bootstrap-release-sha",
+            "--bootstrap-policy",
+            "--bootstrap-policy-sha256",
+            "--bootstrap-signing-run-id",
+            "--bootstrap-signed-artifact-id",
+            "--bootstrap-signed-artifact-name",
+            "--bootstrap-signed-artifact-size",
+            "--bootstrap-signed-artifact-digest",
+        )
+        for index, option in enumerate(bootstrap_options):
+            with self.subTest(option=option):
+                arguments = list(
+                    self.finalize_arguments(self.root / f"missing-bootstrap-{index}")
+                )
+                position = arguments.index(option)
+                del arguments[position : position + 2]
+                self.assertEqual(bundle.main(tuple(arguments)), 1)
+
+    def test_qualified_mode_rejects_wrong_bootstrap_identities(self) -> None:
+        mutations = (
+            ("--bootstrap-release-sha", self.release_sha),
+            ("--bootstrap-policy-sha256", "0" * 64),
+            ("--bootstrap-signing-run-id", "300"),
+            ("--bootstrap-signed-artifact-id", "0"),
+            (
+                "--bootstrap-signed-artifact-id",
+                str(self.bootstrap_signed_artifact_id + 1),
+            ),
+            (
+                "--bootstrap-signed-artifact-size",
+                str(self.bootstrap_signed_artifact_size + 1),
+            ),
+            (
+                "--bootstrap-signed-artifact-name",
+                "syswarden-native-signed-packages-qualified-4.10.0-250-1-"
+                + self.bootstrap_release_sha,
+            ),
+            (
+                "--bootstrap-signed-artifact-name",
+                "syswarden-native-signed-packages-bootstrap-4.10.0-250-1-"
+                + self.bootstrap_release_sha,
+            ),
+            ("--bootstrap-signed-artifact-digest", "sha256:" + "0" * 63),
+            ("--bootstrap-signed-artifact-digest", "sha256:" + "0" * 64),
+        )
+        for index, (option, value) in enumerate(mutations):
+            with self.subTest(option=option):
+                arguments = self.finalize_arguments(
+                    self.root / f"wrong-bootstrap-{index}"
+                )
+                arguments = self.replace_argument(arguments, option, value)
+                self.assertEqual(bundle.main(arguments), 1)
+
+    def test_sealed_bootstrap_reference_schema_fails_closed(self) -> None:
+        output = self.root / "reference-schema"
+        self.assertEqual(bundle.main(self.finalize_arguments(output)), 0)
+        provenance = json.loads(
+            (output / "evidence/NATIVE_SIGNING_PROVENANCE.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        reference = provenance["bootstrap_qualification"]
+        self.assertEqual(
+            bundle.validate_bootstrap_reference(
+                reference, self.release, self.release_sha, "duggytuxy/syswarden"
+            ),
+            reference,
+        )
+        mutations = (
+            lambda value: value.__setitem__("unexpected", True),
+            lambda value: value.__setitem__("schema_version", True),
+            lambda value: value.__setitem__("release_sha", self.release_sha),
+            lambda value: value.__setitem__("repository", "other/repository"),
+            lambda value: value.__setitem__("policy_sha256", "0" * 64),
+            lambda value: value["signing_run"].__setitem__("attempt", 2),
+            lambda value: value["signing_run"].__setitem__("attempt", True),
+            lambda value: value["signing_run"].__setitem__(
+                "workflow_sha", "c" * 40
+            ),
+            lambda value: value["artifact"].__setitem__("id", 0),
+            lambda value: value["artifact"].__setitem__(
+                "id", self.bootstrap_signed_artifact_id + 1
+            ),
+            lambda value: value["artifact"].__setitem__("size", True),
+            lambda value: value["artifact"].__setitem__(
+                "size", self.bootstrap_signed_artifact_size + 1
+            ),
+            lambda value: value["artifact"].__setitem__(
+                "name", "syswarden-native-signed-packages-qualified"
+            ),
+            lambda value: value["artifact"].__setitem__(
+                "digest", "sha256:" + "0" * 63
+            ),
+            lambda value: value["artifact"].__setitem__(
+                "digest", "sha256:" + "0" * 64
+            ),
+        )
+        for index, mutate in enumerate(mutations):
+            with self.subTest(index=index):
+                changed = json.loads(json.dumps(reference))
+                mutate(changed)
+                with self.assertRaises(bundle.SigningBundleError):
+                    bundle.validate_bootstrap_reference(
+                        changed,
+                        self.release,
+                        self.release_sha,
+                        "duggytuxy/syswarden",
+                    )
+
+    def test_policy_transition_allows_only_the_reviewed_state_changes(self) -> None:
+        qualified = self.policy_document("qualified")
+        qualified["publishing"] = True
+        self.write_json(self.policy, qualified)
+        self.rewrite_verification_evidence()
+        self.assertEqual(
+            bundle.main(
+                self.finalize_arguments(self.root / "qualified-publishing-enabled")
+            ),
+            0,
+        )
+
+        mutations = (
+            (
+                "schema-version-type",
+                lambda document: document.__setitem__("schema_version", True),
+            ),
+            (
+                "key-validity",
+                lambda document: document["rpm"]["trusted_keys"][0].__setitem__(
+                    "valid_until", "2027-01-02"
+                ),
+            ),
+            (
+                "signer-image",
+                lambda document: document["apk"].__setitem__(
+                    "signer_image",
+                    "registry.example/syswarden/apk-signer@sha256:" + "6" * 64,
+                ),
+            ),
+            (
+                "deb-signature-suffix",
+                lambda document: document["deb"].__setitem__(
+                    "signature_suffix", ".sig"
+                ),
+            ),
+        )
+        for index, (name, mutate) in enumerate(mutations):
+            with self.subTest(name=name):
+                document = self.policy_document("qualified")
+                mutate(document)
+                self.write_json(self.policy, document)
+                self.rewrite_verification_evidence()
+                self.assertEqual(
+                    bundle.main(
+                        self.finalize_arguments(
+                            self.root / f"transition-rejected-{index}"
+                        )
+                    ),
+                    1,
+                )
 
     def test_bootstrap_qualification_policy_boundaries_fail_closed(self) -> None:
         cases = (
@@ -810,14 +1173,17 @@ class NativePackageSigningBundleTests(unittest.TestCase):
                 self.write_json(self.policy, document)
                 self.rewrite_verification_evidence()
                 arguments = list(
-                    self.finalize_arguments(self.root / f"bootstrap-rejected-{index}")
+                    self.finalize_arguments(
+                        self.root / f"bootstrap-rejected-{index}",
+                        include_bootstrap=False,
+                    )
                 )
                 arguments.append("--bootstrap-qualification")
                 self.assertEqual(bundle.main(tuple(arguments)), 1)
 
     def test_bootstrap_qualification_cannot_use_publishing_purpose(self) -> None:
         self.write_bootstrap_policy()
-        arguments = list(self.finalize_arguments())
+        arguments = list(self.finalize_arguments(include_bootstrap=False))
         arguments.extend(
             ("--bootstrap-qualification", "--purpose", "publishing")
         )
@@ -826,7 +1192,7 @@ class NativePackageSigningBundleTests(unittest.TestCase):
     def test_bootstrap_qualification_requires_committed_public_key_bytes(self) -> None:
         self.write_bootstrap_policy()
         self.rpm_public.unlink()
-        arguments = list(self.finalize_arguments())
+        arguments = list(self.finalize_arguments(include_bootstrap=False))
         arguments.append("--bootstrap-qualification")
         self.assertEqual(bundle.main(tuple(arguments)), 1)
 
@@ -838,7 +1204,7 @@ class NativePackageSigningBundleTests(unittest.TestCase):
             self.key("rpm-second", second_public, "A" * 40)
         )
         self.write_bootstrap_policy(document)
-        arguments = list(self.finalize_arguments())
+        arguments = list(self.finalize_arguments(include_bootstrap=False))
         arguments.append("--bootstrap-qualification")
         self.assertEqual(bundle.main(tuple(arguments)), 1)
 

--- a/scripts/ci/native_package_signing_workflow_test.py
+++ b/scripts/ci/native_package_signing_workflow_test.py
@@ -291,6 +291,7 @@ print(json.dumps(document, separators=(",", ":")))
                 "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
                 "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+                "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
                 "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
             ],
         )
@@ -365,7 +366,7 @@ print(json.dumps(document, separators=(",", ":")))
             self.assertIn(required, self.workflow)
         self.assertEqual(
             self.workflow.count("actions/download-artifact@"),
-            2,
+            3,
         )
         self.assertEqual(
             self.workflow.count('run-id: ${{ inputs.unsigned_package_run_id }}'),
@@ -562,6 +563,210 @@ print(json.dumps(document, separators=(",", ":")))
         ):
             self.assertIn(required, self.workflow)
         self.assertNotIn("--purpose publishing", self.workflow)
+
+    def test_qualified_mode_requires_one_exact_prior_bootstrap(self) -> None:
+        for required in (
+            "bootstrap_release_sha:",
+            "bootstrap_signing_run_id:",
+            "bootstrap_signed_artifact_id:",
+            "bootstrap_policy_sha256:",
+            "APPROVED_BOOTSTRAP_ARTIFACT_DIGEST: sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3",
+            'APPROVED_BOOTSTRAP_ARTIFACT_ID: "10088398939"',
+            "APPROVED_BOOTSTRAP_ARTIFACT_NAME: syswarden-native-signed-packages-4.10.0-34292701745-1-9598861f1be80a651658bf3ca8c10424bd70db6c",
+            'APPROVED_BOOTSTRAP_ARTIFACT_SIZE: "63065295"',
+            "APPROVED_BOOTSTRAP_RELEASE_SHA: 9598861f1be80a651658bf3ca8c10424bd70db6c",
+            "APPROVED_BOOTSTRAP_REPOSITORY: duggytuxy/syswarden",
+            'APPROVED_BOOTSTRAP_RUN_ID: "34292701745"',
+            "FOUNDATION_POLICY_SHA256: 6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d",
+            '"${BOOTSTRAP_POLICY_SHA256}" != "${FOUNDATION_POLICY_SHA256}"',
+            '"${BOOTSTRAP_RELEASE_SHA}" != "${APPROVED_BOOTSTRAP_RELEASE_SHA}"',
+            '"${BOOTSTRAP_SIGNING_RUN_ID}" != "${APPROVED_BOOTSTRAP_RUN_ID}"',
+            '"${BOOTSTRAP_SIGNED_ARTIFACT_ID}" != "${APPROVED_BOOTSTRAP_ARTIFACT_ID}"',
+            "Resolve Exact Prior Bootstrap Run and Artifact",
+            '"${BOOTSTRAP_RELEASE_SHA}" == "${RELEASE_SHA}"',
+            'git merge-base --is-ancestor "${BOOTSTRAP_RELEASE_SHA}" "${RELEASE_SHA}"',
+            'policy_size="$(git cat-file -s "${policy_object}")"',
+            '"${policy_size}" -gt 131072',
+            '.path // ""',
+            '".github/workflows/native-package-signing.yml"',
+            '.event // ""',
+            '"workflow_dispatch"',
+            '.run_attempt | tostring',
+            '.conclusion // ""',
+            '.actor.login // ""',
+            '.triggering_actor.login // ""',
+            "bootstrap signing run must expose exactly one artifact",
+            '.workflow_run.id == $run and .workflow_run.head_sha == $sha and',
+            '.workflow_run.head_branch == "main"',
+            '"${artifact_size}" != "${APPROVED_BOOTSTRAP_ARTIFACT_SIZE}"',
+            '"${artifact_digest}" != "${APPROVED_BOOTSTRAP_ARTIFACT_DIGEST}"',
+            "--bootstrap-bundle",
+            "--bootstrap-policy-sha256",
+            "--bootstrap-signed-artifact-size",
+            "validate_bootstrap_binding",
+        ):
+            self.assertIn(required, self.workflow)
+        guard = self.workflow.index(
+            "Validate Exact Bootstrap Policy Transition and Bundle"
+        )
+        first_secret = self.workflow.index("${{ secrets.")
+        self.assertLess(guard, first_secret)
+
+    def test_bootstrap_and_qualified_artifact_names_are_unambiguous(self) -> None:
+        self.assertIn(
+            'expected_name="syswarden-native-signed-packages-${version}-${REQUESTED_RUN_ID}-1-${BOOTSTRAP_RELEASE_SHA}"',
+            self.workflow,
+        )
+        self.assertIn(
+            'artifact_name="syswarden-native-signed-packages-${RELEASE_TAG#v}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"',
+            self.workflow,
+        )
+        self.assertIn(
+            'artifact_name="syswarden-native-signed-packages-qualified-${RELEASE_TAG#v}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RELEASE_SHA}"',
+            self.workflow,
+        )
+        self.assertIn('verify_args+=(--mode bootstrap)', self.workflow)
+
+    def test_bootstrap_run_resolver_fails_closed(self) -> None:
+        resolver = named_literal_run_block(
+            self.workflow, "Resolve Exact Prior Bootstrap Run and Artifact"
+        )
+        bootstrap_sha = "9598861f1be80a651658bf3ca8c10424bd70db6c"
+        run_id = 34292701745
+        artifact_id = 10088398939
+        artifact_size = 63065295
+        artifact_digest = (
+            "sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3"
+        )
+        artifact_name = (
+            "syswarden-native-signed-packages-4.10.0-"
+            f"{run_id}-1-{bootstrap_sha}"
+        )
+        valid_run = {
+            "actor": {"login": "duggytuxy"},
+            "conclusion": "success",
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": bootstrap_sha,
+            "id": run_id,
+            "path": ".github/workflows/native-package-signing.yml",
+            "run_attempt": 1,
+            "status": "completed",
+            "triggering_actor": {"login": "duggytuxy"},
+        }
+        valid_artifact = {
+            "digest": artifact_digest,
+            "expired": False,
+            "id": artifact_id,
+            "name": artifact_name,
+            "size_in_bytes": artifact_size,
+            "workflow_run": {
+                "head_branch": "main",
+                "head_sha": bootstrap_sha,
+                "id": run_id,
+            },
+        }
+
+        def execute(
+            run_document: dict[str, Any], artifacts: list[dict[str, Any]]
+        ) -> subprocess.CompletedProcess[str]:
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                run_path = root / "run.json"
+                artifacts_path = root / "artifacts.json"
+                output_path = root / "output.txt"
+                run_path.write_text(json.dumps(run_document), encoding="utf-8")
+                artifacts_path.write_text(
+                    json.dumps({"artifacts": artifacts}), encoding="utf-8"
+                )
+                gh = root / "gh"
+                gh.write_text(
+                    """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+endpoint = next(
+    argument for argument in sys.argv[1:] if argument.startswith("repos/")
+)
+if endpoint.endswith("/artifacts"):
+    payload = [json.loads(Path(os.environ["TEST_ARTIFACTS_JSON"]).read_text())]
+else:
+    payload = json.loads(Path(os.environ["TEST_RUN_JSON"]).read_text())
+print(json.dumps(payload, separators=(",", ":")))
+""",
+                    encoding="utf-8",
+                )
+                gh.chmod(0o700)
+                environment = os.environ.copy()
+                environment.update(
+                    {
+                        "BOOTSTRAP_RELEASE_SHA": bootstrap_sha,
+                        "APPROVED_BOOTSTRAP_ARTIFACT_DIGEST": artifact_digest,
+                        "APPROVED_BOOTSTRAP_ARTIFACT_ID": str(artifact_id),
+                        "APPROVED_BOOTSTRAP_ARTIFACT_NAME": artifact_name,
+                        "APPROVED_BOOTSTRAP_ARTIFACT_SIZE": str(artifact_size),
+                        "APPROVED_BOOTSTRAP_RELEASE_SHA": bootstrap_sha,
+                        "APPROVED_BOOTSTRAP_REPOSITORY": "duggytuxy/syswarden",
+                        "APPROVED_BOOTSTRAP_RUN_ID": str(run_id),
+                        "GITHUB_OUTPUT": str(output_path),
+                        "GITHUB_REPOSITORY": "duggytuxy/syswarden",
+                        "GH_TOKEN": "test-token",
+                        "PATH": f"{root}:{environment['PATH']}",
+                        "RELEASE_TAG": "v4.10.0",
+                        "REPOSITORY_OWNER": "duggytuxy",
+                        "REQUESTED_ARTIFACT_ID": str(artifact_id),
+                        "REQUESTED_RUN_ID": str(run_id),
+                        "TEST_ARTIFACTS_JSON": str(artifacts_path),
+                        "TEST_RUN_JSON": str(run_path),
+                    }
+                )
+                return subprocess.run(
+                    ["bash", "-c", resolver],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                    env=environment,
+                )
+
+        accepted = execute(valid_run, [valid_artifact])
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        rejected_cases = []
+        wrong_attempt = json.loads(json.dumps(valid_run))
+        wrong_attempt["run_attempt"] = 2
+        rejected_cases.append((wrong_attempt, [valid_artifact]))
+        extra_artifact = json.loads(json.dumps(valid_artifact))
+        extra_artifact["id"] = artifact_id + 1
+        rejected_cases.append((valid_run, [valid_artifact, extra_artifact]))
+        wrong_sha = json.loads(json.dumps(valid_artifact))
+        wrong_sha["workflow_run"]["head_sha"] = "c" * 40
+        rejected_cases.append((valid_run, [wrong_sha]))
+        wrong_branch = json.loads(json.dumps(valid_artifact))
+        wrong_branch["workflow_run"]["head_branch"] = "other"
+        rejected_cases.append((valid_run, [wrong_branch]))
+        bad_digest = json.loads(json.dumps(valid_artifact))
+        bad_digest["digest"] = "sha256:" + "a" * 63
+        rejected_cases.append((valid_run, [bad_digest]))
+        wrong_digest = json.loads(json.dumps(valid_artifact))
+        wrong_digest["digest"] = "sha256:" + "0" * 64
+        rejected_cases.append((valid_run, [wrong_digest]))
+        wrong_size = json.loads(json.dumps(valid_artifact))
+        wrong_size["size_in_bytes"] = artifact_size + 1
+        rejected_cases.append((valid_run, [wrong_size]))
+        wrong_id = json.loads(json.dumps(valid_artifact))
+        wrong_id["id"] = artifact_id + 1
+        rejected_cases.append((valid_run, [wrong_id]))
+        false_bootstrap_suffix = json.loads(json.dumps(valid_artifact))
+        false_bootstrap_suffix["name"] = (
+            "syswarden-native-signed-packages-bootstrap-4.10.0-"
+            f"{run_id}-1-{bootstrap_sha}"
+        )
+        rejected_cases.append((valid_run, [false_bootstrap_suffix]))
+        for run_document, artifacts in rejected_cases:
+            with self.subTest(run=run_document, artifacts=artifacts):
+                self.assertNotEqual(execute(run_document, artifacts).returncode, 0)
 
     def test_apk_operations_are_offline_and_container_hardened(self) -> None:
         self.assertGreaterEqual(self.workflow.count("--network none"), 2)

--- a/scripts/ci/release_gate_test.py
+++ b/scripts/ci/release_gate_test.py
@@ -2788,7 +2788,7 @@ exit 64
             "native_signing_workflow": "native-package-signing.yml",
             "native_signing_run_id": 104,
             "native_signing_artifact_id": 105,
-            "native_signing_artifact_name": "syswarden-native-signed-packages-4.10.0-104-1-" + release_sha,
+            "native_signing_artifact_name": "syswarden-native-signed-packages-qualified-4.10.0-104-1-" + release_sha,
             "native_signing_artifact_digest": "sha256:" + "e" * 64,
             "native_evidence_workflow": "native-release-evidence.yml",
             "native_evidence_run_id": 106,

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -925,7 +925,7 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             self.workflow, "Resolve Unique Protected Native Signing Bundle"
         )
         release_sha = "a" * 40
-        name = f"syswarden-native-signed-packages-4.10.0-456-1-{release_sha}"
+        name = f"syswarden-native-signed-packages-qualified-4.10.0-456-1-{release_sha}"
         run = {
             "id": 456,
             "path": ".github/workflows/native-package-signing.yml",


### PR DESCRIPTION
## Summary

- require the exact successful Phase A bootstrap run and its unique immutable artifact before qualified native signing can proceed
- bind repository, distinct ancestor SHA, attempt 1, workflow identity, artifact ID, historical bootstrap name, byte size, GitHub digest, and foundation policy digest
- permit only the reviewed policy transition while keeping every key, mechanism, signer image, and unrelated field identical
- seal the bootstrap reference into both qualified provenance documents
- reserve a distinct artifact name for qualified output and make bundle verification qualified-only by default with an explicit bootstrap mode
- keep the committed Phase A foundation policy unchanged and non-publishing

## Validation

- 1097 CI unit tests passed, with 2 environment-specific skips
- exact real bootstrap artifact verified successfully in explicit bootstrap mode
- the same bootstrap artifact rejected by the qualified-only default verifier as expected
- independent final audit passed with no P0, P1, or P2 findings
- workflow YAML parsing, Bash parsing, ShellCheck, documentation truth tests, Python compilation, language checks, and `git diff --check` passed
- `versionctl validate-commit` confirmed that this non-versioning commit preserves v4.10.0
- Phase A policy SHA-256 remains `6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d`

## Scope

This pull request adds the Phase B machine binding only. It does not promote the committed policy, publish packages, create a release, or weaken Phase A.
