### PR TITLE
CI : complete the Go 1.27 evaluation prerequisites

### DIFF
--- a/.github/workflows/go-127-evaluation.yml
+++ b/.github/workflows/go-127-evaluation.yml
@@ -83,7 +83,8 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
             /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install --yes rpm
+          sudo apt-get install --yes --no-install-recommends \
+            rpm bubblewrap=0.9.0-1ubuntu0.1
           gem install --no-document fpm -v 1.17.0
           tool_dir="${RUNNER_TEMP}/go127-tools"
           install -d -m 0700 "${tool_dir}"
@@ -93,6 +94,55 @@ jobs:
           GOTOOLCHAIN=local "${BASELINE_GO}" version -m "${tool_dir}/nfpm" | \
             grep -F $'mod\tgithub.com/goreleaser/nfpm/v2\tv2.47.0' >/dev/null
           printf 'PATH=%s:%s\n' "${tool_dir}" "${PATH}" >> "${GITHUB_ENV}"
+
+      - name: Prepare enforced firewall test sandbox
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(bwrap --version)" = "bubblewrap 0.9.0"
+          command -v apparmor_parser >/dev/null
+          test -r /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          test "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns)" = "1"
+          test ! -e /etc/apparmor.d/local/bwrap-userns-restrict
+          test ! -e /etc/apparmor.d/local/unpriv_bwrap
+
+          profile=".github/apparmor/bwrap-userns-restrict"
+          printf '%s  %s\n' \
+            'a964037f6cf0df1099f14226b037eaedde6237c86e715188e93eb460b30be859' \
+            "${profile}" | sha256sum --check --strict
+          sudo apparmor_parser --replace --skip-cache "${profile}"
+          sudo grep -Fqx 'bwrap (enforce)' \
+            /sys/kernel/security/apparmor/profiles
+          sudo grep -Fqx 'unpriv_bwrap (enforce)' \
+            /sys/kernel/security/apparmor/profiles
+
+          sandbox_label="$(bwrap \
+            --ro-bind / / \
+            --dev /dev \
+            --proc /proc \
+            --tmpfs /tmp \
+            -- /bin/cat /proc/self/attr/current)"
+          test "${sandbox_label}" = "bwrap//&unpriv_bwrap (enforce)"
+
+          test -x /bin/mount
+          if bwrap \
+            --ro-bind / / \
+            --dev /dev \
+            --proc /proc \
+            --tmpfs /tmp \
+            --dir /tmp/mnt \
+            --uid 0 \
+            --gid 0 \
+            --cap-add ALL \
+            -- /bin/mount -t tmpfs none /tmp/mnt; then
+            echo "ERROR: Bubblewrap child retained usable capabilities." >&2
+            exit 1
+          fi
+
+          GOTOOLCHAIN=local CI=true "${CANDIDATE_GO}" \
+            -C src/core/syswarden-cli test -mod=readonly -count=1 \
+            -run '^Test(NftablesRulesGolden|BubblewrapFirewallGoldenTemporaryDirectoryContract)_SW_QA_001$' \
+            ./pkg/firewall
 
       - name: Run Go 1.27 functional, race and vet gates
         shell: bash
@@ -276,9 +326,26 @@ jobs:
           )
           PY
               test "$(git -C "${checkout}" diff --name-only)" = build_packages.sh
+              # Record the compiler-only experiment in its disposable clone.
+              # The package builder still requires a clean, exact source commit.
+              source_time="$(git -C "${checkout}" show -s --format=%cI HEAD)"
+              GIT_AUTHOR_DATE="${source_time}" GIT_COMMITTER_DATE="${source_time}" \
+                git -C "${checkout}" \
+                  -c user.name='SysWarden toolchain evaluation' \
+                  -c user.email='toolchain-evaluation@syswarden.invalid' \
+                  -c commit.gpgsign=false \
+                  commit --quiet --only \
+                  -m 'CI : isolate the Go 1.27 package experiment' -- build_packages.sh
+              test "$(git -C "${checkout}" rev-parse HEAD^)" = "${CANDIDATE_COMMIT}"
+              test "$(git -C "${checkout}" diff --name-only HEAD^ HEAD)" = build_packages.sh
             else
               test -z "$(git -C "${checkout}" status --short)"
             fi
+            test -z "$(git -C "${checkout}" status --short)"
+            printf 'Package comparison source: role=%s release_commit=%s build_commit=%s builder_sha256=%s\n' \
+              "${role}" "${CANDIDATE_COMMIT}" \
+              "$(git -C "${checkout}" rev-parse HEAD)" \
+              "$(sha256sum "${checkout}/build_packages.sh" | awk '{print $1}')"
             PATH="$(dirname "${tool}"):${PATH}" \
               GOTOOLCHAIN=local "${checkout}/build_packages.sh"
             source_tag="$(PATH="$(dirname "${tool}"):${PATH}" \

--- a/scripts/ci/go_toolchain_evaluation_test.py
+++ b/scripts/ci/go_toolchain_evaluation_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -228,6 +229,94 @@ class GoToolchainEvaluationTests(unittest.TestCase):
                 0,
                 f"run block {index} is not valid bash: {result.stderr}",
             )
+
+    def test_firewall_sandbox_is_enforced_before_functional_tests(self) -> None:
+        sandbox_name = "Prepare enforced firewall test sandbox"
+        self.assertLess(
+            self.workflow.index(sandbox_name),
+            self.workflow.index("Run Go 1.27 functional, race and vet gates"),
+        )
+        preparation = self.workflow.split(sandbox_name, 1)[1].split(
+            "      - name: Run Go 1.27 functional, race and vet gates", 1
+        )[0]
+        audit = (REPOSITORY / ".github/workflows/security-audit.yml").read_text(
+            encoding="utf-8"
+        )
+        start = '          test "$(bwrap --version)"'
+        end = '            echo "ERROR: Bubblewrap child retained usable capabilities."'
+        approved = audit[audit.index(start):audit.index(end)]
+        self.assertIn(approved, preparation)
+        self.assertIn("rpm bubblewrap=0.9.0-1ubuntu0.1", self.workflow)
+        self.assertIn('GOTOOLCHAIN=local CI=true "${CANDIDATE_GO}"', preparation)
+        self.assertIn(
+            "^Test(NftablesRulesGolden|BubblewrapFirewallGoldenTemporaryDirectoryContract)_SW_QA_001$",
+            preparation,
+        )
+        for bypass in ("sysctl -w", "aa-disable", "aa-complain", "|| true"):
+            self.assertNotIn(bypass, preparation)
+
+    def test_package_comparison_prepares_clean_exact_experimental_commit(self) -> None:
+        block = next(
+            block for block in self.run_blocks
+            if 'records="${RUNNER_TEMP}/go127-package-records.tsv"' in block
+        )
+        preparation = block.split('            PATH="$(dirname "${tool}"):', 1)[0]
+        preparation = textwrap.dedent(preparation) + "\ndone\n"
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            runner = root / "runner"
+            runner.mkdir()
+            builder = source / "build_packages.sh"
+            original = "# go1.26.6 go1.26.6\n# Go 1.26.6 Go 1.26.6 Go 1.26.6\n"
+            builder.write_text(original, encoding="utf-8")
+            (source / "product-source.txt").write_text("unchanged product\n", encoding="utf-8")
+
+            def git(directory: Path, *arguments: str) -> str:
+                return subprocess.check_output(
+                    ["git", "-c", "core.fsmonitor=false", "-C", str(directory), *arguments],
+                    text=True, stderr=subprocess.PIPE,
+                ).strip()
+
+            git(source, "init", "--quiet")
+            git(source, "add", "build_packages.sh", "product-source.txt")
+            git(source, "-c", "user.name=Evaluation test", "-c",
+                "user.email=evaluation-test@syswarden.invalid", "-c",
+                "commit.gpgsign=false", "commit", "--quiet", "-m", "Fixture source")
+            original_commit = git(source, "rev-parse", "HEAD")
+            result = subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", preparation],
+                env={
+                    **os.environ,
+                    "GITHUB_WORKSPACE": str(source), "RUNNER_TEMP": str(runner),
+                    "CANDIDATE_COMMIT": original_commit,
+                    "BASELINE_GO": "/unused/baseline/go", "CANDIDATE_GO": "/unused/candidate/go",
+                    "GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "core.fsmonitor",
+                    "GIT_CONFIG_VALUE_0": "false",
+                },
+                text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            baseline = runner / "go127-package-baseline"
+            candidate = runner / "go127-package-candidate"
+            for checkout in (source, baseline, candidate):
+                self.assertEqual(git(checkout, "status", "--porcelain"), "")
+                self.assertEqual((checkout / "product-source.txt").read_text(), "unchanged product\n")
+            self.assertEqual(git(source, "rev-parse", "HEAD"), original_commit)
+            self.assertEqual(git(baseline, "rev-parse", "HEAD"), original_commit)
+            self.assertEqual(git(candidate, "rev-parse", "HEAD^"), original_commit)
+            self.assertEqual(git(candidate, "diff", "--name-only", "HEAD^", "HEAD"), "build_packages.sh")
+            self.assertEqual(
+                git(candidate, "show", "-s", "--format=%cI", "HEAD"),
+                git(source, "show", "-s", "--format=%cI", "HEAD"),
+            )
+            self.assertEqual(builder.read_text(), original)
+            self.assertEqual(
+                (candidate / "build_packages.sh").read_text(),
+                original.replace("go1.26.6", "go1.27.1").replace("Go 1.26.6", "Go 1.27.1"),
+            )
+            self.assertEqual(result.stdout.count("Package comparison source:"), 2)
 
 
 class GoToolchainEvaluationGateTests(unittest.TestCase):


### PR DESCRIPTION
The Go 1.27 evaluation fails because its runner lacks the firewall sandbox and its compiler experiment leaves the package checkout dirty. Install pinned Bubblewrap with the same checksum-bound, enforced AppArmor configuration used by the security audit, then run both firewall sandbox tests before the full suite.

Record the compiler-only builder change as a local commit in the disposable experimental clone. Verify its exact parent, sole changed path and clean state before building, preserve the original source timestamp, and log the release commit, experimental build commit and builder digest. The original checkout remains unchanged. The package builder retains its clean-commit requirement, and the release stays at v4.10.0 with Go 1.26.6.

Validation: 25 toolchain evaluation and release-verdict tests passed, including real temporary Git clones that verify experimental commit isolation, unchanged product bytes and source checkout, exact parent, clean state and preserved timestamp. Every workflow run block passes shell syntax validation. The normal versionctl check preserves v4.10.0 and Git whitespace validation passed. The complete Go 1.27 branch evaluation [34390282706](https://github.com/duggytuxy/syswarden/actions/runs/34390282706) passed on b19f271ae12b3b77c111b9a6e08b722a84530601, including actual package comparison, source rollback and unchanged source verification. All normal PR checks also passed, with three expected skips.
