### PR TITLE
Security : qualify the v4.10.0 native package signature policy

### DIFF
--- a/scripts/ci/native_package_signature_gate_test.py
+++ b/scripts/ci/native_package_signature_gate_test.py
@@ -318,13 +318,14 @@ class NativePackageSignatureGateTests(unittest.TestCase):
         self.write_policy(self.bootstrap_document())
         self.assertEqual(gate.main(self.arguments("rpm", "rpm-2026")), 1)
 
-    def test_repository_foundation_policy_cannot_claim_qualification(self) -> None:
+    def test_repository_qualified_policy_remains_non_publishing(self) -> None:
         policy = Path(gate.__file__).with_name("native_package_signature_policy_v4100.json")
         document = gate.load_json(policy, "repository policy")
         qualification_day = gate.parse_day("2026-09-08", "date")
         gate.validate_policy(document, qualification_day)
-        self.assertEqual(document["status"], "foundation-not-qualified")
+        self.assertEqual(document["status"], "qualified")
         self.assertFalse(document["publishing"])
+        self.assertEqual(document["deb"]["implementation"], "qualified")
         expected_ids = {
             "rpm": "rpm-prod-2026-01",
             "apk": "apk-prod-2026-01",
@@ -353,12 +354,6 @@ class NativePackageSignatureGateTests(unittest.TestCase):
             document["apk"]["signer_image"],
             "docker.io/alpinelinux/build-base@sha256:31d2a020ccd2058e6ab47940428bd0b7dc83e37b66880891f9ed903a12ea668b",
         )
-
-        document["publishing"] = True
-        with self.assertRaisesRegex(
-            gate.SignatureGateError, "publishing approval requires"
-        ):
-            gate.validate_policy(document, qualification_day)
 
     @unittest.skipUnless(
         shutil.which("gpg") and shutil.which("openssl"),

--- a/scripts/ci/native_package_signature_policy_v4100.json
+++ b/scripts/ci/native_package_signature_policy_v4100.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "profile": "syswarden-native-package-signatures/v4.10.0",
-  "status": "foundation-not-qualified",
+  "status": "qualified",
   "publishing": false,
   "rpm": {
     "mechanism": "rpm-openpgp",
@@ -51,6 +51,6 @@
         "supersedes": []
       }
     ],
-    "implementation": "implemented-not-qualified"
+    "implementation": "qualified"
   }
 }

--- a/scripts/ci/native_package_signature_v4100.md
+++ b/scripts/ci/native_package_signature_v4100.md
@@ -2,12 +2,12 @@
 
 Status: the protected signing foundation and fail-closed publication
 integration are implemented. Three distinct candidate production public identities are
-enrolled under the non-publishing foundation policy. Phase 1 bootstrap
+enrolled under the qualified, non-publishing policy. Phase 1 bootstrap
 qualification succeeded, and the exact immutable result recorded below is the
-foundation evidence for phase 2. The committed policy remains non-qualified
-until a distinct phase 2 `qualified-policy` run validates the permitted policy
-transition. Policy promotion, normal native proof and publication approval
-remain pending.
+foundation evidence for phase 2. The committed policy is now qualified and
+remains non-publishing. A distinct phase 2 `qualified-policy` run, normal native
+proof, supported-host lifecycle labs and explicit publication approval remain
+required before publishing may be enabled.
 No workflow in this foundation creates a private key.
 
 The offline gate binds one package byte stream to an exact release inventory
@@ -34,9 +34,10 @@ OpenPGP key. APK verification uses a private temporary key directory containing
 only the selected RSA public key. DEB verification uses isolated `gpgv` with a
 temporary keyring derived only from the selected OpenPGP public key. The
 repository policy contains exactly one candidate production public identity per
-package family. Phase 1 has succeeded, but the policy remains intentionally
-non-qualified and non-publishing until the separate reviewed phase 2 policy
-commit and `qualified-policy` run complete. The APK signer is pinned to the
+package family. Phase 1 has succeeded, and the separate reviewed phase 2 policy
+commit promotes only the policy status and DEB implementation while keeping
+publishing disabled. The protected `qualified-policy` run and its downstream
+proofs remain required. The APK signer is pinned to the
 AMD64 manifest of the official Alpine Linux 3.24 build-base image at
 `docker.io/alpinelinux/build-base@sha256:31d2a020ccd2058e6ab47940428bd0b7dc83e37b66880891f9ed903a12ea668b`.
 It was reviewed as an offline runtime containing `abuild-sign`, `apk`, OpenSSL
@@ -323,8 +324,10 @@ package is a new unqualified state and must not resume publishing.
 | Tampered evidence or bundle | Canonical evidence and complete artifact seal reject it | Canonical evidence and complete artifact seal reject it | Signature bytes, verification evidence and complete artifact seal reject it |
 
 Static and adversarial unit tests cover the fail-closed controls available in
-this foundation. Real cryptographic fixtures and supported-host lifecycle labs
-remain mandatory before policy status or publishing approval can change.
+the committed qualified, non-publishing policy. This commit promotes policy
+status only. A protected `qualified-policy` run, real cryptographic fixtures and
+supported-host lifecycle labs remain mandatory before publication approval and
+release qualification.
 
 ## Consumer contract
 
@@ -347,7 +350,9 @@ non-revoked, all three native gates succeed with purpose `publishing`, and the
 DEB detached-signature lane is qualified. The release manager revalidates the
 sealed qualification inventory and byte-compares its RPM, APK, DEB and detached
 DEB signature before staging the public assets. With the current policy state,
-qualification fails before those assets can reach the publisher.
+qualification may consume the protected `qualified-policy` run, but publication
+remains fail-closed while `publishing` is false and until the lifecycle labs and
+release qualification succeed.
 
 Before qualification, the release owner must review the enrolled fingerprints,
 validity intervals and empty initial rotation lineage, confirm the protected

--- a/scripts/ci/native_package_signing_workflow_test.py
+++ b/scripts/ci/native_package_signing_workflow_test.py
@@ -838,11 +838,11 @@ print(json.dumps(payload, separators=(",", ":")))
         self.assertIn("native_package_signing_bundle.py verify", self.workflow)
         self.assertIn("compression-level: 0", self.workflow)
 
-    def test_committed_policy_enrolls_one_key_per_family_but_remains_fail_closed(self) -> None:
+    def test_committed_policy_is_qualified_but_remains_non_publishing(self) -> None:
         policy = json.loads(POLICY.read_text(encoding="utf-8"))
-        self.assertEqual(policy["status"], "foundation-not-qualified")
+        self.assertEqual(policy["status"], "qualified")
         self.assertFalse(policy["publishing"])
-        self.assertEqual(policy["deb"]["implementation"], "implemented-not-qualified")
+        self.assertEqual(policy["deb"]["implementation"], "qualified")
         selected = []
         for family in ("rpm", "apk", "deb"):
             self.assertEqual(len(policy[family]["trusted_keys"]), 1)


### PR DESCRIPTION
## Summary

- promote the v4.10.0 native package signature policy from the reviewed Phase A foundation to the qualified, non-publishing Phase C state
- change only `status` to `qualified` and `deb.implementation` to `qualified`, while preserving every key, mechanism, signer image, and unrelated policy field
- keep `publishing` set to `false` so release qualification and publication remain fail-closed
- align tests and the native signature contract with the reviewed two-phase transition
- require the separate protected `qualified-policy` run bound by PR #163 to the exact successful bootstrap evidence

## Validation

- recursive policy comparison proved that exactly two approved string values changed
- 1097 CI unit tests passed with 12 environment-specific skips
- 158 focused signature, bundle, workflow, and documentation tests passed with 1 environment-specific skip
- independent Phase C audit passed with no P0, P1, or P2 findings
- documentation truth validation against the live wiki checkout passed, including external links
- `versionctl validate-commit` confirmed that this non-versioning commit preserves v4.10.0
- `git diff --check`, ASCII checks, and the frozen diff digest passed
- frozen pre-commit diff SHA-256: `b312284dbbb68f22836c01e8332a0b8d692e7fc15cb57f09e12d715aef8b97bd`
- qualified policy SHA-256: `54a35116b1efd3449e1739067a3ff1a4800721675cf3e9953c6366831c1480b6`

## Scope

This pull request promotes the policy only. It does not sign new packages, qualify the release, enable publishing, publish assets, create a tag, or create a GitHub Release.
