### PR TITLE
Fix : check HA ownership before local unblock

### DIFF
--- a/docs/technical/HA_V2_OPERATOR_PREREQUISITES.md
+++ b/docs/technical/HA_V2_OPERATOR_PREREQUISITES.md
@@ -8,6 +8,8 @@ HA v2 accepts exactly two statically identified nodes in one cluster epoch. Conf
 
 The operator owns role assignment, cluster epoch changes, certificate issuance, certificate rotation, secret distribution, firewall reachability, backups, and explicit recovery decisions. SysWarden does not elect a writer and does not automatically promote a standby.
 
+The legacy CLI `unblock` operation cannot remove HA v2 replicated ownership. It refuses HA v2 before touching persistent lists or the local firewall. In HA v1, the CLI holds the native-sync fence lease across local removal and peer synchronization, so an active or transitioning fence stops the operation before local changes. Use only the supported authenticated, source-owned integration route for integration claims; that route cannot remove an independent core-runtime claim.
+
 ## Required configuration
 
 Set `integrations.ha.enabled = true` and `integrations.ha.v2_enabled = true` only after all of these values are ready:

--- a/src/core/syswarden-cli/pkg/firewall/lists.go
+++ b/src/core/syswarden-cli/pkg/firewall/lists.go
@@ -1412,30 +1412,32 @@ func RemoveFromBlocklist(ip string) error {
 	if err != nil {
 		return fmt.Errorf("invalid IP address: %w", err)
 	}
-	if _, err := preflightConfiguredFirewallBackendMutation(); err != nil {
-		return fmt.Errorf("validate firewall backend before blocklist mutation: %w", err)
-	}
+	return network.WithHAUnbanMutation(func(syncUnban func([]string) error) error {
+		if _, err := preflightConfiguredFirewallBackendMutation(); err != nil {
+			return fmt.Errorf("validate firewall backend before blocklist mutation: %w", err)
+		}
 
-	path := BlocklistV6
-	if entry.isIPv4 {
-		path = BlocklistV4
-	}
-	target, err := approvedListFileForPath(path)
-	if err != nil {
-		return err
-	}
-	sanitizeTargets, err := approvedLegacyOperatorListTargets()
-	if err != nil {
-		return err
-	}
-	return removeFromBlocklistAt(
-		entry.network,
-		target,
-		sanitizeTargets,
-		os.Stdout,
-		applyPoliciesWithDynamicUnban,
-		network.SyncHAUnban,
-	)
+		path := BlocklistV6
+		if entry.isIPv4 {
+			path = BlocklistV4
+		}
+		target, err := approvedListFileForPath(path)
+		if err != nil {
+			return err
+		}
+		sanitizeTargets, err := approvedLegacyOperatorListTargets()
+		if err != nil {
+			return err
+		}
+		return removeFromBlocklistAt(
+			entry.network,
+			target,
+			sanitizeTargets,
+			os.Stdout,
+			applyPoliciesWithDynamicUnban,
+			syncUnban,
+		)
+	})
 }
 
 func removeFromBlocklistAt(

--- a/src/core/syswarden-cli/pkg/firewall/unban_fence_preflight_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/unban_fence_preflight_test.go
@@ -1,0 +1,22 @@
+package firewall
+
+import (
+	"strings"
+	"testing"
+
+	"syswarden-cli/config"
+)
+
+func TestUnblockRejectsHAV2BeforeAnyBackendOrListOperation(t *testing.T) {
+	previous := config.GlobalConfig
+	t.Cleanup(func() { config.GlobalConfig = previous })
+	for _, enabled := range []bool{true, false} {
+		config.GlobalConfig = &config.Config{
+			HAEnabled: enabled, HAV2Enabled: true, FirewallBackend: "iptables",
+		}
+		err := RemoveFromBlocklist("198.51.100.7")
+		if err == nil || !strings.Contains(err.Error(), "HA v2") || strings.Contains(err.Error(), "firewall backend") {
+			t.Fatalf("HA enabled=%t: unblock reached backend preflight before the HA v2 refusal: %v", enabled, err)
+		}
+	}
+}

--- a/src/core/syswarden-cli/pkg/network/ha_unban_lease.go
+++ b/src/core/syswarden-cli/pkg/network/ha_unban_lease.go
@@ -1,0 +1,56 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"syswarden-cli/config"
+)
+
+// WithHAUnbanMutation holds the native-sync fence across the caller's local
+// list and kernel transaction and its peer synchronization. The supplied sync
+// callback uses that held lease and must be invoked before the caller returns.
+func WithHAUnbanMutation(mutate func(func([]string) error) error) error {
+	cfg := config.GlobalConfig
+	if cfg == nil || cfg.HAV2Enabled {
+		_, err := acquireHAUnbanLease(cfg, nil)
+		return err
+	}
+	if mutate == nil {
+		return fmt.Errorf("local unblock operation is unavailable")
+	}
+	if !cfg.HAEnabled {
+		return mutate(func([]string) error { return nil })
+	}
+	options, err := defaultHASyncOptions()
+	if err != nil {
+		return err
+	}
+	return withHAUnbanMutation(cfg, options, mutate)
+}
+
+func withHAUnbanMutation(cfg *config.Config, options haSyncOptions, mutate func(func([]string) error) error) error {
+	release, err := acquireHAUnbanLease(cfg, options.legacyFence)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return mutate(func(ips []string) error {
+		return syncHAUnbanUnderLease(context.Background(), cfg, ips, options)
+	})
+}
+
+func acquireHAUnbanLease(cfg *config.Config, fence *haLegacyWriterFence) (func(), error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("HA configuration is unavailable before local unblock")
+	}
+	if cfg.HAV2Enabled {
+		return nil, fmt.Errorf("local unblock is unavailable with HA v2: a legacy unban cannot remove replicated runtime ownership")
+	}
+	if !cfg.HAEnabled {
+		return func() {}, nil
+	}
+	if fence == nil {
+		return nil, fmt.Errorf("HA native-sync fence is unavailable before local unblock")
+	}
+	return acquireHALegacyWriterLease(fence)
+}

--- a/src/core/syswarden-cli/pkg/network/ha_unban_lease_test.go
+++ b/src/core/syswarden-cli/pkg/network/ha_unban_lease_test.go
@@ -1,0 +1,120 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"syswarden-cli/config"
+)
+
+func TestHAUnbanLeaseRejectsUnsupportedOwnershipBeforeOpeningFence(t *testing.T) {
+	for _, cfg := range []*config.Config{nil, {HAV2Enabled: true}, {HAEnabled: true, HAV2Enabled: true}, {HAEnabled: true}} {
+		if release, err := acquireHAUnbanLease(cfg, nil); err == nil || release != nil {
+			t.Fatalf("unsupported ownership acquired a lease: release present=%t err=%v", release != nil, err)
+		}
+	}
+	release, err := acquireHAUnbanLease(&config.Config{}, nil)
+	if err != nil || release == nil {
+		t.Fatalf("standalone unblock requires HA infrastructure: %v", err)
+	}
+	release()
+}
+
+func TestHAUnbanLeasePreventsFenceTransitionUntilLocalAndPeerWorkEnds(t *testing.T) {
+	directory := haFenceTestDirectory(t)
+	fence := newHALegacyWriterFence(directory, os.Geteuid())
+	wire, err := jsonMarshalLine(cliHAFenceDiskState{Version: cliHAFenceVersion, State: cliHAFenceStateInactive, Generation: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeHAFenceTestFile(t, filepath.Join(directory, cliHAFenceStateName), wire)
+	release, err := acquireHAUnbanLease(&config.Config{HAEnabled: true}, fence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			release()
+		}
+	}()
+	root, err := openCLIHAFenceDirectory(fence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	transition, err := openCLIHAFenceLockMode(root, os.Geteuid(), true, true)
+	if err == nil {
+		closeCLIHAFenceLock(transition)
+		t.Fatal("fence transition raced the protected local unblock")
+	}
+	if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+		t.Fatalf("unexpected transition refusal: %v", err)
+	}
+	var requests atomic.Int32
+	server := newLoopbackTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if request.Method != http.MethodDelete || request.Header.Get("Authorization") != "Bearer test-unban" {
+			t.Error("unexpected HA unban request")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	host, port := splitTestServerAddress(t, server.Listener.Addr().String())
+	cfg := &config.Config{HAEnabled: true, HAPeerIP: host, HAPeerPort: port, HAToken: "test-unban"}
+	options := testHASyncOptions(t, server.Client())
+	options.legacyFence = fence
+	if err := syncHAUnbanUnderLease(context.Background(), cfg, []string{"198.51.100.7"}, options); err != nil {
+		t.Fatalf("peer synchronization tried to reacquire the retained exclusive lease: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("unban requests=%d", requests.Load())
+	}
+	release()
+	released = true
+	transition, err = openCLIHAFenceLockMode(root, os.Geteuid(), true, true)
+	if err != nil {
+		t.Fatalf("fence remains locked after unblock completion: %v", err)
+	}
+	closeCLIHAFenceLock(transition)
+}
+
+func TestHAUnbanLeaseRejectsActiveAndUnavailableFence(t *testing.T) {
+	for _, state := range []string{"missing", cliHAFenceStateActiveDrained, cliHAFenceStateEngaging, cliHAFenceStateRecovering, cliHAFenceStateError} {
+		t.Run(state, func(t *testing.T) {
+			directory := haFenceTestDirectory(t)
+			if state != "missing" {
+				value := cliHAFenceDiskState{Version: cliHAFenceVersion, State: state, Generation: 1}
+				if state != cliHAFenceStateError {
+					value.Epoch = "native-unban-test"
+					value.MembershipSHA256 = strings.Repeat("a", 64)
+					value.LegacyWriterInventorySHA256 = strings.Repeat("b", 64)
+				}
+				if state == cliHAFenceStateActiveDrained {
+					drained := "2026-09-10T12:00:00Z"
+					value.DrainedAt = &drained
+					value.Condition = "sw-fence-v1-" + strings.Repeat("A", 43)
+				}
+				if err := validateCLIHAFenceState(value); err != nil {
+					t.Fatal(err)
+				}
+				wire, err := jsonMarshalLine(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeHAFenceTestFile(t, filepath.Join(directory, cliHAFenceStateName), wire)
+			}
+			release, err := acquireHAUnbanLease(&config.Config{HAEnabled: true}, newHALegacyWriterFence(directory, os.Geteuid()))
+			if release != nil || err == nil || !strings.Contains(err.Error(), "fence") {
+				t.Fatalf("unblock passed an unavailable or non-inactive fence: %v", err)
+			}
+		})
+	}
+}

--- a/src/core/syswarden-cli/pkg/network/sync.go
+++ b/src/core/syswarden-cli/pkg/network/sync.go
@@ -501,7 +501,7 @@ func syncHAUnban(ctx context.Context, cfg *config.Config, ips []string, options 
 	if cfg.HAToken == "" || strings.TrimSpace(cfg.HAToken) != cfg.HAToken {
 		return errors.New(haAuthSetupErrorMessage)
 	}
-	peers, err := dialableHAPeers(cfg.HAPeerIP)
+	_, err := dialableHAPeers(cfg.HAPeerIP)
 	if err != nil {
 		if errors.Is(err, errNoDialableHAPeer) {
 			return nil
@@ -519,6 +519,34 @@ func syncHAUnban(ctx context.Context, cfg *config.Config, ips []string, options 
 		return err
 	}
 	defer releaseFence()
+	return syncHAUnbanUnderLease(ctx, cfg, ips, options)
+}
+
+// syncHAUnbanUnderLease is used only while the caller retains the same fence
+// lease for the complete local mutation and peer synchronization.
+func syncHAUnbanUnderLease(ctx context.Context, cfg *config.Config, ips []string, options haSyncOptions) error {
+	if cfg == nil {
+		return fmt.Errorf("HA configuration is unavailable")
+	}
+	if !cfg.HAEnabled {
+		return nil
+	}
+	if cfg.HAToken == "" || strings.TrimSpace(cfg.HAToken) != cfg.HAToken {
+		return errors.New(haAuthSetupErrorMessage)
+	}
+	peers, err := dialableHAPeers(cfg.HAPeerIP)
+	if err != nil {
+		if errors.Is(err, errNoDialableHAPeer) {
+			return nil
+		}
+		return err
+	}
+	if len(ips) == 0 {
+		return nil
+	}
+	if err := validateHASyncOptions(options); err != nil {
+		return err
+	}
 	canonicalIPs, err := canonicalHAIPList(ips)
 	if err != nil {
 		return err


### PR DESCRIPTION
The CLI could commit local blocklist and nftables removal before discovering that HA synchronization was fenced. With HA v2, this bypassed replicated ownership and could leave the local firewall inconsistent with the retained model.

Check HA ownership before any backend or list operation. Refuse the unsupported legacy unblock route in HA v2, and hold the existing exclusive native-sync fence lease across the complete HA v1 local operation and peer synchronization. The synchronization callback reuses that lease instead of trying to reacquire it. Standalone unblock retains its existing local path.

Validation: the regression failed before the correction; all CLI tests, affected firewall/network race suites and vet pass. Real temporary-file lock tests cover active, transitioning, missing and error fences, including a loopback TLS unban while the lease is retained. Pinned gosec v2.28.0 scanned all 397 CLI production/test files with zero findings and zero loading errors. Version validation preserves v4.10.0.

This fixes the unblock ordering defect. Full authoritative GRC lifecycle integration and final native release qualification remain outstanding; no qualification gate is relaxed by this PR.
