### PR TITLE
Test : seal the exact PR167 changelog follow-up

### DIFF
--- a/scripts/versionctl/release_test.go
+++ b/scripts/versionctl/release_test.go
@@ -315,7 +315,7 @@ func TestValidateReleaseAcceptsOnlyTheInjectedDigestBoundFollowup(t *testing.T) 
 	}
 }
 
-func TestValidateReleaseAcceptsTwoSequentialSealedFollowups(t *testing.T) {
+func TestValidateReleaseAcceptsThreeSequentialSealedFollowups(t *testing.T) {
 	repo := newReleaseHistoryRepository(t, "v4.03.3")
 	writeReleaseTransition(t, repo, "v4.10.0")
 	commitReleaseFixture(t, repo, "Major : prepare release")
@@ -348,17 +348,22 @@ func TestValidateReleaseAcceptsTwoSequentialSealedFollowups(t *testing.T) {
 		"Attest the native signing environment",
 		"Sign the exact APK control stream",
 	)
+	third := commitFollowup(
+		"Docs : record v4.10.0 lifecycle and telemetry corrections (#167)",
+		"Sign the exact APK control stream",
+		"Record lifecycle and telemetry corrections",
+	)
 
 	writeReleaseTestFile(t, repo, "qualification.txt", []byte("qualified\n"))
 	commitReleaseFixture(t, repo, "Qualification : preserve the sealed changelog")
 	tagReleaseFixture(t, repo, "v4.10.0")
 
 	before := string(runTestGit(t, repo, "status", "--porcelain=v1"))
-	output, err := validateReleaseFixtureWithFollowupPolicies(repo, "v4.10.0", []changelogFollowupPolicy{first, second})
+	output, err := validateReleaseFixtureWithFollowupPolicies(repo, "v4.10.0", []changelogFollowupPolicy{first, second, third})
 	if err != nil {
 		t.Fatalf("validate sequential approved follow-ups: %v\n%s", err, output)
 	}
-	if !strings.Contains(output, "3 non-versioning follow-up commit(s)") {
+	if !strings.Contains(output, "4 non-versioning follow-up commit(s)") {
 		t.Fatalf("unexpected validation output: %s", output)
 	}
 	after := string(runTestGit(t, repo, "status", "--porcelain=v1"))

--- a/scripts/versionctl/repository.go
+++ b/scripts/versionctl/repository.go
@@ -64,6 +64,13 @@ const (
 	approvedChangelogFollowupPR161Subject       = "Fix : sign the exact APK control stream (#161)"
 	approvedChangelogFollowupPR161BaseHash      = "7aafe544ad7f6a9ec678fc722992f83f0088632ff7dd0c33bbf54ca4537f8902"
 	approvedChangelogFollowupPR161CandidateHash = "637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281"
+
+	approvedChangelogFollowupPR167Commit        = "95ab8d1ad185f6a6f7ad507bf194fbde9a6e28f0"
+	approvedChangelogFollowupPR167Parent        = "dd78da07ab0a20fd2e560403231740ba9ed396d7"
+	approvedChangelogFollowupPR167Version       = "v4.10.0"
+	approvedChangelogFollowupPR167Subject       = "Docs : record v4.10.0 lifecycle and telemetry corrections (#167)"
+	approvedChangelogFollowupPR167BaseHash      = "637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281"
+	approvedChangelogFollowupPR167CandidateHash = "defc336ef48123c6ae936bda26b43a300c9a7b1ee2954f014468f44dd5d7f8d3"
 )
 
 type changelogResetPolicy struct {
@@ -131,9 +138,22 @@ var approvedChangelogFollowupPR161 = changelogFollowupPolicy{
 	CandidateSHA256: approvedChangelogFollowupPR161CandidateHash,
 }
 
+// approvedChangelogFollowupPR167 is a single-use exception for the exact
+// PR167 lifecycle and telemetry changelog correction. It extends no general
+// permission to edit an active release changelog after its version transition.
+var approvedChangelogFollowupPR167 = changelogFollowupPolicy{
+	CommitSHA:       approvedChangelogFollowupPR167Commit,
+	ParentSHA:       approvedChangelogFollowupPR167Parent,
+	Version:         approvedChangelogFollowupPR167Version,
+	Subject:         approvedChangelogFollowupPR167Subject,
+	BaseSHA256:      approvedChangelogFollowupPR167BaseHash,
+	CandidateSHA256: approvedChangelogFollowupPR167CandidateHash,
+}
+
 var approvedChangelogFollowups = []changelogFollowupPolicy{
 	approvedChangelogFollowup,
 	approvedChangelogFollowupPR161,
+	approvedChangelogFollowupPR167,
 }
 
 type snapshot map[string][]byte

--- a/scripts/versionctl/repository_test.go
+++ b/scripts/versionctl/repository_test.go
@@ -197,9 +197,25 @@ func TestApprovedChangelogFollowupRemainsBoundToPR161(t *testing.T) {
 	if approvedChangelogFollowupPR161 != want {
 		t.Fatalf("approved PR161 follow-up policy = %#v, want %#v", approvedChangelogFollowupPR161, want)
 	}
-	if len(approvedChangelogFollowups) != 2 ||
+}
+
+func TestApprovedChangelogFollowupRemainsBoundToPR167(t *testing.T) {
+	t.Parallel()
+	want := changelogFollowupPolicy{
+		CommitSHA:       "95ab8d1ad185f6a6f7ad507bf194fbde9a6e28f0",
+		ParentSHA:       "dd78da07ab0a20fd2e560403231740ba9ed396d7",
+		Version:         "v4.10.0",
+		Subject:         "Docs : record v4.10.0 lifecycle and telemetry corrections (#167)",
+		BaseSHA256:      "637597c8343dfcefb1562088ebd483a0c334529118be6e393a2cadea340ac281",
+		CandidateSHA256: "defc336ef48123c6ae936bda26b43a300c9a7b1ee2954f014468f44dd5d7f8d3",
+	}
+	if approvedChangelogFollowupPR167 != want {
+		t.Fatalf("approved PR167 follow-up policy = %#v, want %#v", approvedChangelogFollowupPR167, want)
+	}
+	if len(approvedChangelogFollowups) != 3 ||
 		approvedChangelogFollowups[0] != approvedChangelogFollowup ||
-		approvedChangelogFollowups[1] != approvedChangelogFollowupPR161 {
+		approvedChangelogFollowups[1] != approvedChangelogFollowupPR161 ||
+		approvedChangelogFollowups[2] != approvedChangelogFollowupPR167 {
 		t.Fatalf("approved changelog follow-up inventory = %#v", approvedChangelogFollowups)
 	}
 }


### PR DESCRIPTION
PR167 updates the active v4.10.0 changelog after the release version transition. Release validation rejects that follow-up until its actual merged identity is explicitly sealed.

This change adds the exact merged commit, parent, v4.10.0 version, subject and before/after changelog SHA-256 values to the existing single-use follow-up inventory. It adds an exact-value regression and extends the release-chain test to three sealed follow-ups. The general commit validator, version targets, changelog, README and workflows are unchanged. The normal `Test :` commit preserves v4.10.0.

The expected historical Auto-Versioning failure for PR167 is not rewritten. This seal enables validation of the future release chain; the seal commit itself must pass the ordinary non-versioning contract.

Validation: complete versionctl tests, race detector, vet, formatting and whitespace checks pass with Go1.26.6. The real Git history from v4.04.3 to v4.10.0 passes in an isolated rehearsal clone. The commit signature is verified. Independent review found no actionable issue.
