### PR TITLE
Docs : record v4.10.0 lifecycle and telemetry corrections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,12 @@
   updater path for protected native labs. It binds the signed manifest,
   package bytes, embedded CLI, installed package record and activated CLI to
   the same candidate before any service activation.
+- **Explicit legacy WireGuard recovery:** Add `syswarden recover-wireguard`
+  for the two supported historical SysWarden nftables generations on systemd
+  and OpenRC. A read-only plan precedes a separate application bound to its
+  exact SHA-256 digest. Support exact partial cleanup with zero, one or two
+  historical shared forward rules remaining; unknown, active, enabled or
+  changed state remains blocked.
 - **Versioned TUI and GRC evidence:** Add stable KPI fields for admitted and
   rejected events, HITS, highest signature-backed severity, enforcement jail,
   policy action, evidence quality and time window. The TUI and exported
@@ -102,6 +108,13 @@
   the producer, HA transport and TUI. Display payload projection is
   deterministic and explicitly reported, while an oversized essential state
   preserves the last valid snapshot and records a publication failure.
+- **Live alert streaming:** Start `syswarden alerts` at the current kernel and
+  WAAP source boundary without replaying historical events. Expose source
+  health, bound the TUI update queue and cancel and reap follower processes
+  on Ctrl+C, SIGTERM or TUI errors.
+- **Telemetry freshness:** Publish the producer timestamp after collection
+  completes and classify native TUI telemetry as online, degraded, stale or
+  offline from timestamp freshness, read errors and display projection quality.
 - **Persistent blocklist initialization:** Create and attest both IPv4 and
   IPv6 persistent list files during installation, including an initialization
   marker. A later disappearance fails closed instead of silently recreating a
@@ -125,6 +138,12 @@
   ownership or mode drift, substituted package members, changed installed CLI
   bytes, unbounded package-manager children and unsigned or network-fallback
   qualification paths.
+- **Exact service lifecycle compatibility:** Normalize byte-exact historical
+  SysWarden systemd units from mode 0644 to the canonical 0600 mode. Accept the
+  same exact legacy source units during RHEL package-owned migration. Reconcile only an
+  attested failed systemd service state before uninstall, with bounded reset
+  and re-attestation. Modified content, unsafe modes, links, ambiguous owners
+  and changing runtime state continue to fail closed.
 - **Fail-closed native trust policy:** Reject missing, wrong, expired, revoked
   or substituted RPM, APK and DEB signing identities. Production trust roots,
   protected secrets and native signature proof remain required before release.
@@ -173,6 +192,11 @@
   event-quality states, queue pressure, deduplication, rate limits, retry
   boundaries, cancellation ambiguity, bounded dashboard projection, malicious
   terminal strings, secret-safe failures and provider-specific wire payloads.
+- **Legacy recovery and live telemetry coverage:** Add tests for exact
+  WireGuard recovery plans, partial cleanup, stale authorization and host
+  drift, historical service modes, failed-service removal and RHEL ownership
+  attestation. Cover live-only alerts, source health, queue pressure, signal
+  cleanup and native TUI freshness states.
 - **Package and release contracts:** Add fail-closed tests for native signing,
   bootstrap mode boundaries, cross-family key reuse, family-scoped secret
   cleanup, lifecycle evidence, NODE01 migration, protected workflows and final


### PR DESCRIPTION
Record the lifecycle and telemetry corrections merged in PR #166 in the active v4.10.0 changelog: explicit SHA-256-bound legacy WireGuard recovery, exact source-unit compatibility, live alert streaming, follower cleanup and TUI freshness. Only 24 lines in changelog.md change. Previous release history, version targets, README and source code remain byte-exact.

Validation passed: version inspection, versionctl tests and race tests, go vet, 50 documentation tests with one expected skip, complete documentation validation against wiki commit df0baa52873b50a4e638103e697bee7443dfd2bf including real TOML parsing and external links, pinned Gitleaks v8.24.3 history and worktree scans, signature verification, ASCII, whitespace and byte-exact history checks. Independent review checked each new statement against the merged implementation and tests. This intermediate documentation step does not claim a complete release preflight or native qualification.

This follows the two-PR procedure used for PR #157/#158 and PR #161/#162. The unchanged version contract correctly rejects this same-version changelog edit with `non-versioning commit must preserve changelog.md byte-for-byte`; its first merge therefore leaves an expected historical Auto-Versioning failure. After Laurent merges this PR, a separate follow-up will seal its actual squash SHA, parent, exact subject, v4.10.0 version and both changelog SHA-256 digests in approvedChangelogFollowups. That follow-up repairs future release-chain validation without changing the strict commit validator, workflows or historical run. Native qualification and public release must wait for the sealed chain and fresh evidence.

Changelog SHA-256 before: `637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281`.
Changelog SHA-256 after: `defc336ef48123c6ae936bda26b43a300c9a7b1ee2954f014468f44dd5d7f8d3`.
