### PR TITLE
Fix : recognize OpenSSH session authentication records

### DIFF
--- a/src/core/syswarden-core/engine/ssh_session_catalog_test.go
+++ b/src/core/syswarden-core/engine/ssh_session_catalog_test.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+)
+
+func TestProductionSSHSessionAuthentication(t *testing.T) {
+	detector := newProductionTestEngine(t)
+	for _, process := range []string{"sshd", "sshd-session"} {
+		for _, address := range []string{"192.0.2.44", "2001:db8::44"} {
+			for _, prefix := range []string{"", "Sep 10 11:53:27 gateway "} {
+				for _, event := range []string{
+					"Invalid user native-probe",
+					"Failed password for invalid user native-probe",
+					"Failed password for root",
+					"POSSIBLE BREAK-IN attempt",
+				} {
+					line := fmt.Sprintf("%s%s[7393]: %s from %s port 33071", prefix, process, event, address)
+					t.Run(line, func(t *testing.T) {
+						match := detector.Scan(line)
+						if match == nil || match.RuleID != "ssh-auth" || match.Action != "track" || match.Service != "sshd" {
+							t.Fatalf("native SSH authentication record was not tracked: %#v", match)
+						}
+						if match.Host != netip.MustParseAddr(address) || !match.MetricEligible || match.RiskCategory != "brute_force" {
+							t.Fatalf("SSH source or risk attribution changed: %#v", match)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestProductionSSHSessionRejectsNonAuthenticationAndForgedIdentity(t *testing.T) {
+	detector := newProductionTestEngine(t)
+	for _, line := range []string{
+		"Sep 10 11:53:27 gateway sshd-session[7393]: Accepted publickey for root from 192.0.2.44 port 33071 ssh2",
+		"Sep 10 11:53:27 gateway sshd-session[7393]: Connection closed by invalid user native-probe 192.0.2.44 port 33071 [preauth]",
+		"Sep 10 11:53:27 gateway not-sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"Sep 10 11:53:27 gateway sshd-session-extra[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"Sep 10 11:53:27 gateway sshd-session[7393]: Invalid user native-probe from 999.0.2.44 port 33071",
+		"Sep 10 11:53:27 gateway nginx[7393]: sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+	} {
+		t.Run(line, func(t *testing.T) {
+			if match := detector.Scan(line); match != nil {
+				t.Fatalf("non-authentication or forged SSH record was admitted: %#v", match)
+			}
+		})
+	}
+	line := "Sep 10 11:53:27 gateway sshd-session[7393]: Failed password for invalid user alice from 198.51.100.99 from 192.0.2.44 port 33071 ssh2"
+	match := detector.Scan(line)
+	if match == nil || match.RuleID != "ssh-auth" || match.Host != netip.MustParseAddr("192.0.2.44") {
+		t.Fatalf("username redirected the SSH enforcement address: %#v", match)
+	}
+}

--- a/src/core/syswarden-core/signatures.json
+++ b/src/core/syswarden-core/signatures.json
@@ -98,7 +98,7 @@
     {
       "id": "ssh-auth",
       "type": "regex",
-      "pattern": "^(?:[A-Z][a-z]{2}[[:space:]]+[0-9]{1,2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]+[^[:space:]]+[[:space:]]+)?sshd(?:\\[[0-9]+\\])?:[[:space:]]+(?:Failed password for|Invalid user|POSSIBLE BREAK-IN).*?from <HOST>(?: port [0-9]+(?: ssh[0-9]+)?)?(?: \\[preauth\\])?[[:space:]]*$",
+      "pattern": "^(?:[A-Z][a-z]{2}[[:space:]]+[0-9]{1,2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]+[^[:space:]]+[[:space:]]+)?sshd(?:-session)?(?:\\[[0-9]+\\])?:[[:space:]]+(?:Failed password for|Invalid user|POSSIBLE BREAK-IN).*?from <HOST>(?: port [0-9]+(?: ssh[0-9]+)?)?(?: \\[preauth\\])?[[:space:]]*$",
       "service": "sshd",
       "action": "track",
       "trusted_host_capture": true


### PR DESCRIPTION
Real native qualification on AlmaLinux 9 recorded four controlled invalid-user SSH attempts under `sshd-session`, but the candidate detected zero events and created no ban. The production `ssh-auth` signature only accepted `sshd`.

Accept the exact `sshd-session` process name alongside `sshd`, retaining the existing record anchors, trusted terminal source capture, tracking action and risk attribution. Regression tests cover both names, IPv4 and IPv6, timestamped and direct records, ordinary non-authentication messages, forged process identities and an injected address in the username.

Validation: the new regression failed before the signature change; `go test ./engine ./network ./telemetry` passes with Go 1.26.6. The version contract confirms that this change preserves v4.10.0. Corrected signed packages still require fresh native qualification before release.
