### PR TITLE
Fix : reject unsafe custom rsyslog log sources

### DIFF
--- a/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
+++ b/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
@@ -1,0 +1,22 @@
+# Custom log source ownership and permissions
+
+The `waap.modsec_logs` setting supplies custom inputs to the rsyslog bridge and
+the direct WAAP log collector. Both paths require a real regular file owned by
+the service's effective user, which is root for the native installation. Group
+and other write permissions are refused. Read permissions for a monitoring
+group are allowed; for example, root-owned mode 0640 is eligible.
+
+Before publishing a custom rsyslog input, the CLI checks the matching file's
+owner, permissions and type. It opens the final component without following
+links or blocking on a special file, then rechecks the opened descriptor and
+the path identity. A symlink, special file, different owner, writable file or
+identity change stops configuration generation before that custom input is
+published. The operator must correct the source; SysWarden does not change its
+ownership or permissions automatically.
+
+These checks align the custom bridge inputs with the existing direct collector
+ownership policy. The direct collector also rechecks its held file and handles
+rotation. The rsyslog check is a configuration-time check, so source directories
+must remain under trusted administrative control while rsyslog runs. Native
+qualification must exercise the installed package and retain its actual refusal
+records; local regression tests alone do not qualify a release.

--- a/src/core/syswarden-cli/pkg/integration/rsyslog_linux.go
+++ b/src/core/syswarden-cli/pkg/integration/rsyslog_linux.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/sys/unix"
 )
 
 func quoteRsyslogString(value string) (string, error) {
@@ -79,28 +81,56 @@ func validatedRsyslogLogPatterns(raw string) ([]string, error) {
 }
 
 func verifyRsyslogLogFile(path string) error {
-	before, err := os.Lstat(path)
-	if err != nil {
+	return verifyRsyslogLogFileForOwner(path, int64(os.Geteuid()))
+}
+
+func verifyRsyslogLogFileForOwner(path string, expectedUID int64) error {
+	var before unix.Stat_t
+	if err := unix.Lstat(path, &before); err != nil {
 		return fmt.Errorf("inspect rsyslog log match %q: %w", path, err)
 	}
-	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
-		return fmt.Errorf("rsyslog log match %q is not a real regular file", path)
+	if err := validateRsyslogLogSecurity(before, expectedUID); err != nil {
+		return fmt.Errorf("rsyslog log match %q is unsafe: %w", path, err)
 	}
-	file, err := os.Open(path) // #nosec G304 -- path is an exact match of a validated absolute log pattern
+	// Refuse a final-component link or blocking special-file replacement between
+	// the initial inspection and open. Check ownership and mode on the held file.
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return fmt.Errorf("open rsyslog log match %q: %w", path, err)
 	}
-	opened, statErr := file.Stat()
-	closeErr := file.Close()
+	var opened, after unix.Stat_t
+	statErr := unix.Fstat(fd, &opened)
+	lstatErr := unix.Lstat(path, &after)
+	closeErr := unix.Close(fd)
 	if statErr != nil {
 		return fmt.Errorf("inspect opened rsyslog log match %q: %w", path, statErr)
 	}
-	after, lstatErr := os.Lstat(path)
-	if lstatErr != nil || !os.SameFile(before, opened) || !os.SameFile(opened, after) || opened.Mode() != after.Mode() {
-		return fmt.Errorf("rsyslog log match %q changed while verifying its type", path)
+	if lstatErr != nil || before.Dev != opened.Dev || before.Ino != opened.Ino ||
+		opened.Dev != after.Dev || opened.Ino != after.Ino || opened.Mode != after.Mode ||
+		opened.Uid != after.Uid || opened.Gid != after.Gid {
+		return fmt.Errorf("rsyslog log match %q changed while verifying its identity", path)
+	}
+	if err := validateRsyslogLogSecurity(opened, expectedUID); err != nil {
+		return fmt.Errorf("opened rsyslog log match %q is unsafe: %w", path, err)
+	}
+	if err := validateRsyslogLogSecurity(after, expectedUID); err != nil {
+		return fmt.Errorf("rsyslog log match %q became unsafe: %w", path, err)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("close rsyslog log match %q: %w", path, closeErr)
+	}
+	return nil
+}
+
+func validateRsyslogLogSecurity(identity unix.Stat_t, expectedUID int64) error {
+	if identity.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("not a real regular file")
+	}
+	if int64(identity.Uid) != expectedUID {
+		return fmt.Errorf("owner UID %d does not match expected UID %d", identity.Uid, expectedUID)
+	}
+	if identity.Mode&0022 != 0 {
+		return fmt.Errorf("group or other write bits are set")
 	}
 	return nil
 }

--- a/src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go
+++ b/src/core/syswarden-cli/pkg/integration/rsyslog_linux_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -71,6 +72,45 @@ func TestConfiguredRsyslogPatternsRequireRealRegularMatches_SW_CFG_002(t *testin
 		if _, err := validatedRsyslogLogPatterns(path); err == nil {
 			t.Fatalf("non-regular rsyslog input %s was accepted", path)
 		}
+	}
+}
+
+func TestRsyslogCustomSourcesRequireTrustedOwnershipAndMode_SW_CFG_002(t *testing.T) {
+	for _, mode := range []os.FileMode{0600, 0640, 0644, 0620, 0660, 0602, 0666} {
+		t.Run(fmt.Sprintf("mode-%04o", mode), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "custom.log")
+			if err := os.WriteFile(path, nil, 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, mode); err != nil {
+				t.Fatal(err)
+			}
+			patterns, patternErr := validatedRsyslogLogPatterns(path)
+			rendered, count, renderErr := renderWAFRsyslogConfig(path, false)
+			if mode&0022 != 0 {
+				if patternErr == nil || renderErr == nil || len(patterns) != 0 || rendered != "" || count != 0 {
+					t.Fatal("writable custom source was admitted or emitted in the rsyslog configuration")
+				}
+				return
+			}
+			if patternErr != nil || renderErr != nil || len(patterns) != 1 || count != 1 || !strings.Contains(rendered, path) {
+				t.Fatalf("trusted custom source was rejected: patterns=%v render=%v", patternErr, renderErr)
+			}
+		})
+	}
+
+	path := filepath.Join(t.TempDir(), "different-owner.log")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Exercise actual file metadata with a different trusted UID without root
+	// privileges or a test-only override of the production ownership policy.
+	expectedUID := int64(os.Geteuid())
+	if err := verifyRsyslogLogFileForOwner(path, expectedUID); err != nil {
+		t.Fatalf("actual owner was rejected: %v", err)
+	}
+	if err := verifyRsyslogLogFileForOwner(path, expectedUID+1); err == nil || !strings.Contains(err.Error(), "owner UID") {
+		t.Fatalf("different file owner was not refused: %v", err)
 	}
 }
 


### PR DESCRIPTION
The custom rsyslog bridge currently accepts log files owned by another user or writable by a group or everyone, although the direct WAAP collector rejects those inputs. Reject those custom sources before generating their rsyslog configuration. Open the final component without following links or blocking on special files, and recheck the held descriptor and path identity.

Regression coverage includes eligible modes 0600/0640/0644, four writable modes, owner mismatch, and the existing symlink/special-file refusals. An empty mode-0666 source reproduced acceptance in the original validator before the correction. Document the ownership requirement and configuration-time scope; SysWarden does not change source permissions automatically.

Validation: all CLI packages pass with race detection, go vet passes, gosec including tests reports 405 files and zero findings, and 50 documentation tests complete with one intentional private-archive skip. Version validation preserves v4.10.0. Frozen release contracts and changelog are unchanged. Native qualification remains required on the merged source and signed packages.
