### PR TITLE
CI : preserve nested allocation isolation without procfs

### DIFF
--- a/scripts/ci/performance_v4100.md
+++ b/scripts/ci/performance_v4100.md
@@ -391,8 +391,10 @@ launcher runs only under privileged-mode `/usr/bin/bash` and uses the real
 target of `/usr/bin/python3` in isolated mode. It binds both interpreter
 digests and identities before and after production. Its outer filesystem starts
 empty and allowlists only the root-owned runtime directories, `os-release`,
-the exact read-only inputs, and the new read-write evidence root. Host `/run`,
-`/tmp`, and `/var/tmp` are not exposed. Repository and module-cache trees are
+the exact read-only inputs, and the new read-write evidence root.
+The fixed `/bin` link resolves to the already read-only `/usr/bin` runtime so
+Git can launch its local transport through `/bin/sh`.
+Host `/run`, `/tmp`, and `/var/tmp` are not exposed. Repository and module-cache trees are
 scanned before Git is invoked and fail on a special file, symlink, nested
 filesystem, unsafe owner, or unsafe mode. An outer Unix-socket canary must be
 unreachable before the attestation can claim egress denial. Temporary detached

--- a/scripts/ci/performance_v4100.md
+++ b/scripts/ci/performance_v4100.md
@@ -400,7 +400,15 @@ build checkouts live inside the evidence workspace and remain writable by the
 trusted producer; this is not represented as a read-only checkout guarantee.
 Every candidate and baseline probe runs inside a second minimal bubblewrap
 filesystem and separately unshared network. The producer runs a nested
-Unix-socket canary before any measured probe. The launcher fails if either
+Unix-socket canary before any measured probe. Nested sandboxes expose no
+`/proc`: the outer procfs has protected submounts that prevent mounting another
+procfs in a nested user namespace. The probe still has a separate PID namespace
+and executes the verified probe bound read-only at a fixed entrypoint. The
+probe requires that exact entrypoint, an absent procfs, isolated PID ancestry,
+and a kernel-confirmed read-only mount before checking its own file metadata
+and SHA-256. The producer retains and checks its original open descriptor
+before and after execution. The canary checks the absent procfs and PID ancestry as
+well as the hidden outer socket. The launcher fails if either
 namespace or canary cannot be established, or if post-execution raw-bundle
 validation fails.
 

--- a/scripts/ci/source_allocation_probe.go
+++ b/scripts/ci/source_allocation_probe.go
@@ -41,6 +41,7 @@ const (
 	maxRequestBytes  = 64 * 1024
 	maxFixtureBytes  = 64 * 1024
 	maxCatalogBytes  = 1024 * 1024
+	sandboxProbePath = "/syswarden-allocation-probe"
 )
 
 var (
@@ -275,6 +276,33 @@ func readBounded(path string, maximum int64, requiredMode os.FileMode) ([]byte, 
 	return raw, nil
 }
 
+func probeExecutable() (string, error) {
+	path, err := os.Executable()
+	if err == nil {
+		return path, nil
+	}
+	// The trusted nested launcher exposes no procfs. It executes this exact
+	// read-only bind mount, whose bytes are independently checked below and
+	// whose source descriptor remains checked by the producer before and after.
+	if !errors.Is(err, os.ErrNotExist) || len(os.Args) != 1 || os.Args[0] != sandboxProbePath ||
+		os.Getpid() != 2 || os.Getppid() != 1 {
+		return "", errors.New("probe executable is not the fixed isolated entrypoint")
+	}
+	if _, procErr := os.Lstat("/proc"); !errors.Is(procErr, os.ErrNotExist) {
+		return "", errors.New("isolated probe unexpectedly exposes procfs")
+	}
+	info, err := os.Lstat(sandboxProbePath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("isolated probe entrypoint is not a regular file")
+	}
+	var filesystem syscall.Statfs_t
+	// Linux statfs ST_RDONLY is bit zero; require the actual mount flag.
+	if err := syscall.Statfs(sandboxProbePath, &filesystem); err != nil || filesystem.Flags&1 == 0 {
+		return "", errors.New("isolated probe entrypoint is not mounted read-only")
+	}
+	return sandboxProbePath, nil
+}
+
 func readExecutable(path string, maximum int64) ([]byte, error) {
 	file, err := os.Open(path) // #nosec G304 -- opened executable identity is verified by fstat and SHA-256.
 	if err != nil {
@@ -413,7 +441,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "probe kernel architecture is not x86_64")
 		os.Exit(1)
 	}
-	executable, err := os.Executable()
+	executable, err := probeExecutable()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "resolve probe executable:", err)
 		os.Exit(1)

--- a/scripts/ci/source_allocation_producer.py
+++ b/scripts/ci/source_allocation_producer.py
@@ -435,7 +435,10 @@ def _verify_nested_unix_socket_isolation(
         listener.bind(str(canary_path))
         listener.listen(1)
         code = (
-            "import errno,socket,sys;"
+            "import errno,os,socket,sys;"
+            "\nif os.path.lexists('/proc'): raise SystemExit(5)"
+            "\nif os.getpid() != 2 or os.getppid() != 1: raise SystemExit(6)"
+            "\n"
             "client=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM);"
             "\ntry: client.connect(sys.argv[1])"
             "\nexcept OSError as error:"
@@ -469,8 +472,6 @@ def _verify_nested_unix_socket_isolation(
                 "/var",
                 "--tmpfs",
                 "/var/tmp",
-                "--proc",
-                "/proc",
                 "--dev",
                 "/dev",
                 "--clearenv",
@@ -1196,9 +1197,6 @@ def _invoke_probe(
                 "--unshare-pid",
                 "--unshare-ipc",
                 "--unshare-uts",
-                "--ro-bind",
-                str(binary.parent),
-                str(binary.parent),
                 "--dir",
                 "/run",
                 "--tmpfs",
@@ -1207,14 +1205,23 @@ def _invoke_probe(
                 "/var",
                 "--tmpfs",
                 "/var/tmp",
-                "--proc",
-                "/proc",
+                # Mount inputs after private temporary roots so a workspace
+                # beneath /tmp or /var/tmp remains visible and read-only.
+                "--ro-bind",
+                str(binary.parent),
+                str(binary.parent),
+                # The outer procfs contains protected submounts. Linux refuses
+                # a fresh procfs in this nested user namespace. Expose no procfs
+                # and bind the verified probe at its fixed read-only entrypoint.
+                "--ro-bind",
+                str(binary),
+                "/syswarden-allocation-probe",
                 "--dev",
                 "/dev",
                 "--chdir",
                 "/",
                 "--",
-                f"/proc/self/fd/{descriptor}",
+                "/syswarden-allocation-probe",
             ]
         elif sandbox_sha256 is not None:
             raise AllocationProducerError(

--- a/scripts/ci/source_allocation_producer_test.py
+++ b/scripts/ci/source_allocation_producer_test.py
@@ -376,6 +376,7 @@ class SourceAllocationProducerTests(unittest.TestCase):
             "--unshare-user",
             "--unshare-net",
             "--ro-bind /usr /usr",
+            "--symlink usr/bin /bin",
             "--tmpfs /tmp",
             '--bind "${output_root}" "${output_root}"',
             "--prepared-output-root",
@@ -434,7 +435,8 @@ class SourceAllocationProducerTests(unittest.TestCase):
         # A standalone canary does not reproduce the outer procfs submounts.
         # Execute the same canary inside the actual outer namespace shape.
         code = (
-            "import hashlib,sys; from pathlib import Path; "
+            "import hashlib,subprocess,sys; from pathlib import Path; "
+            "subprocess.run(['/bin/sh','-c','test -x /usr/bin/git'],check=True); "
             "sys.path.insert(0,sys.argv[1]); "
             "import source_allocation_producer as p; "
             "p._verify_nested_unix_socket_isolation("
@@ -446,7 +448,8 @@ class SourceAllocationProducerTests(unittest.TestCase):
                 str(sandbox), "--die-with-parent", "--new-session",
                 "--unshare-user", "--unshare-net", "--unshare-pid",
                 "--unshare-ipc", "--unshare-uts",
-                "--ro-bind", "/usr", "/usr", "--ro-bind", "/lib", "/lib",
+                "--ro-bind", "/usr", "/usr", "--symlink", "usr/bin", "/bin",
+                "--ro-bind", "/lib", "/lib",
                 "--ro-bind-try", "/lib64", "/lib64",
                 "--ro-bind", str(producer.REPOSITORY), str(producer.REPOSITORY),
                 "--dir", "/run", "--tmpfs", "/tmp", "--dir", "/var",

--- a/scripts/ci/source_allocation_producer_test.py
+++ b/scripts/ci/source_allocation_producer_test.py
@@ -425,6 +425,40 @@ class SourceAllocationProducerTests(unittest.TestCase):
             python_target,
         )
 
+    @unittest.skipUnless(platform.system() == "Linux" and os.geteuid() == 0, "protected root runner")
+    def test_probe_canary_runs_inside_the_outer_root_namespace(self) -> None:
+        sandbox = producer.SYSTEM_BWRAP
+        if not sandbox.is_file() or sandbox.stat().st_uid != 0:
+            self.skipTest("canonical root-owned /usr/bin/bwrap is unavailable")
+        python_target = producer.SYSTEM_PYTHON_ENTRY.resolve(strict=True)
+        # A standalone canary does not reproduce the outer procfs submounts.
+        # Execute the same canary inside the actual outer namespace shape.
+        code = (
+            "import hashlib,sys; from pathlib import Path; "
+            "sys.path.insert(0,sys.argv[1]); "
+            "import source_allocation_producer as p; "
+            "p._verify_nested_unix_socket_isolation("
+            "p.SYSTEM_BWRAP,hashlib.sha256(p.SYSTEM_BWRAP.read_bytes()).hexdigest(),"
+            "p.SYSTEM_PYTHON_ENTRY.resolve(strict=True))"
+        )
+        completed = subprocess.run(
+            [
+                str(sandbox), "--die-with-parent", "--new-session",
+                "--unshare-user", "--unshare-net", "--unshare-pid",
+                "--unshare-ipc", "--unshare-uts",
+                "--ro-bind", "/usr", "/usr", "--ro-bind", "/lib", "/lib",
+                "--ro-bind-try", "/lib64", "/lib64",
+                "--ro-bind", str(producer.REPOSITORY), str(producer.REPOSITORY),
+                "--dir", "/run", "--tmpfs", "/tmp", "--dir", "/var",
+                "--tmpfs", "/var/tmp", "--proc", "/proc", "--dev", "/dev",
+                "--clearenv", "--setenv", "PATH", "/usr/bin:/bin",
+                "--", str(python_target), "-I", "-c", code,
+                str(producer.REPOSITORY / "scripts" / "ci"),
+            ],
+            capture_output=True, timeout=30,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr.decode())
+
     @unittest.skipUnless(platform.system() == "Linux", "Linux launcher")
     def test_qualifying_launcher_ignores_python_path_injection(self) -> None:
         injected = self.root / "injected"
@@ -717,6 +751,39 @@ class SourceAllocationProducerTests(unittest.TestCase):
         byte_delta = int(counters["total_alloc_bytes_after"]) - int(counters["total_alloc_bytes_before"])
         self.assertEqual(malloc_delta == 0, byte_delta == 0)
         self.assertEqual(counters["gc_cycles_before"], counters["gc_cycles_after"])
+        sandbox = producer.SYSTEM_BWRAP
+        if sandbox.is_file() and sandbox.stat().st_uid == 0:
+            isolated_raw = producer._invoke_probe(
+                probe, probe_sha, request, 30,
+                sandbox_executable=sandbox,
+                sandbox_sha256=hashlib.sha256(sandbox.read_bytes()).hexdigest(),
+            )
+            isolated = json.loads(isolated_raw)
+            self.assertEqual(isolated["workload"], document["workload"])
+            self.assertEqual(isolated["subject"]["probe_binary_sha256"], probe_sha)
+            mismatched = dict(request, probe_binary_sha256="f" * 64)
+            with self.assertRaisesRegex(producer.AllocationProducerError, "executable identity mismatch"):
+                producer._invoke_probe(
+                    probe, probe_sha, mismatched, 30,
+                    sandbox_executable=sandbox,
+                    sandbox_sha256=hashlib.sha256(sandbox.read_bytes()).hexdigest(),
+                )
+            real_popen = subprocess.Popen
+
+            def writable_entrypoint(command, *args, **kwargs):
+                changed = list(command)
+                index = changed.index("/syswarden-allocation-probe")
+                self.assertEqual(changed[index - 2:index], ["--ro-bind", str(probe)])
+                changed[index - 2] = "--bind"
+                return real_popen(changed, *args, **kwargs)
+
+            with mock.patch.object(producer.subprocess, "Popen", side_effect=writable_entrypoint):
+                with self.assertRaisesRegex(producer.AllocationProducerError, "not mounted read-only"):
+                    producer._invoke_probe(
+                        probe, probe_sha, request, 30,
+                        sandbox_executable=sandbox,
+                        sandbox_sha256=hashlib.sha256(sandbox.read_bytes()).hexdigest(),
+                    )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/source_allocation_sandbox.sh
+++ b/scripts/ci/source_allocation_sandbox.sh
@@ -249,6 +249,7 @@ outer_sandbox_arguments=(
     --unshare-ipc
     --unshare-uts
     --ro-bind /usr /usr
+    --symlink usr/bin /bin
     --ro-bind /lib /lib
     --ro-bind-try /lib64 /lib64
     --ro-bind "${os_release_source}" /etc/os-release


### PR DESCRIPTION
The protected native allocation run stops before measurements because the outer bubblewrap procfs contains protected submounts and Linux rejects mounting another procfs in the nested user namespace. Nested probes now retain separate user, network, PID, IPC and UTS namespaces while exposing no procfs. The producer binds the verified executable read-only at a fixed entrypoint; the probe checks that entrypoint, isolated PID ancestry, the kernel read-only mount flag, file metadata and its SHA-256 before measuring the unchanged Engine.Scan workload.

Inputs are mounted after private temporary roots so workspaces under /tmp or /var/tmp remain visible. A fixed /bin link points to the already read-only /usr/bin runtime so Git can use its local transport. A new root-runner regression executes the socket canary inside the real outer namespace shape, and real Go probe tests reject an incorrect executable digest and a writable executable mount.

Validation: producer suite 25 tests passed with two explicit environment skips; allocation gate suite 20 tests passed; actual nested root canary passed on Debian 13; SSH commit signature verified; version validator confirms v4.10.0. The complete protected Debian 13 source allocation rehearsal passed: 60 fresh-process samples, two exact metrics and zero stable regressions, with outer and nested socket controls, offline dependencies and recorded CPU/RAM/PID/wall-time/filesystem bounds. The exported raw bundle independently passed validation again. All 18 GitHub checks completed: 15 successes and three expected skips. Native qualification and public release remain pending.
