### PR TITLE
Fix : preserve native RHEL library directory permissions

### DIFF
--- a/extensions/rhel-package-owned/README.md
+++ b/extensions/rhel-package-owned/README.md
@@ -166,6 +166,12 @@ frontend before first boot. Existing firewalld deployments are preserved.
 Direct nftables deployments remain valid. Ambiguous or conflicting firewall
 frontends must still fail through the normal SysWarden runtime checks.
 
+The distribution-owned `/usr/lib` parent may retain its native root-owned
+`0555` mode or use `0755`. Installation, runtime attestation and erase preserve
+that mode. This allowance applies only to that shared parent; dedicated product
+directories, ownership, symlink rejection and all other metadata checks remain
+exact.
+
 The package deliberately owns only the protected configuration directories,
 not an administrator's TOML files. This makes an image pipeline free to seed
 its approved configuration after the RPM transaction. Later RPM upgrades do

--- a/extensions/rhel-package-owned/inventory.json
+++ b/extensions/rhel-package-owned/inventory.json
@@ -205,7 +205,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "47e365db8be55981db47d5c10cc15a30a371fce96a36c1997592f7bde5c1a210",
+      "sha256": "0eaaf275afec8a24a8c93bcd1419c31b608be1259ede53a12c29ba16e75b89dd",
       "rpm_ownership": "scriptlet",
       "rpm_package": "syswarden",
       "role": "rpm-pre-install"
@@ -231,7 +231,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "a328d09a4e6ae5899365bad10a7f2b1a2a1d2a8aa675b2e35e03d5b720208bb5",
+      "sha256": "f8aeeeaf0ea95819da83d8892fb8c6247a7709ec61ae1694a75da131486e5ea3",
       "rpm_ownership": "scriptlet",
       "rpm_package": "syswarden",
       "role": "rpm-pre-uninstall"

--- a/extensions/rhel-package-owned/scriptlets/pre-install.sh
+++ b/extensions/rhel-package-owned/scriptlets/pre-install.sh
@@ -66,7 +66,12 @@ exact_existing_directory() {
         return 0
     fi
     [ -d "$path" ] && [ ! -L "$path" ] || fail "Refusing unsafe RPM payload directory: $path"
-    [ "$(/usr/bin/stat -Lc '%u:%g:%a' -- "$path")" = "0:0:${mode}" ] || \
+    metadata="$(/usr/bin/stat -Lc '%u:%g:%a' -- "$path")"
+    # RHEL filesystem packages ship this shared parent read-only.
+    if [ "$path" = /usr/lib ] && [ "$mode" = 755 ] && [ "$metadata" = '0:0:555' ]; then
+        return 0
+    fi
+    [ "$metadata" = "0:0:${mode}" ] || \
         fail "Refusing modified RPM payload directory metadata: $path"
 }
 

--- a/extensions/rhel-package-owned/scriptlets/pre-uninstall.sh
+++ b/extensions/rhel-package-owned/scriptlets/pre-uninstall.sh
@@ -261,7 +261,13 @@ if [ "$1" -eq 0 ]; then
         parent_mode="${parent_and_mode##*:}"
         [ -d "$parent_path" ] && [ ! -L "$parent_path" ] || \
             fail "Refusing unsafe RPM payload ancestry before erase: $parent_path"
-        [ "$(/usr/bin/stat -Lc '%u:%g:%a' -- "$parent_path")" = "0:0:${parent_mode}" ] || \
+        parent_metadata="$(/usr/bin/stat -Lc '%u:%g:%a' -- "$parent_path")"
+        # Preserve the distribution-owned read-only shared parent.
+        if [ "$parent_path" = /usr/lib ] && [ "$parent_mode" = 755 ] && \
+           [ "$parent_metadata" = '0:0:555' ]; then
+            continue
+        fi
+        [ "$parent_metadata" = "0:0:${parent_mode}" ] || \
             fail "Refusing modified RPM payload ancestry before erase: $parent_path"
     done
     for preset_marker in \

--- a/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
+++ b/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
@@ -22,6 +22,13 @@ cleanup() {
     trap - EXIT HUP INT TERM
     case "${TEST_WORKSPACE}" in
         /tmp/syswarden-rhel-profile-rpm-test.*)
+            if [ "${RPM_ROOT_MODE:-}" = user-namespace ]; then
+                for root in "${CHROOT_ROOT}" "${CLEAN_CHROOT_ROOT}"; do
+                    if [ -d "${root}/usr/lib" ] && [ ! -L "${root}/usr/lib" ]; then
+                        chmod u+w -- "${root}/usr/lib" || status=1
+                    fi
+                done
+            fi
             if [ "${RPM_ROOT_MODE:-}" = sudo ]; then
                 for root in "${CHROOT_ROOT}" "${CLEAN_CHROOT_ROOT}"; do
                     if [ -d "${root}" ]; then
@@ -799,6 +806,8 @@ for root in "${CLEAN_CHROOT_ROOT}" "${CHROOT_ROOT}"; do
     [[ "$(run_in_chroot "${root}" /usr/bin/rpm --eval '%{_dbpath}')" == \
         /usr/lib/sysimage/rpm ]]
     rpm_at_root "${root}" --initdb
+    # Match the native RHEL parent after creating the fixture RPM database.
+    chroot_admin chmod 0555 -- "${root}/usr/lib"
 done
 
 expect_clean_install_refusal() {
@@ -813,6 +822,12 @@ expect_clean_install_refusal() {
         exit 1
     fi
 }
+
+for unsafe_library_mode in 0550 0750 0775; do
+    chroot_admin chmod "${unsafe_library_mode}" -- "${CLEAN_CHROOT_ROOT}/usr/lib"
+    expect_clean_install_refusal "unsupported shared /usr/lib mode ${unsafe_library_mode}"
+done
+chroot_admin chmod 0555 -- "${CLEAN_CHROOT_ROOT}/usr/lib"
 
 # RPM follows directory symlinks while extracting its payload. The PREIN must
 # reject every reserved payload-root redirection before any package bytes land.
@@ -1470,4 +1485,7 @@ prepare_exact_erase_state "${CHROOT_ROOT}"
 rpm_at_root "${CHROOT_ROOT}" --erase syswarden
 assert_final_absence "${CHROOT_ROOT}"
 
+for root in "${CLEAN_CHROOT_ROOT}" "${CHROOT_ROOT}"; do
+    [[ "$(run_in_chroot "${root}" /usr/bin/stat -Lc '%u:%g:%a' -- /usr/lib)" == 0:0:555 ]]
+done
 printf '%s\n' 'RHEL package-owned RPM assembly contract passed.'

--- a/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux.go
+++ b/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux.go
@@ -801,9 +801,16 @@ func attestRHELPackageOwnedDirectory(
 		return removalArtifactIdentity{}, err
 	}
 	identity, identityErr := exactRemovalArtifactIdentity(info)
+	modeMatches := info.Mode().Perm() == expectedMode
+	// RHEL filesystem packages own /usr/lib with mode 0555. This shared
+	// parent stays read-only; dedicated product directories remain exact.
+	if expectedMode == 0755 && info.Mode().Perm() == 0555 &&
+		filepath.Clean(path) == filepath.Join(trustedRoot, "usr", "lib") {
+		modeMatches = true
+	}
 	if identityErr != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() ||
 		info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 ||
-		info.Mode().Perm() != expectedMode || identity.uid != expectedUID || identity.gid != expectedGID {
+		!modeMatches || identity.uid != expectedUID || identity.gid != expectedGID {
 		return removalArtifactIdentity{}, errors.Join(
 			fmt.Errorf("RHEL package-owned directory is not exact: %s", path), identityErr,
 		)

--- a/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux_test.go
@@ -118,6 +118,47 @@ func testSuccessfulRHELPackagePayloadAttestation() error {
 	return nil
 }
 
+func TestRHELPackageOwnedDistributionLibraryDirectoryModes(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		path string
+		mode os.FileMode
+		want bool
+	}{
+		{name: "native read-only library parent", path: "usr/lib", mode: 0555, want: true},
+		{name: "writable root library parent", path: "usr/lib", mode: 0755, want: true},
+		{name: "group writable library parent", path: "usr/lib", mode: 0775},
+		{name: "restricted library parent", path: "usr/lib", mode: 0550},
+		{name: "unapproved library parent mode", path: "usr/lib", mode: 0750},
+		{name: "other shared parent stays exact", path: "usr/libexec", mode: 0555},
+		{name: "product directory stays exact", path: "usr/libexec/syswarden", mode: 0555},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			installTestRHELPackageOwnedProfile(t, root)
+			path := filepath.Join(root, test.path)
+			if err := os.Chmod(path, test.mode); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := os.Chmod(path, 0755); err != nil { // #nosec G302 -- restore the private fixture directory for cleanup
+					t.Error(err)
+				}
+			}()
+			host := testRHELPackageOwnedHost(t, root)
+			present, err := host.attest()
+			if (err == nil && present) != test.want {
+				t.Fatalf("attest() = (%t, %v), want accepted=%t", present, err, test.want)
+			}
+			info, statErr := os.Lstat(path)
+			if statErr != nil || info.Mode().Perm() != test.mode {
+				t.Fatalf("attestation changed directory metadata: %v", statErr)
+			}
+		})
+	}
+}
+
 func installTestRHELPackageOwnedProductSkeleton(t *testing.T, root string) {
 	t.Helper()
 	for _, path := range rhelPackageOwnedProductDirectories {


### PR DESCRIPTION
Native AlmaLinux 9.8 and 10.2 ship the distribution-owned `/usr/lib` directory as root-owned `0555`. The package-owned v4.10.0 RPM rejected this intact directory during PREIN, and runtime and PREUN attestation applied the same incompatible assumption.

Accept exactly root-owned `0555` or `0755` for this shared parent during installation, runtime attestation and erase, preserving the existing directory mode. Keep dedicated product directories and every other ownership, mode and symlink check exact. Update the scriptlet source digests and exercise both accepted modes and rejected alternatives. The complete RPM lifecycle fixture now retains the native `0555` parent throughout installation, migration, rollback and erase.

Validation:
- Targeted Go RHEL ownership regressions passed.
- Python staging and package lifecycle contracts passed: 117 tests, 6 existing environment skips.
- Version controller reports exactly v4.10.0; whitespace checks pass.
- Native failure and unmodified distribution metadata were captured independently on AlmaLinux 9 and 10.
- Full local RPM assembly is blocked by RPM database creation permissions, also reproduced with a separate new 0755 root. The full CI assembly/lifecycle check is required before merge.

All previously signed candidate artifacts remain tied to their original commit and must be regenerated after this correction is merged. Public release qualification remains pending.
