### PR TITLE
Security : authorize v4.10.0 native publication eligibility

### DIFF
--- a/docs/maintainers/LOCAL_RELEASE_PREFLIGHT.md
+++ b/docs/maintainers/LOCAL_RELEASE_PREFLIGHT.md
@@ -307,6 +307,14 @@ the new exact `main` SHA and run `qualified-policy`. No bootstrap package or
 observation may be reused. Official native campaigns and release qualification
 consume only the phase 2 bundle and its provenance-selected key identities.
 
+After independently reviewing that first phase 2 bundle, merge a distinct
+non-versioning release-owner decision that changes only `publishing` from false
+to true. This value makes the unchanged trust roots eligible for eventual
+publication but does not create a tag, Release or public asset. Because the
+decision changes the source SHA, rebuild the packages and repeat
+`qualified-policy` for that exact commit. Do not approve the candidate update
+workflow before this promotion and fresh signing proof are complete.
+
 Before the NODE01 migration campaign, run the protected candidate update
 workflow once for the exact untagged `main` SHA and the unique phase 2 native
 signing artifact. It creates a signed, non-public qualification bundle without

--- a/docs/technical/OFFLINE_CANDIDATE_QUALIFICATION.md
+++ b/docs/technical/OFFLINE_CANDIDATE_QUALIFICATION.md
@@ -29,6 +29,13 @@ verify the producer attestation and detached DEB signature. The workflow does
 not create a tag or GitHub Release. The protected native-evidence and release
 qualification workflows must independently resolve the same immutable
 artifact by run and artifact ID and revalidate it before accepting evidence.
+Before it may use the updater signing key, the workflow requires the committed
+native package policy to be qualified and explicitly approved for future
+publishing. That approval only establishes eligibility. This workflow retains
+read-only repository permissions and cannot create a tag, Release or public
+asset. Requiring the decision before this bundle ensures that the package,
+candidate update, native evidence and final qualification all share one exact
+source SHA.
 
 Only the exact host subdirectory is passed to `syswarden update`. For NODE01,
 that directory is `node01/` and has the three-file contract below.

--- a/scripts/ci/native_package_signature_gate_test.py
+++ b/scripts/ci/native_package_signature_gate_test.py
@@ -318,13 +318,13 @@ class NativePackageSignatureGateTests(unittest.TestCase):
         self.write_policy(self.bootstrap_document())
         self.assertEqual(gate.main(self.arguments("rpm", "rpm-2026")), 1)
 
-    def test_repository_qualified_policy_remains_non_publishing(self) -> None:
+    def test_repository_qualified_policy_is_approved_for_publishing(self) -> None:
         policy = Path(gate.__file__).with_name("native_package_signature_policy_v4100.json")
         document = gate.load_json(policy, "repository policy")
         qualification_day = gate.parse_day("2026-09-08", "date")
         gate.validate_policy(document, qualification_day)
         self.assertEqual(document["status"], "qualified")
-        self.assertFalse(document["publishing"])
+        self.assertTrue(document["publishing"])
         self.assertEqual(document["deb"]["implementation"], "qualified")
         expected_ids = {
             "rpm": "rpm-prod-2026-01",
@@ -1132,6 +1132,16 @@ class NativePackageSignatureGateTests(unittest.TestCase):
         arguments = list(self.arguments("rpm", "rpm-2026"))
         arguments.extend(("--purpose", "publishing"))
         self.assertEqual(gate.main(tuple(arguments)), 1)
+
+    def test_approved_policy_allows_publishing_verification(self) -> None:
+        document = self.document()
+        document["publishing"] = True
+        self.write_policy(document)
+        arguments = self.arguments("rpm", "rpm-2026") + (
+            "--purpose",
+            "publishing",
+        )
+        self.assertEqual(gate.main(arguments), 0)
 
     def test_verification_evidence_is_canonical_and_bound(self) -> None:
         evidence = self.root / "rpm-verification.json"

--- a/scripts/ci/native_package_signature_policy_v4100.json
+++ b/scripts/ci/native_package_signature_policy_v4100.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "profile": "syswarden-native-package-signatures/v4.10.0",
   "status": "qualified",
-  "publishing": false,
+  "publishing": true,
   "rpm": {
     "mechanism": "rpm-openpgp",
     "trusted_keys": [

--- a/scripts/ci/native_package_signature_v4100.md
+++ b/scripts/ci/native_package_signature_v4100.md
@@ -2,12 +2,12 @@
 
 Status: the protected signing foundation and fail-closed publication
 integration are implemented. Three distinct candidate production public identities are
-enrolled under the qualified, non-publishing policy. Phase 1 bootstrap
-qualification succeeded, and the exact immutable result recorded below is the
-foundation evidence for phase 2. The committed policy is now qualified and
-remains non-publishing. A distinct phase 2 `qualified-policy` run, normal native
-proof, supported-host lifecycle labs and explicit publication approval remain
-required before publishing may be enabled.
+enrolled under the qualified policy. Phase 1 bootstrap qualification and the
+first non-publishing phase 2 proof succeeded. The release owner has now approved
+these unchanged trust roots for eventual publication. This policy decision does
+not create a tag, a GitHub Release or a public asset. A fresh `qualified-policy`
+run for the exact approval commit, normal native proof, supported-host lifecycle
+labs and final release qualification remain required before publication.
 No workflow in this foundation creates a private key.
 
 The offline gate binds one package byte stream to an exact release inventory
@@ -34,10 +34,11 @@ OpenPGP key. APK verification uses a private temporary key directory containing
 only the selected RSA public key. DEB verification uses isolated `gpgv` with a
 temporary keyring derived only from the selected OpenPGP public key. The
 repository policy contains exactly one candidate production public identity per
-package family. Phase 1 has succeeded, and the separate reviewed phase 2 policy
-commit promotes only the policy status and DEB implementation while keeping
-publishing disabled. The protected `qualified-policy` run and its downstream
-proofs remain required. The APK signer is pinned to the
+package family. Phase 1 and the initial non-publishing phase 2 proof have
+succeeded. A separate reviewed policy decision now makes the unchanged trust
+roots eligible for eventual publication. The protected `qualified-policy` run
+must be repeated for this new exact commit, and its downstream proofs remain
+required. The APK signer is pinned to the
 AMD64 manifest of the official Alpine Linux 3.24 build-base image at
 `docker.io/alpinelinux/build-base@sha256:31d2a020ccd2058e6ab47940428bd0b7dc83e37b66880891f9ed903a12ea668b`.
 It was reviewed as an offline runtime containing `abuild-sign`, `apk`, OpenSSL
@@ -93,6 +94,25 @@ in the workflow and bundle verifier:
 | Signed artifact size | `63065295` bytes |
 | Signed artifact digest | `sha256:a76917630d5d5a90bddcf936d47ec75a987f098c9048bce0d320d1ffda131ad3` |
 | Foundation policy SHA-256 | `6b98b3b5bca83b9bc611c3b2e384636b5bbcbecc9e818e0f06104255200b011d` |
+
+The first phase 2 proof was independently reviewed before publication
+eligibility was approved:
+
+| Field | Exact value |
+| --- | --- |
+| Source SHA | `017fcbd7996102f025c9c1467cda67e2e2f8867d` |
+| Signing run | `34319794608`, attempt `1` |
+| Signed artifact ID | `10091742320` |
+| Signed artifact name | `syswarden-native-signed-packages-qualified-4.10.0-34319794608-1-017fcbd7996102f025c9c1467cda67e2e2f8867d` |
+| Signed artifact size | `63066907` bytes |
+| Signed artifact digest | `sha256:b7411d4e41a738bde48b3a7658b8379f1975a982a8ba842232b0af26f68c13fa` |
+| Qualified policy SHA-256 | `54a35116b1efd3449e1739067a3ff1a4800721675cf3e9953c6366831c1480b6` |
+| Independent verdict | PASS with no P0, P1 or P2 finding |
+
+This artifact proves the non-publishing policy state that authorized the next
+reviewed decision. It remains immutable evidence but cannot be reused after the
+source SHA changes. Packages and signatures must be regenerated from the exact
+publication-approval commit.
 
 The workflow accepts only a completed successful
 `workflow_dispatch` attempt 1 owned by the repository owner, with one unexpired
@@ -324,10 +344,11 @@ package is a new unqualified state and must not resume publishing.
 | Tampered evidence or bundle | Canonical evidence and complete artifact seal reject it | Canonical evidence and complete artifact seal reject it | Signature bytes, verification evidence and complete artifact seal reject it |
 
 Static and adversarial unit tests cover the fail-closed controls available in
-the committed qualified, non-publishing policy. This commit promotes policy
-status only. A protected `qualified-policy` run, real cryptographic fixtures and
-supported-host lifecycle labs remain mandatory before publication approval and
-release qualification.
+the committed qualified, publication-approved policy. This decision changes
+only publication eligibility and does not publish anything. A fresh protected
+`qualified-policy` run for the same exact source commit, real cryptographic
+fixtures, supported-host lifecycle labs and release qualification remain
+mandatory before any tag or public Release.
 
 ## Consumer contract
 
@@ -349,10 +370,10 @@ sets `publishing` to true through review, the public keys remain valid and
 non-revoked, all three native gates succeed with purpose `publishing`, and the
 DEB detached-signature lane is qualified. The release manager revalidates the
 sealed qualification inventory and byte-compares its RPM, APK, DEB and detached
-DEB signature before staging the public assets. With the current policy state,
-qualification may consume the protected `qualified-policy` run, but publication
-remains fail-closed while `publishing` is false and until the lifecycle labs and
-release qualification succeed.
+DEB signature before staging the public assets. The current policy authorizes
+future publication eligibility only. Publication remains fail-closed until the
+fresh exact-commit signing proof, lifecycle labs and release qualification all
+succeed.
 
 Before qualification, the release owner must review the enrolled fingerprints,
 validity intervals and empty initial rotation lineage, confirm the protected

--- a/scripts/ci/native_package_signing_workflow_test.py
+++ b/scripts/ci/native_package_signing_workflow_test.py
@@ -838,10 +838,10 @@ print(json.dumps(payload, separators=(",", ":")))
         self.assertIn("native_package_signing_bundle.py verify", self.workflow)
         self.assertIn("compression-level: 0", self.workflow)
 
-    def test_committed_policy_is_qualified_but_remains_non_publishing(self) -> None:
+    def test_committed_policy_is_qualified_and_approved_for_publishing(self) -> None:
         policy = json.loads(POLICY.read_text(encoding="utf-8"))
         self.assertEqual(policy["status"], "qualified")
-        self.assertFalse(policy["publishing"])
+        self.assertTrue(policy["publishing"])
         self.assertEqual(policy["deb"]["implementation"], "qualified")
         selected = []
         for family in ("rpm", "apk", "deb"):

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -973,6 +973,19 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
                 failed, _ = run_native_signing_resolver(script, runs, artifacts)
                 self.assertNotEqual(failed.returncode, 0)
 
+        publication_gate = workflow_step_script(
+            self.workflow, "Verify and Bind Exact Native Signing Bundle"
+        )
+        self.assertIn(
+            'policy_document["status"] != "qualified" or '
+            'policy_document["publishing"] is not True',
+            publication_gate,
+        )
+        self.assertIn(
+            "native signature policy is not approved for release publication",
+            publication_gate,
+        )
+
     def test_hosted_native_evidence_resolution_is_independent_and_fail_closed(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Authorize the already qualified v4.10.0 native signing identities for future publication by changing only `publishing` from `false` to `true` in the policy document.
- Record the independently reviewed first Phase 2 proof and its exact immutable GitHub identity.
- Document the required fail-closed sequence after merge: fresh package build, fresh `qualified-policy` signing proof on the new exact SHA, candidate bundle, native labs and final release qualification.
- Add regression coverage for publishing-purpose verification and the final qualification publication guard.

## Safety boundary

- This PR does not create a tag, GitHub Release or public asset.
- No workflow or GitHub permission changes.
- The previous signed bundle cannot be reused after this source SHA changes.
- The stable release remains v4.04.3 and the candidate version remains v4.10.0.
- `changelog.md` and `README.md` remain byte-for-byte unchanged.

## Reviewed evidence

- Source SHA: `017fcbd7996102f025c9c1467cda67e2e2f8867d`
- Protected signing run: `34319794608`, attempt `1`
- Signed artifact ID: `10091742320`
- Signed artifact digest: `sha256:b7411d4e41a738bde48b3a7658b8379f1975a982a8ba842232b0af26f68c13fa`
- Qualified policy SHA-256: `54a35116b1efd3449e1739067a3ff1a4800721675cf3e9953c6366831c1480b6`
- Independent review: PASS, no P0, P1 or P2 finding

## Validation

- 1,098 Python tests passed, 12 environment-specific skips
- 229 targeted security and sequencing tests passed
- 253 documentation and consumer tests passed
- versionctl Go tests passed
- Non-versioning commit validation passed for v4.10.0
- SSH commit signature verified locally and by GitHub
- `git diff --check` passed

The complete documentation truth gate also identified existing version drift in four external wiki pages. That drift is outside this seven-file branch and is intentionally not mixed into this security decision.