### PR TITLE
CI : stage exact signed packages for candidate manifests

### DIFF
--- a/.github/workflows/candidate-update-bundle.yml
+++ b/.github/workflows/candidate-update-bundle.yml
@@ -233,15 +233,17 @@ jobs:
           umask 077
           candidate_root="$(mktemp -d "${RUNNER_TEMP%/}/syswarden-candidate-update.XXXXXX")"
           native_dir="${candidate_root}/native-signing"
+          manifest_packages="${candidate_root}/manifest-packages"
           tool_dir="${candidate_root}/tool"
           update_dir="${candidate_root}/update"
           bundle_root="${candidate_root}/bundle"
           install -d -m 0700 \
-            "${native_dir}" "${tool_dir}" "${update_dir}" \
+            "${native_dir}" "${manifest_packages}" "${tool_dir}" "${update_dir}" \
             "${bundle_root}" "${bundle_root}/node01" "${bundle_root}/verification"
           {
             printf 'CANDIDATE_ROOT=%s\n' "${candidate_root}"
             printf 'NATIVE_SIGNING_DIR=%s\n' "${native_dir}"
+            printf 'CANDIDATE_PACKAGES_DIR=%s\n' "${manifest_packages}"
             printf 'MANIFEST_TOOL_DIR=%s\n' "${tool_dir}"
             printf 'UPDATE_DIR=%s\n' "${update_dir}"
             printf 'BUNDLE_ROOT=%s\n' "${bundle_root}"
@@ -336,6 +338,43 @@ jobs:
             ([.rpm.trusted_keys[], .apk.trusted_keys[], .deb.trusted_keys[]] | length == 3)
           ' "${policy}" >/dev/null
 
+      - name: Stage Exact Candidate Manifest Packages
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          umask 077
+          PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY'
+          import os
+          from pathlib import Path
+          from scripts.ci import native_package_signing_bundle as bundle
+
+          source = Path(os.environ["NATIVE_SIGNING_DIR"])
+          destination = Path(os.environ["CANDIDATE_PACKAGES_DIR"])
+          release = os.environ["RELEASE_TAG"]
+          bundle.exact_directory_files(destination, set(), "manifest package staging")
+          bundle.ensure_protected_directory(destination, "manifest package staging")
+          packages = bundle.package_set(
+              source / "packages", release, require_manifest=True, include_deb_signature=True
+          )
+          names = bundle.package_names(release)
+          provenance = bundle.load_json(
+              source / "evidence/NATIVE_SIGNING_PROVENANCE.json", "native signing provenance"
+          )
+          records = [bundle.file_record(names[family], packages[family]) for family in packages]
+          if not bundle.exact_json_equal(
+              sorted(records, key=lambda item: item["name"]), provenance["packages"]["signed"]
+          ):
+              raise SystemExit("manifest packages differ from protected signing provenance")
+          files = {names[family]: data for family, data in packages.items()}
+          for name, data in files.items():
+              bundle.write_exclusive(destination / name, data)
+          bundle.write_exclusive(destination / "SHA256SUMS.txt", bundle.canonical_manifest(files))
+          if bundle.package_set(destination, release, require_manifest=True) != packages:
+              raise SystemExit("staged manifest package bytes changed")
+          PY
+
       - name: Build and Test Candidate Manifest Tool
         id: manifest_tool
         shell: bash
@@ -403,11 +442,11 @@ jobs:
           test -n "${SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY}"
           "${manifest_tool}" generate \
             --repository "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" \
-            --packages "${NATIVE_SIGNING_DIR}/packages" --output "${UPDATE_DIR}"
+            --packages "${CANDIDATE_PACKAGES_DIR}" --output "${UPDATE_DIR}"
           unset SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY
           env -u SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY "${manifest_tool}" verify \
             --repository "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" \
-            --packages "${NATIVE_SIGNING_DIR}/packages" \
+            --packages "${CANDIDATE_PACKAGES_DIR}" \
             --manifest "${manifest_path}" --signature "${signature_path}"
           version="${RELEASE_TAG#v}"
           install -m 0600 -- \

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -960,7 +960,7 @@ jobs:
           env -u SYSWARDEN_UPDATE_ED25519_PRIVATE_KEY GOFLAGS=-mod=readonly \
             go run ./scripts/ci/update_manifest.go verify \
               --repository "${GITHUB_WORKSPACE}" --tag "${RELEASE_TAG}" \
-              --packages "${NATIVE_SIGNING_DIR}/packages" \
+              --packages "${CANDIDATE_PACKAGES_DIR}" \
               --manifest "${manifest}" --signature "${signature}"
           cmp -- "${deb}" "${NATIVE_SIGNING_DIR}/packages/${deb_name}"
           cmp -- "${deb_signature}" "${NATIVE_SIGNING_DIR}/packages/${deb_name}.asc"

--- a/scripts/ci/candidate_update_bundle_workflow_test.py
+++ b/scripts/ci/candidate_update_bundle_workflow_test.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 import re
 import subprocess
+import tempfile
 import textwrap
 import unittest
 from pathlib import Path
@@ -208,6 +212,7 @@ class CandidateUpdateBundleWorkflowTests(unittest.TestCase):
             "Validate Exact Untagged Candidate Source",
             "Enforce One Successful Candidate Producer Per Commit",
             "Verify Exact Qualified Native Package Source",
+            "Stage Exact Candidate Manifest Packages",
             "Build and Test Candidate Manifest Tool",
             "Revalidate Candidate Manifest Tool Before Secret Exposure",
         ):
@@ -215,6 +220,99 @@ class CandidateUpdateBundleWorkflowTests(unittest.TestCase):
                 self.workflow.index(prior),
                 self.workflow.index("Generate and Verify Protected Candidate Manifest"),
             )
+
+    def manifest_staging_fixture(self, root: Path) -> tuple[Path, Path, dict[str, bytes]]:
+        source = root / "native-signing"
+        packages = source / "packages"
+        packages.mkdir(parents=True, mode=0o700)
+        evidence = source / "evidence"
+        evidence.mkdir(mode=0o700)
+        destination = root / "manifest-packages"
+        destination.mkdir(mode=0o700)
+        files = {
+            name: ("unit fixture: " + name + "\n").encode("ascii")
+            for name in (
+                "syswarden-4.10.0-1.x86_64.rpm",
+                "syswarden_4.10.0_amd64.deb",
+                "syswarden_4.10.0_x86_64.apk",
+            )
+        }
+        records = [
+            {"name": name, "sha256": hashlib.sha256(data).hexdigest(), "size": len(data)}
+            for name, data in sorted(files.items())
+        ]
+        (evidence / "NATIVE_SIGNING_PROVENANCE.json").write_text(
+            json.dumps({"packages": {"signed": records}}), encoding="ascii"
+        )
+        files["syswarden_4.10.0_amd64.deb.asc"] = b"unit detached signature\n"
+        for name, data in files.items():
+            (packages / name).write_bytes(data)
+        files["SHA256SUMS.txt"] = "".join(
+            f"{hashlib.sha256(data).hexdigest()}  {name}\n"
+            for name, data in sorted(files.items())
+        ).encode("ascii")
+        (packages / "SHA256SUMS.txt").write_bytes(files["SHA256SUMS.txt"])
+        return source, destination, files
+
+    def run_manifest_staging(self, source: Path, destination: Path) -> subprocess.CompletedProcess:
+        step = workflow_step(self.workflow, "Stage Exact Candidate Manifest Packages")
+        script, = literal_run_blocks(step)
+        return subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", script], cwd=ROOT,
+            env={**os.environ, "NATIVE_SIGNING_DIR": str(source),
+                 "CANDIDATE_PACKAGES_DIR": str(destination), "RELEASE_TAG": "v4.10.0"},
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_actual_staging_preserves_signed_source_and_exact_manifest_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source, destination, original = self.manifest_staging_fixture(Path(temporary))
+            result = self.run_manifest_staging(source, destination)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            expected = {name: data for name, data in original.items()
+                        if name.endswith((".rpm", ".deb", ".apk"))}
+            expected["SHA256SUMS.txt"] = "".join(
+                f"{hashlib.sha256(data).hexdigest()}  {name}\n"
+                for name, data in sorted(expected.items())
+            ).encode("ascii")
+            self.assertEqual({p.name: p.read_bytes() for p in destination.iterdir()}, expected)
+            self.assertEqual({p.name: p.read_bytes() for p in (source / "packages").iterdir()}, original)
+            for path in destination.iterdir():
+                self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+                self.assertEqual(path.stat().st_nlink, 1)
+            signing = workflow_step(self.workflow, "Generate and Verify Protected Candidate Manifest")
+            self.assertEqual(signing.count('--packages "${CANDIDATE_PACKAGES_DIR}"'), 2)
+            self.assertNotIn('--packages "${NATIVE_SIGNING_DIR}/packages"', signing)
+            self.assertIn('"${BUNDLE_ROOT}/verification/"', signing)
+
+    def test_actual_staging_rejects_tampering_links_and_destination_collisions(self) -> None:
+        for mutation in ("package", "signature", "checksum", "provenance", "extra", "symlink", "collision"):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
+                source, destination, original = self.manifest_staging_fixture(Path(temporary))
+                packages = source / "packages"
+                if mutation in ("package", "signature", "checksum"):
+                    name = {"package": "syswarden_4.10.0_amd64.deb",
+                            "signature": "syswarden_4.10.0_amd64.deb.asc",
+                            "checksum": "SHA256SUMS.txt"}[mutation]
+                    (packages / name).write_bytes(original[name] + b"tampered\n")
+                elif mutation == "provenance":
+                    path = source / "evidence/NATIVE_SIGNING_PROVENANCE.json"
+                    document = json.loads(path.read_text())
+                    document["packages"]["signed"][0]["sha256"] = "0" * 64
+                    path.write_text(json.dumps(document))
+                elif mutation == "extra":
+                    (packages / "extra").write_bytes(b"extra\n")
+                elif mutation == "symlink":
+                    path = packages / "syswarden_4.10.0_amd64.deb"
+                    target = source / "linked-deb"
+                    path.rename(target)
+                    path.symlink_to(target)
+                else:
+                    (destination / "SHA256SUMS.txt").write_bytes(b"preserve\n")
+                before = {p.name: p.read_bytes() for p in destination.iterdir()}
+                result = self.run_manifest_staging(source, destination)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual({p.name: p.read_bytes() for p in destination.iterdir()}, before)
 
     def test_descriptor_attestation_and_inventory_are_exact(self) -> None:
         for contract in (
@@ -267,6 +365,7 @@ class CandidateUpdateBundleWorkflowTests(unittest.TestCase):
             "Resolve Exact Qualified Native Signing Bundle",
             "Download Exact Native Signing Bundle by Artifact ID",
             "Verify Exact Qualified Native Package Source",
+            "Stage Exact Candidate Manifest Packages",
             "Build and Test Candidate Manifest Tool",
             "Revalidate Candidate Manifest Tool Before Secret Exposure",
             "Generate and Verify Protected Candidate Manifest",

--- a/scripts/ci/release_qualification_workflow_test.py
+++ b/scripts/ci/release_qualification_workflow_test.py
@@ -1260,11 +1260,13 @@ class ReleaseQualificationWorkflowTests(unittest.TestCase):
             'gh attestation verify "${descriptor}"',
             "--deny-self-hosted-runners",
             "update_manifest.go verify",
+            '--packages "${CANDIDATE_PACKAGES_DIR}"',
             'cmp -- "${deb}"',
             'cmp -- "${deb_signature}"',
             "producer_attestation_sha256",
         ):
             self.assertIn(contract, verify)
+        self.assertNotIn('--packages "${NATIVE_SIGNING_DIR}/packages"', verify)
         for contract in (
             'qualification_bundle_identity == $bundle_identity',
             'qualification_bundle_descriptor_sha256 == $descriptor_sha256',


### PR DESCRIPTION
The protected candidate updater failed because the native signing package directory includes the detached DEB signature, while the update manifest requires exactly three packages and their checksums.

Stage the verified signed RPM, DEB and APK in a private package directory before exposing the signing secret. Bind every staged byte to the protected signing provenance, produce the exact three-entry checksum manifest, and preserve the original signing bundle and detached signature. Point the qualification consumer at its existing package-only directory as well. The manifest inventory guard, signature verification, artifact seals and v4.10.0 remain unchanged.

Validation: 93 candidate workflow, native signing bundle and release qualification tests passed; Go manifest tests passed; the actual workflow staging, generation and verification passed with explicit unit packages and an RFC 8032 test key. Staging the downloaded signed bundle preserved all 19 original files. Tampered packages, signatures, checksums and provenance, extra files, symlinks and destination collisions are rejected. Normal versionctl validation preserves v4.10.0; Bash syntax, whitespace and the commit signature passed.
