### PR TITLE
CI : isolate package setup from the runner Chrome repository

### DIFF
--- a/.github/workflows/go-127-evaluation.yml
+++ b/.github/workflows/go-127-evaluation.yml
@@ -79,6 +79,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Keep package setup independent of the optional Chrome repository.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+            /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install --yes rpm
           gem install --no-document fpm -v 1.17.0

--- a/.github/workflows/native-package-signing.yml
+++ b/.github/workflows/native-package-signing.yml
@@ -627,6 +627,9 @@ jobs:
           APK_SIGNER_IMAGE: ${{ vars.SYSWARDEN_APK_SIGNER_IMAGE }}
         run: |
           set -euo pipefail
+          # Keep package setup independent of the optional Chrome repository.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+            /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gnupg rpm
           for tool in docker gpg gpgconf gpgv openssl rpm rpm2cpio rpmkeys rpmsign; do

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -311,6 +311,9 @@ jobs:
       - name: Install FPM and RPM build tools
         run: |
           set -euo pipefail
+          # Keep package setup independent of the optional Chrome repository.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+            /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y cpio rpm
           gem install --no-document fpm -v 1.17.0

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -53,6 +53,9 @@ jobs:
             echo "Act uses the verified disposable container firewall sandbox."
             exit 0
           fi
+          # Keep package setup independent of the optional Chrome repository.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+            /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
             bubblewrap=0.9.0-1ubuntu0.1


### PR DESCRIPTION
The main package build and Go1.27 evaluation for e604c1cc failed before compilation because the preinstalled Google Chrome APT repository returned an index that did not match its signed release metadata. Neither run produced qualifying artifacts.

Remove only the optional Chrome source-list files from the disposable Ubuntu runners before updating APT in the package, Go evaluation, native-signing and security workflows. These jobs do not install Chrome. Ubuntu package sources, signature verification, checksum checks and fail-closed APT behavior are unchanged. The upstream runner-image Chrome installer also removes this optional repository: https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-google-chrome.sh.

The change is limited to twelve added workflow lines. Product sources, version targets and changelog are unchanged; the normal CI commit preserves v4.10.0. A new merged SHA is needed because native signing requires an attempt1 main-push package build.

Validation:119 existing targeted tests pass across native-signing workflow, Go toolchain evaluation, security gate, package binary provenance and package systemd ordering. Version-contract and Git whitespace checks pass.

Failed infrastructure runs retained for traceability:
- https://github.com/duggytuxy/syswarden/actions/runs/34385014385
- https://github.com/duggytuxy/syswarden/actions/runs/34385181500
