### PR TITLE
Fix : initialize persistent policy on RHEL activation

### DIFF
--- a/extensions/rhel-package-owned/README.md
+++ b/extensions/rhel-package-owned/README.md
@@ -179,6 +179,13 @@ not replace those files and do not re-enable a service disabled by the image
 owner. Dynamic nftables policy is compiled only when the packaged firewall
 service starts on the real system.
 
+That first policy reload initializes and attests both persistent blocklist
+files, including an empty address family, before applying the firewall policy.
+Existing entries are preserved. Once the durable initialization marker exists,
+a missing or unsafe file stops reload; it is never silently recreated as empty.
+This gives the GRC reader explicit empty-state evidence on a fresh image while
+preserving its refusal of incomplete policy state after initialization.
+
 On a configured host, do not erase this variant directly. Run
 `syswarden uninstall` first and require its package-owned erase-ready result,
 then erase the exact `syswarden` RPM with the native package manager. The final

--- a/src/core/syswarden-cli/cmd/reload.go
+++ b/src/core/syswarden-cli/cmd/reload.go
@@ -12,6 +12,7 @@ import (
 
 var noRestart bool
 var applyPoliciesForReload = firewall.ApplyPolicies
+var ensurePersistentBlocklistPairForReload = firewall.EnsurePersistentBlocklistPair
 var recoverPendingWireGuardForwardingForReload = network.RecoverPendingWireGuardForwardingState
 var recoverPendingWireGuardForReload = network.RecoverPendingWireguardState
 var preflightWireGuardForReload = network.PreflightWireguard
@@ -37,6 +38,9 @@ var reloadCmd = &cobra.Command{
 		}
 		if err := preflightWireGuardForReload(); err != nil {
 			return fmt.Errorf("WireGuard preflight failed before reload mutation: %w", err)
+		}
+		if err := ensurePersistentBlocklistPairForReload(); err != nil {
+			return fmt.Errorf("persistent blocklist initialization failed before policy reload: %w", err)
 		}
 		fmt.Println("[*] Reloading SYSWARDEN configuration from memory...")
 		var failures []error

--- a/src/core/syswarden-cli/cmd/reload_test.go
+++ b/src/core/syswarden-cli/cmd/reload_test.go
@@ -3,8 +3,47 @@ package cmd
 import (
 	"errors"
 	"reflect"
+	"strings"
+	"syswarden-cli/config"
 	"testing"
 )
+
+func TestReloadRefusesPersistentPolicyInitializationFailureBeforeFirewall(t *testing.T) {
+	previousConfig := config.GlobalConfig
+	previousCron := hostCronSchedulingPreflight
+	previousBackend := hostFirewallBackendPreflight
+	previousForwarding := recoverPendingWireGuardForwardingForReload
+	previousRecovery := recoverPendingWireGuardForReload
+	previousPreflight := preflightWireGuardForReload
+	previousApply := applyPoliciesForReload
+	previousInitialize := ensurePersistentBlocklistPairForReload
+	t.Cleanup(func() {
+		config.GlobalConfig = previousConfig
+		hostCronSchedulingPreflight = previousCron
+		hostFirewallBackendPreflight = previousBackend
+		recoverPendingWireGuardForwardingForReload = previousForwarding
+		recoverPendingWireGuardForReload = previousRecovery
+		preflightWireGuardForReload = previousPreflight
+		applyPoliciesForReload = previousApply
+		ensurePersistentBlocklistPairForReload = previousInitialize
+	})
+	config.GlobalConfig = &config.Config{FirewallBackend: "keep"}
+	hostCronSchedulingPreflight = func(bool) error { return nil }
+	hostFirewallBackendPreflight = func(string) error { return nil }
+	recoverPendingWireGuardForwardingForReload = func() error { return nil }
+	recoverPendingWireGuardForReload = func() error { return nil }
+	preflightWireGuardForReload = func() error { return nil }
+	initializationFailure := errors.New("persistent blocklist file unexpectedly missing after pair initialization")
+	ensurePersistentBlocklistPairForReload = func() error { return initializationFailure }
+	applyPoliciesForReload = func() error {
+		t.Fatal("reload reached firewall mutation after an initialized family disappeared")
+		return nil
+	}
+	err := reloadCmd.RunE(reloadCmd, nil)
+	if !errors.Is(err, initializationFailure) || !strings.Contains(err.Error(), "persistent blocklist initialization failed before policy reload") {
+		t.Fatalf("lost initialized family was not refused: %v", err)
+	}
+}
 
 func TestReloadReconcilesSIEMBeforeWAFAndReportsBothFailures_SW2_PKG_001(t *testing.T) {
 	previousWAF := setupWAFForReload

--- a/src/core/syswarden-cli/pkg/firewall/lists.go
+++ b/src/core/syswarden-cli/pkg/firewall/lists.go
@@ -164,7 +164,7 @@ func unlockListDirectory(lockFile *os.File) {
 }
 
 // EnsurePersistentBlocklistPair establishes an explicit, durable empty-state
-// attestation for both address families during install or upgrade. Runtime
+// attestation for both address families during install, upgrade or activation. Runtime
 // readers remain fail-closed if either file disappears after this migration.
 func EnsurePersistentBlocklistPair() error {
 	targets := []approvedListFile{


### PR DESCRIPTION
The package-owned RHEL service starts through `reload --no-restart`. On a fresh image, that path left both persistent blocklist files absent, so the GRC reader correctly reported incomplete policy evidence despite healthy services.

Run the existing durable pair initializer after reload preflights and before applying policy. It preserves existing entries, initializes an empty family when needed, and refuses missing files after the initialization marker exists. Add a regression for refusal before firewall mutation and document first-boot behavior. The release remains v4.10.0.

Validation: CLI tests with the race detector and `go vet`; gosec v2.28.0 with no findings; 95 package lifecycle tests including the socket cleanup matrix; 22 RHEL staging tests; 50 documentation tests with the intentional private archive exclusion; exact version inspection. Native release qualification will run on the merged, signed candidate.
