### PR TITLE
CI : verify RPM ownership across purge and rollback

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1201,6 +1201,8 @@ jobs:
             --after-install "${PACKAGE_RPM_SCRIPTS}/postinst.sh" \
             --before-remove "${PACKAGE_RPM_SCRIPTS}/prerm.sh" \
             --after-remove "${PACKAGE_RPM_SCRIPTS}/postrm.sh" \
+            --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
+            --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
             --directories /usr/share/doc/syswarden \
             -C "${STAGING_AMD64}" .
 
@@ -1243,6 +1245,8 @@ jobs:
             --directories /var/lib/syswarden \
             --directories /var/lib/syswarden/ui \
             --directories /var/log/syswarden \
+            --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
+            --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
             --rpm-attr "0750,root,root:/etc/syswarden" \
             --rpm-attr "0750,root,root:/etc/syswarden/config" \
             --rpm-attr "0750,root,root:/etc/syswarden/config/modules" \

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1085,6 +1085,8 @@ fi
         --rpm-rpmbuild-define "clamp_mtime_to_source_date_epoch 1" \
         --rpm-rpmbuild-define "_buildhost syswarden-build.invalid" \
         "${RPM_BUILD_ID_FPM_OPTIONS[@]}" \
+        --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
+        --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
         --directories /usr/share/doc/syswarden \
         -p "${PACKAGE_WORKSPACE}/${RPM_PACKAGE_FILENAME}" \
         -C staging-rpm .

--- a/docs/technical/NATIVE_PACKAGE_LIFECYCLE_QUALIFICATION_V4.10.0.md
+++ b/docs/technical/NATIVE_PACKAGE_LIFECYCLE_QUALIFICATION_V4.10.0.md
@@ -69,7 +69,12 @@ legacy units under `/etc/systemd/system` were migrated, that the package-owned
 units under `/usr/lib/systemd/system` are the authoritative loaded fragments,
 and that the installed package-owned profile is exact. The rollback scenario
 must prove the inverse transition: the standard units are authoritative again
-and no package-owned vendor payload from v4.10.0 remains.
+and no profile-specific vendor payload from v4.10.0 remains. The shared
+WireGuard ordering drop-in is present in the public v4.04.3 RPM and must remain:
+the rollback proof verifies its exact bytes, safe file and parent metadata, and
+ownership by `syswarden-4.04.3-1.x86_64`. It must not claim that shared file is
+absent. Both final purge checkpoints still require the drop-in and its directory
+to be absent.
 
 For both package-owned purge scenarios, run the verified SysWarden cleanup
 before the final native RPM erase. The cleanup must stop and disable the exact

--- a/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
+++ b/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
@@ -177,6 +177,8 @@ assemble_profile_rpm() {
         --directories /var/lib/syswarden \
         --directories /var/lib/syswarden/ui \
         --directories /var/log/syswarden \
+        --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
+        --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
         --rpm-attr "0750,root,root:/etc/syswarden" \
         --rpm-attr "0750,root,root:/etc/syswarden/config" \
         --rpm-attr "0750,root,root:/etc/syswarden/config/modules" \

--- a/extensions/rhel-package-owned/verify-rpm.py
+++ b/extensions/rhel-package-owned/verify-rpm.py
@@ -117,6 +117,7 @@ SHARED_PAYLOAD_RECORDS = {
     ),
     "/usr/share/bash-completion/completions/syswarden": ("-rw-r--r--", ""),
     "/usr/share/doc/syswarden": ("drwxr-xr-x", ""),
+    "/usr/lib/systemd/system/syswarden-firewall.service.d": ("drwxr-xr-x", ""),
     "/usr/share/doc/syswarden/GEOIP-DATA-LICENSE.txt": ("-rw-r--r--", ""),
     "/usr/share/doc/syswarden/LICENSE.txt": ("-rw-r--r--", ""),
 }

--- a/scripts/ci/native_lifecycle_contract_v4.10.0.json
+++ b/scripts/ci/native_lifecycle_contract_v4.10.0.json
@@ -253,7 +253,7 @@
       "candidate-clean-install": ["offline_chroot_stage_succeeded", "active_systemd_not_required_during_stage", "package_owned_units_installed", "package_owned_configuration_installed", "package_owned_firewall_assets_installed", "first_real_boot_observed", "first_real_boot_services_activated", "first_real_boot_firewall_activated"],
       "clean-cycle-uninstall-purge": ["package_owned_units_removed", "package_owned_dropin_removed", "package_owned_preset_removed", "package_owned_profile_removed", "package_owned_enablement_removed", "erase_ready_boundary_consumed"],
       "candidate-upgrade-v4043-v4100": ["legacy_systemd_units_migrated", "package_owned_units_authoritative", "package_owned_profile_attested"],
-      "verified-rollback-v4100-v4043": ["standard_systemd_units_authoritative", "package_owned_vendor_payload_absent"],
+      "verified-rollback-v4100-v4043": ["standard_systemd_units_authoritative", "package_owned_vendor_payload_absent", "standard_ordering_dropin_owned_and_intact"],
       "candidate-reupgrade-v4043-v4100": ["legacy_systemd_units_migrated", "package_owned_units_authoritative", "package_owned_profile_attested"],
       "candidate-final-uninstall-purge": ["package_owned_units_removed", "package_owned_dropin_removed", "package_owned_preset_removed", "package_owned_profile_removed", "package_owned_enablement_removed", "erase_ready_boundary_consumed"]
     },
@@ -261,7 +261,7 @@
       "candidate-clean-install": ["offline_chroot_stage_succeeded", "active_systemd_not_required_during_stage", "package_owned_units_installed", "package_owned_configuration_installed", "package_owned_firewall_assets_installed", "first_real_boot_observed", "first_real_boot_services_activated", "first_real_boot_firewall_activated"],
       "clean-cycle-uninstall-purge": ["package_owned_units_removed", "package_owned_dropin_removed", "package_owned_preset_removed", "package_owned_profile_removed", "package_owned_enablement_removed", "erase_ready_boundary_consumed"],
       "candidate-upgrade-v4043-v4100": ["legacy_systemd_units_migrated", "package_owned_units_authoritative", "package_owned_profile_attested"],
-      "verified-rollback-v4100-v4043": ["standard_systemd_units_authoritative", "package_owned_vendor_payload_absent"],
+      "verified-rollback-v4100-v4043": ["standard_systemd_units_authoritative", "package_owned_vendor_payload_absent", "standard_ordering_dropin_owned_and_intact"],
       "candidate-reupgrade-v4043-v4100": ["legacy_systemd_units_migrated", "package_owned_units_authoritative", "package_owned_profile_attested"],
       "candidate-final-uninstall-purge": ["package_owned_units_removed", "package_owned_dropin_removed", "package_owned_preset_removed", "package_owned_profile_removed", "package_owned_enablement_removed", "erase_ready_boundary_consumed"]
     }
@@ -275,8 +275,6 @@
     "/var/lib/.syswarden-rhelpo-postun-recovery-v1.new",
     "/usr/lib/systemd/system/syswarden-core.service",
     "/usr/lib/systemd/system/syswarden-firewall.service",
-    "/usr/lib/systemd/system/syswarden-firewall.service.d",
-    "/usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf",
     "/usr/lib/systemd/system-preset/90-syswarden-rhel-image.preset",
     "/usr/libexec/syswarden",
     "/usr/libexec/syswarden/rhelpo-postun-recovery-v1",

--- a/scripts/ci/native_lifecycle_evidence.py
+++ b/scripts/ci/native_lifecycle_evidence.py
@@ -18,11 +18,11 @@ from typing import Any, Sequence
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONTRACT = ROOT / "scripts/ci/native_lifecycle_contract_v4.10.0.json"
-CONTRACT_SHA256 = "4948a3dab989c7537755862d882f3589400ed01d984c2e22dce56fc680a81230"
+CONTRACT_SHA256 = "6fdc20d732a2f9601eba4add202956bbb53aa62e14df65489ed9724f31da0f29"
 OBSERVATION_SCHEMA = "syswarden-native-package-lifecycle-observation/v1"
 VERDICT_SCHEMA = "syswarden-native-package-lifecycle-verdict/v1"
 RHEL_PACKAGE_OWNED_ROLLBACK_EVIDENCE_SCHEMA = (
-    "syswarden-rhel-package-owned-rollback-vendor-absence/v1"
+    "syswarden-rhel-package-owned-rollback-vendor-absence/v2"
 )
 REPOSITORY = "duggytuxy/syswarden"
 TARGET_RELEASE = "v4.10.0"
@@ -136,6 +136,7 @@ RHEL_PACKAGE_OWNED_SCENARIO_CHECKS = {
     "verified-rollback-v4100-v4043": [
         "standard_systemd_units_authoritative",
         "package_owned_vendor_payload_absent",
+        "standard_ordering_dropin_owned_and_intact",
     ],
     "candidate-reupgrade-v4043-v4100": [
         "legacy_systemd_units_migrated",
@@ -160,8 +161,6 @@ RHEL_PACKAGE_OWNED_ROLLBACK_ABSENCE_PATHS = (
     "/var/lib/.syswarden-rhelpo-postun-recovery-v1.new",
     "/usr/lib/systemd/system/syswarden-core.service",
     "/usr/lib/systemd/system/syswarden-firewall.service",
-    "/usr/lib/systemd/system/syswarden-firewall.service.d",
-    "/usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf",
     "/usr/lib/systemd/system-preset/90-syswarden-rhel-image.preset",
     "/usr/libexec/syswarden",
     "/usr/libexec/syswarden/rhelpo-postun-recovery-v1",
@@ -169,6 +168,19 @@ RHEL_PACKAGE_OWNED_ROLLBACK_ABSENCE_PATHS = (
     "/etc/systemd/system/multi-user.target.wants/syswarden-core.service.syswarden-rhelpo-migration",
     "/etc/systemd/system/multi-user.target.wants/syswarden-firewall.service.syswarden-rhelpo-migration",
 )
+STANDARD_ROLLBACK_ORDERING = {
+    "directory": {
+        "path": "/usr/lib/systemd/system/syswarden-firewall.service.d",
+        "type": "directory", "mode": "0755", "uid": 0, "gid": 0,
+    },
+    "file": {
+        "path": "/usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf",
+        "type": "regular", "mode": "0644", "uid": 0, "gid": 0,
+        "nlink": 1, "size": 43,
+        "sha256": "8c4b31f25436882197beec8c8bff5a7599389e564593bd7c353aa99ef3854483",
+        "rpm_owner": "syswarden-4.04.3-1.x86_64",
+    },
+}
 EXPECTED_PROFILE_SCENARIO_CHECKS = {
     "RPM-A9-RHELPO": RHEL_PACKAGE_OWNED_SCENARIO_CHECKS,
     "RPM-A10-RHELPO": RHEL_PACKAGE_OWNED_SCENARIO_CHECKS,
@@ -649,6 +661,7 @@ def _validate_rhel_package_owned_rollback_evidence(
             "checked_path_count",
             "present_path_count",
             "path_inventory",
+            "standard_ordering_dropin",
         },
         "RHEL package-owned rollback raw evidence",
     )
@@ -693,6 +706,15 @@ def _validate_rhel_package_owned_rollback_evidence(
         raise LifecycleEvidenceError(
             "RHEL package-owned rollback path inventory is not exact"
         )
+    ordering = _exact(
+        evidence["standard_ordering_dropin"], set(STANDARD_ROLLBACK_ORDERING),
+        "standard rollback ordering payload",
+    )
+    for name, expected in STANDARD_ROLLBACK_ORDERING.items():
+        observed = _exact(ordering[name], set(expected), "standard rollback ordering payload")
+        if any(type(observed[key]) is not type(value) or observed[key] != value
+               for key, value in expected.items()):
+            raise LifecycleEvidenceError("standard rollback ordering payload is not exact")
 
 
 def _validate_host(

--- a/scripts/ci/native_lifecycle_evidence_test.py
+++ b/scripts/ci/native_lifecycle_evidence_test.py
@@ -326,6 +326,7 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
                     {"path": path, "state": "absent", "errno": "ENOENT"}
                     for path in rollback_paths
                 ],
+                "standard_ordering_dropin": copy.deepcopy(evidence.STANDARD_ROLLBACK_ORDERING),
             }
         self.attach(
             item,
@@ -782,6 +783,7 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
                 {
                     "standard_systemd_units_authoritative",
                     "package_owned_vendor_payload_absent",
+                    "standard_ordering_dropin_owned_and_intact",
                 },
             )
             for scenario_id in (
@@ -816,6 +818,31 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
             self.assertEqual(raw_document["present_path_count"], 0)
 
             mutations = (
+                (
+                    "missing standard ordering payload",
+                    lambda value: value.pop("standard_ordering_dropin"),
+                    "keys are not exact",
+                ),
+                (
+                    "wrong standard ordering digest",
+                    lambda value: value["standard_ordering_dropin"]["file"].update({"sha256": "0" * 64}),
+                    "ordering payload",
+                ),
+                (
+                    "wrong standard package owner",
+                    lambda value: value["standard_ordering_dropin"]["file"].update({"rpm_owner": "syswarden-4.10.0-1.rhelpo.x86_64"}),
+                    "ordering payload",
+                ),
+                (
+                    "unsafe standard ordering directory",
+                    lambda value: value["standard_ordering_dropin"]["directory"].update({"type": "symlink"}),
+                    "ordering payload",
+                ),
+                (
+                    "boolean standard file owner",
+                    lambda value: value["standard_ordering_dropin"]["file"].update({"uid": False}),
+                    "ordering payload",
+                ),
                 (
                     "present vendor path",
                     lambda value: value["path_inventory"][0].update(

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -1228,6 +1228,10 @@ class PackageLifecycleContractTests(unittest.TestCase):
             self.assertEqual(
                 rpm_block.count("--directories /usr/share/doc/syswarden"), 1
             )
+            self.assertEqual(
+                rpm_block.count("--directories /usr/lib/systemd/system/syswarden-firewall.service.d"),
+                1,
+            )
         self.assertIn("prepare_rpm_scriptlet() {", workflow_script_preparation)
         self.assertIn("prepare_rpm_scriptlet() {", local)
         for source in (workflow_script_preparation, local):

--- a/scripts/ci/package_lifecycle_lab.py
+++ b/scripts/ci/package_lifecycle_lab.py
@@ -830,6 +830,8 @@ SYSTEMD_WIREGUARD_ORDERING_DROPIN_PATH = (
     "10-syswarden-wireguard-ordering.conf"
 )
 SYSTEMD_WIREGUARD_ORDERING_DROPIN_FIRST_VERSION = "4.04.3"
+SYSTEMD_ORDERING_RPM_DIRECTORY = "/usr/lib/systemd/system/syswarden-firewall.service.d"
+SYSTEMD_ORDERING_RPM_DIRECTORY_FIRST_VERSION = "4.10.0"
 SYSTEMD_WIREGUARD_ORDERING_DROPIN_SHA256 = (
     "8c4b31f25436882197beec8c8bff5a7599389e564593bd7c353aa99ef3854483"
 )
@@ -2856,6 +2858,15 @@ version_uses_systemd_wireguard_ordering_payload() {
     }
 }
 
+package_owns_systemd_ordering_directory() {
+    package_uses_systemd_wireguard_ordering_payload "$1" || return
+    [ "${PACKAGE_FAMILY}" = rpm ] || return 1
+    [ "${systemd_ordering_major}" -gt 4 ] || {
+        [ "${systemd_ordering_major}" -eq 4 ] && \
+            [ "${systemd_ordering_minor}" -ge 10 ]
+    }
+}
+
 package_uses_systemd_wireguard_ordering_payload() {
     systemd_ordering_role="$1"
     case "${systemd_ordering_role}" in
@@ -2916,6 +2927,10 @@ validate_manifest_contract() {
         systemd_ordering_payload=1
         required_manifest_path "${manifest}" \
             /usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf || return 1
+        if package_owns_systemd_ordering_directory "${artifact_role}"; then
+            required_manifest_path "${manifest}" \
+                /usr/lib/systemd/system/syswarden-firewall.service.d || return 1
+        fi
         if [ "${PACKAGE_FAMILY}" = deb ]; then
             for systemd_ordering_directory in \
                 /usr/lib \
@@ -2974,7 +2989,11 @@ validate_manifest_contract() {
                 allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
             elif [ "${geoip_data_license_payload}" -eq 1 ] && \
                  [ "${systemd_ordering_payload}" -eq 1 ]; then
-                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden|usr/share/doc/syswarden/(GEOIP-DATA-LICENSE|LICENSE)\.txt|usr/lib/systemd/system/syswarden-firewall\.service\.d/10-syswarden-wireguard-ordering\.conf|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
+                allowed='^/(opt/syswarden/bin/syswarden-(cli|core|tui)|opt/syswarden/signatures\.json|usr/local/bin/syswarden(-tui)?|usr/share/bash-completion/completions/syswarden|usr/share/doc/syswarden|usr/share/doc/syswarden/(GEOIP-DATA-LICENSE|LICENSE)\.txt|usr/lib/systemd/system/syswarden-firewall\.service\.d(/10-syswarden-wireguard-ordering\.conf)?|usr/lib/\.build-id|usr/lib/\.build-id/[0-9a-f]{2}|usr/lib/\.build-id/[0-9a-f]{2}/[0-9a-f]{38})$'
+                if ! package_owns_systemd_ordering_directory "${artifact_role}"; then
+                    required_manifest_path "${manifest}" \
+                        /usr/lib/systemd/system/syswarden-firewall.service.d && return 1
+                fi
                 required_manifest_path "${manifest}" \
                     /usr/share/doc/syswarden || return 1
             elif [ "${geoip_data_license_payload}" -eq 1 ]; then
@@ -3075,6 +3094,10 @@ validate_inventory_contract() {
             /usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf \
             file 644 \
             8c4b31f25436882197beec8c8bff5a7599389e564593bd7c353aa99ef3854483 || return 1
+        if package_owns_systemd_ordering_directory "${artifact_role}"; then
+            inventory_has_exact_entry "${inventory}" \
+                /usr/lib/systemd/system/syswarden-firewall.service.d directory 755 - || return 1
+        fi
     else
         systemd_ordering_payload_rc=$?
         [ "${systemd_ordering_payload_rc}" -eq 1 ] || return 1
@@ -6668,6 +6691,13 @@ def _uses_systemd_wireguard_ordering_payload(
     )
 
 
+def _owns_systemd_ordering_directory(family: str, version: str) -> bool:
+    return family == "rpm" and (
+        parse_syswarden_version(version)
+        >= parse_syswarden_version(SYSTEMD_ORDERING_RPM_DIRECTORY_FIRST_VERSION)
+    )
+
+
 def _validate_manager_paths(
     family: str,
     paths: list[str],
@@ -6757,6 +6787,7 @@ def _validate_manager_paths(
     expected = (
         expected_payload_paths
         | ({RPM_DOCUMENTATION_ROOT} if license_payloads else set())
+        | ({SYSTEMD_ORDERING_RPM_DIRECTORY} if _owns_systemd_ordering_directory(family, version) else set())
         | {"/usr/lib/.build-id"}
         | required_build_directories
         | build_links
@@ -6945,6 +6976,14 @@ def validate_inventory_snapshot(
             raise LifecycleLabError("DEB generated changelog inventory is invalid")
     if family == "rpm":
         build_id_targets: set[str] = set()
+        if _owns_systemd_ordering_directory(family, version):
+            directory = entries[SYSTEMD_ORDERING_RPM_DIRECTORY]
+            if (
+                directory["type"] != "directory"
+                or directory["mode"] != "755"
+                or directory["value"] != "-"
+            ):
+                raise LifecycleLabError("RPM ordering directory metadata is not exact")
         if license_payloads:
             documentation_root = entries[RPM_DOCUMENTATION_ROOT]
             if (

--- a/scripts/ci/package_lifecycle_lab_test.py
+++ b/scripts/ci/package_lifecycle_lab_test.py
@@ -165,6 +165,8 @@ class _LegacyFakePodmanRunner(package_lifecycle_lab.CommandRunner):
                     path_set.add(
                         package_lifecycle_lab.SYSTEMD_WIREGUARD_ORDERING_DROPIN_PATH
                     )
+                if package_lifecycle_lab.parse_syswarden_version(version) >= (4, 10, 0):
+                    path_set.add(package_lifecycle_lab.SYSTEMD_ORDERING_RPM_DIRECTORY)
                 paths = sorted(path_set)
             filesystem: list[str] = []
             for path in paths:
@@ -1116,6 +1118,8 @@ class PackageLifecycleLabTests(unittest.TestCase):
             )
             if licensed:
                 path_set.add(package_lifecycle_lab.RPM_DOCUMENTATION_ROOT)
+            if package_lifecycle_lab.parse_syswarden_version(version) >= (4, 10, 0):
+                path_set.add(package_lifecycle_lab.SYSTEMD_ORDERING_RPM_DIRECTORY)
             if systemd_ordering:
                 path_set.add(
                     package_lifecycle_lab.SYSTEMD_WIREGUARD_ORDERING_DROPIN_PATH
@@ -4731,6 +4735,37 @@ probe
                     ).returncode,
                     0,
                 )
+
+    def test_rpm_ordering_directory_ownership_is_version_bound(self) -> None:
+        def shell_inventory(filesystem):
+            return [
+                "\t".join(str(entry[key]) for key in ("path", "type", "mode", "uid", "gid", "value"))
+                for entry in filesystem
+            ]
+
+        directory = package_lifecycle_lab.SYSTEMD_ORDERING_RPM_DIRECTORY
+        for version in ("4.04.3", "4.10.0"):
+            paths, filesystem = self.exact_v404x_inventory("rpm", version, "candidate")
+            package_lifecycle_lab.validate_inventory_snapshot(
+                "rpm", paths, filesystem, role="candidate", version=version,
+                candidate_version=version,
+            )
+            result = self.run_embedded_inventory_contract(
+                "rpm", paths, shell_inventory(filesystem), role="candidate",
+                version=version, candidate_version=version,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            wrong_paths = sorted(set(paths) ^ {directory})
+            with self.assertRaises(package_lifecycle_lab.LifecycleLabError):
+                package_lifecycle_lab._validate_manager_paths(
+                    "rpm", wrong_paths, role="candidate", version=version,
+                    candidate_version=version,
+                )
+            result = self.run_embedded_inventory_contract(
+                "rpm", wrong_paths, role="candidate", version=version,
+                candidate_version=version,
+            )
+            self.assertNotEqual(result.returncode, 0)
 
     def test_systemd_ordering_runtime_attestation_is_version_bound(self) -> None:
         source = package_lifecycle_lab.LIFECYCLE_SCRIPT

--- a/scripts/ci/package_systemd_ordering_artifact_gate.py
+++ b/scripts/ci/package_systemd_ordering_artifact_gate.py
@@ -22,6 +22,7 @@ RELATIVE_PATH = (
     "10-syswarden-wireguard-ordering.conf"
 )
 ABSOLUTE_PATH = "/" + RELATIVE_PATH
+DIRECTORY_PATH = str(Path(ABSOLUTE_PATH).parent)
 RPM_QUERY_FORMAT = (
     "[%{FILENAMES}\\t%{FILEMODES:perms}\\t%{FILEUSERNAME}\\t"
     "%{FILEGROUPNAME}\\t%{FILESIZES}\\t%{FILEDIGESTS}\\n]"
@@ -198,12 +199,15 @@ def validate_rpm(package: Path, expected: bytes, contract: ContentContract) -> N
     if inventory.returncode != 0 or "\x00" in inventory.stdout or "\r" in inventory.stdout:
         raise OrderingArtifactError("cannot inspect the RPM ordering inventory")
     matches = []
+    directories = []
     for line in inventory.stdout.splitlines():
         fields = line.split("\t")
         if len(fields) != 6:
             raise OrderingArtifactError("RPM inventory record is malformed")
         if fields[0] == ABSOLUTE_PATH:
             matches.append(fields)
+        if fields[0] == DIRECTORY_PATH:
+            directories.append(fields)
     if len(matches) != 1:
         raise OrderingArtifactError("RPM ordering member count is not exactly one")
     path, permissions, owner, group, size, digest = matches[0]
@@ -216,6 +220,17 @@ def validate_rpm(package: Path, expected: bytes, contract: ContentContract) -> N
         or digest != contract.sha256
     ):
         raise OrderingArtifactError("RPM ordering member metadata is not exact")
+    if len(directories) != 1:
+        raise OrderingArtifactError("RPM ordering directory ownership is not exactly one")
+    _, permissions, owner, group, size, digest = directories[0]
+    if (
+        permissions != "drwxr-xr-x"
+        or owner != "root"
+        or group != "root"
+        or re.fullmatch(r"[0-9]+", size) is None
+        or digest != ""
+    ):
+        raise OrderingArtifactError("RPM ordering directory metadata is not exact")
 
     producer = subprocess.Popen(
         ["rpm2cpio", str(package)], stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/scripts/ci/package_systemd_ordering_artifact_gate_test.py
+++ b/scripts/ci/package_systemd_ordering_artifact_gate_test.py
@@ -186,6 +186,7 @@ class OrderingArtifactGateTests(unittest.TestCase):
     def test_rpm_member_contract_is_exact(self) -> None:
         inventory = (
             f"{gate.ABSOLUTE_PATH}\t-rw-r--r--\troot\troot\t43\t{CONTRACT.sha256}\n"
+            f"{gate.DIRECTORY_PATH}\tdrwxr-xr-x\troot\troot\t0\t\n"
         )
         run_results = [
             subprocess.CompletedProcess([], 0, "8\n", ""),
@@ -205,6 +206,30 @@ class OrderingArtifactGateTests(unittest.TestCase):
             gate.subprocess, "Popen", return_value=Producer()
         ):
             gate.validate_rpm(self.root / "candidate.rpm", CONTENT, CONTRACT)
+
+    def test_rpm_requires_one_safe_owned_ordering_directory(self) -> None:
+        member = (
+            f"{gate.ABSOLUTE_PATH}\t-rw-r--r--\troot\troot\t43\t{CONTRACT.sha256}\n"
+        )
+        directory = f"{gate.DIRECTORY_PATH}\tdrwxr-xr-x\troot\troot\t0\t\n"
+        for record in (
+            "",
+            directory + directory,
+            directory.replace("drwxr-xr-x", "lrwxrwxrwx"),
+            directory.replace("drwxr-xr-x", "drwxrwxrwx"),
+            directory.replace("\troot\troot\t", "\toperator\troot\t"),
+            directory.replace("\t0\t\n", "\t0\t" + CONTRACT.sha256 + "\n"),
+        ):
+            with self.subTest(record=record), mock.patch.object(
+                gate.subprocess,
+                "run",
+                side_effect=(
+                    subprocess.CompletedProcess([], 0, "8\n", ""),
+                    subprocess.CompletedProcess([], 0, member + record, ""),
+                ),
+            ):
+                with self.assertRaisesRegex(gate.OrderingArtifactError, "ordering directory"):
+                    gate.validate_rpm(self.root / "candidate.rpm", CONTENT, CONTRACT)
 
     def test_rpm_rejects_non_sha256_or_ambiguous_inventory(self) -> None:
         bad_algorithm = subprocess.CompletedProcess([], 0, "1\n", "")


### PR DESCRIPTION
The native AlmaLinux 9.8 purge left an empty systemd drop-in directory because the RPM installed its file without owning the parent directory. Both RPM variants now own that exact directory with root:root 0755 metadata. Artifact and lifecycle validation reject missing or unsafe ownership; RPM removes an empty directory and preserves an unrelated operator file.

The RHEL rollback contract also incorrectly required the shared WireGuard ordering file to be absent, although the verified public v4.04.3 RPM contains it. Rollback evidence now requires its exact baseline digest, file and directory metadata, and v4.04.3 package ownership, while still requiring every profile-specific vendor path to be absent. The final purge residue inventory is unchanged.

Validation:
- Package artifact, lifecycle inventory, native evidence and RHEL profile unit suites passed.
- Real FPM/RPM isolated install and erase proved empty-directory removal and unrelated-file preservation; the artifact gate rejected the original unowned shape.
- Full RHEL package-owned assembly and chroot lifecycle test passed. The sandbox could not run systemd-analyze credential-socket verification; the existing test reports that skip explicitly.
- Version validation passed: the change preserves exactly v4.10.0. Fresh signed packages and native release qualification are still required after merge.
