### PR TITLE
Fix : restore native log ingestion and HA startup

### DIFF
--- a/.github/baselines/nosec-legacy.json
+++ b/.github/baselines/nosec-legacy.json
@@ -109,10 +109,6 @@
       "source_sha256": "541e5063ede65ae76837557956f1801e2b6f2cf25efb927a48f9c5e98f44527f"
     },
     {
-      "file": "src/core/syswarden-core/network/uds.go",
-      "source_sha256": "f66021f9493c7824529ad9f8aad4c89c774039b7fdcc3cd13acc8d46a77bd717"
-    },
-    {
       "file": "src/core/syswarden-core/telemetry/abuse.go",
       "source_sha256": "4591cfef2f14bf71c49c5958567575878304c81b0dc03dec268c01909cf5de7d"
     },

--- a/.github/baselines/nosec-legacy.json
+++ b/.github/baselines/nosec-legacy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "baseline_commit": "371d353e871fedb410b08f0618a1ae6aa2f7fedc",
-  "policy": "The 37 legacy annotations remain tracked debt. Deletions and fully qualified replacements are allowed; new, moved, or reintroduced unqualified annotations fail.",
+  "policy": "The 36 legacy annotations remain tracked debt. Deletions and fully qualified replacements are allowed; new, moved, or reintroduced unqualified annotations fail.",
   "legacy": [
     {
       "file": "src/core/syswarden-cli/pkg/firewall/auto_whitelist.go",

--- a/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
+++ b/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
@@ -20,3 +20,29 @@ rotation. The rsyslog check is a configuration-time check, so source directories
 must remain under trusted administrative control while rsyslog runs. Native
 qualification must exercise the installed package and retain its actual refusal
 records; local regression tests alone do not qualify a release.
+
+## Native authentication writer and socket access
+
+Native authentication logs retain the supported rsyslog writer: root by
+default, or the `syslog` account selected by `$PrivDropToUser syslog` in the
+root-owned, non-writable `/etc/rsyslog.conf`. Hardening uses mode 0640 and
+preserves that writer in logrotate rules, including rules already using 0600
+or 0640. An existing `syslog` membership in `adm` is retained for the configured
+writer. Unknown or ambiguous privilege-drop declarations stop hardening before
+authentication log ownership changes. Other privilege-drop configuration
+formats must be reviewed and expressed in this supported form first.
+
+On Linux the datagram socket grants write access to root and the private
+`syslog` group when its account and primary group agree. Every datagram must
+also carry kernel-generated sender credentials for root or that exact syslog
+UID. Membership in the group alone does not authorize injection; missing,
+truncated, or unauthorized credentials are refused before rule evaluation.
+When the syslog account is absent, only root is authorized. A service running
+as a non-root user accepts only its own UID. Platforms without the Linux
+credential mechanism cannot start this receiver.
+
+Custom inputs still require root ownership for a native root service. Operators
+using an unprivileged rsyslog producer must additionally provide read and
+directory traversal access, for example a root-owned 0640 log readable by the
+logging group. The local audit reports permissions and configuration; it does
+not claim that configuration inspection proves successful event delivery.

--- a/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
+++ b/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
@@ -25,8 +25,8 @@ records; local regression tests alone do not qualify a release.
 
 Native authentication logs retain the supported rsyslog writer: root by
 default, or the `syslog` account selected by `$PrivDropToUser syslog` in the
-root-owned, non-writable `/etc/rsyslog.conf`. Hardening uses mode 0640 and
-preserves that writer in logrotate rules, including rules already using 0600
+root-owned `/etc/rsyslog.conf` without group or other write access. Hardening
+uses mode 0640 and preserves that writer in logrotate rules, including rules already using 0600
 or 0640. An existing `syslog` membership in `adm` is retained for the configured
 writer. Unknown or ambiguous privilege-drop declarations stop hardening before
 authentication log ownership changes. Other privilege-drop configuration

--- a/src/core/syswarden-cli/pkg/security/auth_log_writer_linux.go
+++ b/src/core/syswarden-cli/pkg/security/auth_log_writer_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package security
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+type authLogWriter struct {
+	name string
+	uid  int
+}
+
+func authenticationLogWriterOn(host hardeningHost) (authLogWriter, error) {
+	if err := host.verifyHardeningPolicyParent("/etc/rsyslog.conf"); err != nil {
+		return authLogWriter{}, err
+	}
+	snapshot, err := host.snapshot("/etc/rsyslog.conf")
+	if err != nil {
+		return authLogWriter{}, err
+	}
+	if snapshot.existed && (!snapshot.identity.ownerKnown || snapshot.identity.uid != host.expectedRootUID || snapshot.mode&0022 != 0) {
+		return authLogWriter{}, fmt.Errorf("rsyslog configuration has unsafe ownership or write permissions")
+	}
+	return resolveAuthenticationLogWriter(snapshot.content, user.Lookup)
+}
+
+// AuthenticationLogOwner identifies the supported writer without changing the host.
+func AuthenticationLogOwner() (string, error) {
+	writer, err := authenticationLogWriterOn(productionHardeningHost())
+	if err != nil {
+		return "", err
+	}
+	return writer.name, nil
+}
+
+func resolveAuthenticationLogWriter(content []byte, lookup func(string) (*user.User, error)) (authLogWriter, error) {
+	writer := authLogWriter{name: "root", uid: 0}
+	configured := ""
+	for _, line := range strings.Split(string(content), "\n") {
+		fields := strings.Fields(strings.SplitN(line, "#", 2)[0])
+		if len(fields) == 0 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "$PrivDropToUser") {
+			if len(fields) != 2 || configured != "" {
+				return authLogWriter{}, fmt.Errorf("ambiguous rsyslog writer identity")
+			}
+			configured = fields[1]
+		} else if strings.Contains(strings.ToLower(line), "privdrop.user") {
+			return authLogWriter{}, fmt.Errorf("unsupported rsyslog writer declaration; preserve authentication log ownership")
+		}
+	}
+	if configured == "" || configured == "root" {
+		return writer, nil
+	}
+	if configured != "syslog" {
+		return authLogWriter{}, fmt.Errorf("unsupported rsyslog writer %q; preserve authentication log ownership", configured)
+	}
+	account, err := lookup("syslog")
+	if err != nil {
+		return authLogWriter{}, fmt.Errorf("resolve configured rsyslog account: %w", err)
+	}
+	if account == nil || account.Username != "syslog" {
+		return authLogWriter{}, fmt.Errorf("configured rsyslog account identity differs")
+	}
+	uid, err := strconv.Atoi(account.Uid)
+	if err != nil || uid <= 0 || uint64(uid) >= 1<<32-1 || strconv.Itoa(uid) != account.Uid {
+		return authLogWriter{}, fmt.Errorf("configured rsyslog account has invalid UID")
+	}
+	return authLogWriter{name: "syslog", uid: uid}, nil
+}

--- a/src/core/syswarden-cli/pkg/security/auth_log_writer_linux_test.go
+++ b/src/core/syswarden-cli/pkg/security/auth_log_writer_linux_test.go
@@ -1,0 +1,56 @@
+package security
+
+import (
+	"errors"
+	"os/user"
+	"strings"
+	"testing"
+)
+
+func TestAuthenticationLogWriterPreservesConfiguredRsyslogIdentity(t *testing.T) {
+	lookup := func(name string) (*user.User, error) {
+		if name != "syslog" {
+			t.Fatalf("unexpected account lookup %q", name)
+		}
+		return &user.User{Username: "syslog", Uid: "100", Gid: "101"}, nil
+	}
+	writer, err := resolveAuthenticationLogWriter([]byte("$FileOwner syslog\n$PrivDropToUser syslog\n$PrivDropToGroup syslog\n"), lookup)
+	if err != nil || writer.name != "syslog" || writer.uid != 100 {
+		t.Fatalf("unprivileged native auth writer lost write access: %+v %v", writer, err)
+	}
+	root, err := resolveAuthenticationLogWriter([]byte("# $PrivDropToUser syslog\nmodule(load=\"imuxsock\")\n"), lookup)
+	if err != nil || root.name != "root" || root.uid != 0 {
+		t.Fatalf("native root writer changed: %+v %v", root, err)
+	}
+	for _, input := range []string{"$PrivDropToUser alice\n", "$PrivDropToUser syslog\n$PrivDropToUser root\n", "global(privdrop.user.name=\"syslog\")\n"} {
+		if _, err := resolveAuthenticationLogWriter([]byte(input), lookup); err == nil {
+			t.Fatalf("ambiguous or unsupported declaration accepted: %q", input)
+		}
+	}
+	for _, uid := range []string{"0", "-1", "0100", "4294967295", "4294967296", "invalid"} {
+		if _, err := resolveAuthenticationLogWriter([]byte("$PrivDropToUser syslog\n"), func(string) (*user.User, error) {
+			return &user.User{Username: "syslog", Uid: uid}, nil
+		}); err == nil {
+			t.Fatalf("unsafe configured writer UID accepted: %q", uid)
+		}
+	}
+	if _, err := resolveAuthenticationLogWriter([]byte("$PrivDropToUser syslog\n"), func(string) (*user.User, error) {
+		return nil, errors.New("account unavailable")
+	}); err == nil {
+		t.Fatal("failed account resolution silently selected root")
+	}
+}
+
+func TestAuthenticationLogRotationRetainsWriterAtSecureModes(t *testing.T) {
+	for _, mode := range []string{"0640", "0600"} {
+		input := []byte("{\n  create " + mode + " root adm\n}\n")
+		output, changed, err := hardenLogrotateCreateRules(input, "create 0640 syslog adm")
+		if err != nil || !changed || !strings.Contains(string(output), "create "+mode+" syslog adm") {
+			t.Fatalf("rotation made the hardened auth log unwritable: %s %t %v", output, changed, err)
+		}
+		stable, changed, err := hardenLogrotateCreateRules(output, "create 0640 syslog adm")
+		if err != nil || changed || string(stable) != string(output) {
+			t.Fatalf("secure configured writer was not stable: %s %t %v", stable, changed, err)
+		}
+	}
+}

--- a/src/core/syswarden-cli/pkg/security/os_hardening_linux.go
+++ b/src/core/syswarden-cli/pkg/security/os_hardening_linux.go
@@ -53,6 +53,10 @@ func lockCrontabOn(host hardeningHost) error {
 
 func purgePrivilegedGroupsOn(host hardeningHost) error {
 	fmt.Println(" -> Purging non-root users from privileged groups")
+	logWriter, err := authenticationLogWriterOn(host)
+	if err != nil {
+		return err
+	}
 	currentAdmin := os.Getenv("SUDO_USER")
 	if currentAdmin == "" {
 		current, err := user.Current()
@@ -80,6 +84,10 @@ func purgePrivilegedGroupsOn(host hardeningHost) error {
 			}
 			if member == currentAdmin {
 				fmt.Printf(" [!] SAFEGUARD: Preserving current admin '%s' in '%s' group\n", member, group)
+				continue
+			}
+			if group == "adm" && member == "syslog" && logWriter.name == "syslog" {
+				fmt.Println(" [!] Preserving the configured rsyslog reader in adm")
 				continue
 			}
 			if err := host.executor.run("gpasswd", "-d", member, group); err != nil {
@@ -552,6 +560,10 @@ func reconcileRsyslogService(host hardeningHost) error {
 
 func restrictAuthLogsOn(host hardeningHost) error {
 	fmt.Println(" -> Restricting auth log permissions")
+	writer, err := authenticationLogWriterOn(host)
+	if err != nil {
+		return err
+	}
 	for _, entry := range []struct {
 		path  string
 		group string
@@ -567,7 +579,7 @@ func restrictAuthLogsOn(host hardeningHost) error {
 		if err != nil {
 			return fmt.Errorf("resolve group %s: %w", entry.group, err)
 		}
-		if _, err := host.securePathPermissions(entry.path, false, 0640, 0, gid); err != nil {
+		if _, err := host.securePathPermissions(entry.path, false, 0640, writer.uid, gid); err != nil {
 			return err
 		}
 		fmt.Printf("   [+] Hardened %s to 0640\n", entry.path)
@@ -576,7 +588,7 @@ func restrictAuthLogsOn(host hardeningHost) error {
 	for _, entry := range []struct {
 		path string
 		rule string
-	}{{path: "/etc/logrotate.d/rsyslog", rule: "create 0640 root adm"}, {path: "/etc/logrotate.d/syslog", rule: "create 0640 root root"}} {
+	}{{path: "/etc/logrotate.d/rsyslog", rule: "create 0640 " + writer.name + " adm"}, {path: "/etc/logrotate.d/syslog", rule: "create 0640 " + writer.name + " root"}} {
 		snapshot, err := host.snapshot(entry.path)
 		if err != nil {
 			return err
@@ -608,6 +620,10 @@ func lookupGroupID(name string) (int, error) {
 }
 
 func hardenLogrotateCreateRules(input []byte, replacement string) ([]byte, bool, error) {
+	want := strings.Fields(replacement)
+	if len(want) != 4 || want[0] != "create" || want[1] != "0640" {
+		return nil, false, fmt.Errorf("invalid authentication log rotation policy")
+	}
 	lines := strings.Split(string(input), "\n")
 	changed := false
 	for index, raw := range lines {
@@ -619,11 +635,16 @@ func hardenLogrotateCreateRules(input []byte, replacement string) ([]byte, bool,
 		if err != nil {
 			return nil, false, fmt.Errorf("invalid logrotate create mode %q", fields[1])
 		}
-		if mode&0137 == 0 {
+		ownerMatches := len(fields) == 4 && fields[2] == want[2] && fields[3] == want[3]
+		if (mode == 0600 || mode == 0640) && ownerMatches {
 			continue
 		}
 		indent := raw[:len(raw)-len(strings.TrimLeft(raw, " \t"))]
-		lines[index] = indent + replacement
+		lineReplacement := replacement
+		if mode == 0600 {
+			lineReplacement = "create 0600 " + want[2] + " " + want[3]
+		}
+		lines[index] = indent + lineReplacement
 		changed = true
 	}
 	return []byte(strings.Join(lines, "\n")), changed, nil

--- a/src/core/syswarden-cli/pkg/system/audit_file_permissions_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/audit_file_permissions_linux_test.go
@@ -1,0 +1,44 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuditFilePermissionsRefusesWrongOwnerAndUnsafeFileIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.log")
+	if err := os.WriteFile(path, []byte("diagnostic fixture\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	uid := uint64(os.Geteuid()) // #nosec G115 -- kernel effective UID is nonnegative
+	if err := inspectAuditFilePermissions(path, []string{"600", "640"}, uid); err != nil {
+		t.Fatal(err)
+	}
+	if err := inspectAuditFilePermissions(path, []string{"600", "640"}, uid+1); err == nil {
+		t.Fatal("audit accepted the wrong authentication writer")
+	}
+	link := filepath.Join(filepath.Dir(path), "alias.log")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := inspectAuditFilePermissions(link, []string{"600"}, uid); err == nil {
+		t.Fatal("audit followed a symbolic link")
+	}
+	hardlink := filepath.Join(filepath.Dir(path), "hardlink.log")
+	if err := os.Link(path, hardlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := inspectAuditFilePermissions(path, []string{"600"}, uid); err == nil {
+		t.Fatal("audit accepted a log with multiple links")
+	}
+	if err := os.Remove(hardlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0666); err != nil { // #nosec G302 -- intentionally unsafe temporary fixture must be rejected
+		t.Fatal(err)
+	}
+	if err := inspectAuditFilePermissions(path, []string{"600", "640"}, uid); err == nil {
+		t.Fatal("audit accepted a writable authentication log")
+	}
+}

--- a/src/core/syswarden-cli/pkg/system/audit_linux.go
+++ b/src/core/syswarden-cli/pkg/system/audit_linux.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
+	"strconv"
 	"strings"
+	"syscall"
 	"syswarden-cli/config"
 	"syswarden-cli/pkg/cronstate"
+	"syswarden-cli/pkg/security"
 )
 
 func logHeader(title string) {
@@ -50,31 +54,42 @@ func isServiceActive(service string) bool {
 }
 
 func checkFilePerms(filepath string, validPerms []string, expectedOwner string) {
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		warn(fmt.Sprintf("File %s does not exist.", filepath))
+	account, err := user.Lookup(expectedOwner)
+	if err != nil || account == nil || account.Username != expectedOwner {
+		fail(fmt.Sprintf("Cannot resolve expected owner %s for %s.", expectedOwner, filepath))
 		return
 	}
-
-	info, err := os.Stat(filepath)
+	uid, err := strconv.ParseUint(account.Uid, 10, 32)
 	if err != nil {
-		fail(fmt.Sprintf("Cannot stat %s", filepath))
+		fail(fmt.Sprintf("Invalid expected owner UID for %s.", filepath))
 		return
 	}
+	if err := inspectAuditFilePermissions(filepath, validPerms, uid); err != nil {
+		fail(fmt.Sprintf("%s file permissions or ownership FAILED: %v", filepath, err))
+		return
+	}
+	pass(fmt.Sprintf("%s is a regular file with permitted mode and owner %s.", filepath, expectedOwner))
+}
 
-	modeStr := fmt.Sprintf("%04o", info.Mode().Perm())
-	isValid := false
+func inspectAuditFilePermissions(path string, validPerms []string, expectedUID uint64) error {
+	entry, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	identity, ok := entry.Sys().(*syscall.Stat_t)
+	if !entry.Mode().IsRegular() || !ok || identity.Nlink != 1 || uint64(identity.Uid) != expectedUID {
+		return fmt.Errorf("expected a single-link regular file owned by UID %d", expectedUID)
+	}
+	if entry.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return fmt.Errorf("unexpected special mode bits")
+	}
 	for _, perm := range validPerms {
-		if strings.Contains(modeStr, perm) {
-			isValid = true
-			break
+		mode, err := strconv.ParseUint(perm, 8, 12)
+		if err == nil && uint64(entry.Mode().Perm()) == mode {
+			return nil
 		}
 	}
-
-	if isValid {
-		pass(fmt.Sprintf("%s permissions VERIFIED (%s).", filepath, modeStr))
-	} else {
-		fail(fmt.Sprintf("%s permissions FAILED (Got %s, Expected one of %v).", filepath, modeStr, validPerms))
-	}
+	return fmt.Errorf("got mode %04o, expected one of %v", entry.Mode().Perm(), validPerms)
 }
 
 func RunAudit() {
@@ -113,17 +128,20 @@ func RunAudit() {
 	// Phase 2
 	logHeader("Phase 2: Log Routing & Anti-Injection Verification")
 
-	if _, err := os.Stat("/var/log/auth.log"); err == nil {
-		checkFilePerms("/var/log/auth.log", []string{"640", "600"}, "root")
-	} else if _, err := os.Stat("/var/log/secure"); err == nil {
-		checkFilePerms("/var/log/secure", []string{"640", "600"}, "root")
+	logOwner, ownerErr := security.AuthenticationLogOwner()
+	if ownerErr != nil {
+		fail(fmt.Sprintf("Cannot attest authentication log writer: %v", ownerErr))
+	} else if _, err := os.Lstat("/var/log/auth.log"); err == nil {
+		checkFilePerms("/var/log/auth.log", []string{"640", "600"}, logOwner)
+	} else if _, err := os.Lstat("/var/log/secure"); err == nil {
+		checkFilePerms("/var/log/secure", []string{"640", "600"}, logOwner)
 	}
 
 	if isServiceActive("rsyslog") {
 		pass("Rsyslog daemon is active.")
 		bridgeConf, err := os.ReadFile("/etc/rsyslog.d/99-syswarden-waf-bridge.conf") // #nosec
 		if err == nil && strings.Contains(string(bridgeConf), "omuxsock") {
-			pass("Rsyslog UDS Bridge VERIFIED: Logs are streamed to /var/run/syswarden.sock natively.")
+			pass("Rsyslog UDS bridge configuration contains omuxsock. Live delivery and kernel sender authorization were not tested by this diagnostic.")
 		} else {
 			fail("Rsyslog UDS Bridge FAILED: /etc/rsyslog.d/99-syswarden-waf-bridge.conf is missing or incorrectly configured.")
 		}

--- a/src/core/syswarden-core/network/ha_api.go
+++ b/src/core/syswarden-core/network/ha_api.go
@@ -2776,6 +2776,17 @@ func StartHAServerContext(ctx context.Context, fwManager firewall.Manager) (fire
 		return nil, fmt.Errorf("HA token is required")
 	}
 
+	// Publish the complete legacy identity before newHAAPI creates its fence
+	// in the same directory. Existing incomplete identities still fail closed.
+	var certificate tls.Certificate
+	if !cfg.V2Enabled {
+		var err error
+		certificate, err = loadOrCreateHATLSCertificate(haTLSDir)
+		if err != nil {
+			return nil, fmt.Errorf("load persistent TLS identity: %w", err)
+		}
+	}
+
 	coreVersion := "unknown"
 	cmd := exec.Command("syswarden")
 	if out, err := cmd.Output(); err == nil {
@@ -2793,7 +2804,6 @@ func StartHAServerContext(ctx context.Context, fwManager firewall.Manager) (fire
 		return nil, fmt.Errorf("invalid HA configuration: %w", err)
 	}
 	effectiveManager := fwManager
-	var certificate tls.Certificate
 	var components *haRuntimeV2Components
 	v2LeaseCommitted := false
 	defer func() {
@@ -2813,11 +2823,6 @@ func StartHAServerContext(ctx context.Context, fwManager firewall.Manager) (fire
 		certificate = components.identity.Certificate
 		effectiveManager = components.manager
 		api.fwManager = effectiveManager
-	} else {
-		certificate, err = loadOrCreateHATLSCertificate(haTLSDir)
-		if err != nil {
-			return nil, fmt.Errorf("load persistent TLS identity: %w", err)
-		}
 	}
 	if components == nil {
 		if err := prepareHAServerAPI(api); err != nil {

--- a/src/core/syswarden-core/network/ha_tls_startup_test.go
+++ b/src/core/syswarden-core/network/ha_tls_startup_test.go
@@ -1,0 +1,87 @@
+package network
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestRuntimeLifecycleHAFencePreservesTLSIdentityAcrossRestart(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), "ha")
+	ledger := filepath.Join(directory, "bans.json")
+	if _, err := prepareRuntimeLifecycleHAFence(directory, ledger, os.Geteuid()); err != nil {
+		t.Fatal(err)
+	}
+	first, err := loadOrCreateHATLSCertificate(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareRuntimeLifecycleHAFence(directory, ledger, os.Geteuid()); err != nil {
+		t.Fatalf("runtime restart rejected the retained identity and fence: %v", err)
+	}
+	second, err := loadOrCreateHATLSCertificate(directory)
+	if err != nil || !bytes.Equal(first.Certificate[0], second.Certificate[0]) {
+		t.Fatalf("runtime restart replaced the peer's trusted identity: %v", err)
+	}
+}
+
+func TestRuntimeLifecycleHAFenceRefusesIncompleteIdentityBeforeFence(t *testing.T) {
+	for _, missing := range []string{haTLSCertificateName, haTLSPrivateKeyName} {
+		t.Run(missing, func(t *testing.T) {
+			directory := filepath.Join(t.TempDir(), "ha")
+			if _, err := loadOrCreateHATLSCertificate(directory); err != nil {
+				t.Fatal(err)
+			}
+			root, err := os.OpenRoot(directory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+			if err := root.Remove(missing); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := prepareRuntimeLifecycleHAFence(directory, filepath.Join(directory, "bans.json"), os.Geteuid()); err == nil {
+				t.Fatal("incomplete identity was silently replaced")
+			}
+			for _, name := range []string{missing, "fence"} {
+				if _, err := root.Lstat(name); !os.IsNotExist(err) {
+					t.Fatalf("failed TLS attestation created %s: %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestHALegacyStartupCreatesIdentityBeforeSharedFence(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	originalTLS, originalLedger := haTLSDir, haRuntimeBanLedgerFile
+	t.Cleanup(func() {
+		haTLSDir, haRuntimeBanLedgerFile = originalTLS, originalLedger
+	})
+	haTLSDir = filepath.Join(t.TempDir(), "ha")
+	haRuntimeBanLedgerFile = filepath.Join(haTLSDir, "bans.json")
+	viper.Set("integrations.ha.enabled", true)
+	viper.Set("integrations.ha.token", strings.Repeat("f", 64))
+	viper.Set("integrations.ha.peer_ips", []string{"127.0.0.1/32"})
+	// Stop at listener validation after real identity and fence initialization.
+	// No socket or host firewall is required for this startup regression.
+	viper.Set("integrations.ha.peer_port", 65536)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := StartHAServerContext(ctx, noOpFirewallManager{})
+	if err == nil || !strings.Contains(err.Error(), "bind HA listener:") {
+		t.Fatalf("fresh shared HA directory failed before listener validation: %v", err)
+	}
+	if _, err := loadOrCreateHATLSCertificate(haTLSDir); err != nil {
+		t.Fatalf("startup did not persist a complete TLS identity: %v", err)
+	}
+	if info, err := os.Lstat(filepath.Join(haTLSDir, "fence")); err != nil || !info.IsDir() {
+		t.Fatalf("startup did not initialize the shared fence after TLS: %v", err)
+	}
+}

--- a/src/core/syswarden-core/network/runtime_lifecycle_start.go
+++ b/src/core/syswarden-core/network/runtime_lifecycle_start.go
@@ -26,10 +26,7 @@ func PrepareRuntimeLifecycle(ctx context.Context, underlying firewall.Manager) (
 		return nil, nil, err
 	}
 	if cfg.Enabled == "y" || cfg.Enabled == "true" || cfg.Enabled == "1" {
-		fence, err := newHAFenceController(filepath.Join(filepath.Dir(haRuntimeBanLedgerFile), "fence"), 0)
-		if err == nil {
-			err = fence.prepareForServer()
-		}
+		fence, err := prepareRuntimeLifecycleHAFence(haTLSDir, haRuntimeBanLedgerFile, 0)
 		if err != nil {
 			closeStore()
 			return nil, nil, err
@@ -41,6 +38,22 @@ func PrepareRuntimeLifecycle(ctx context.Context, underlying firewall.Manager) (
 		return nil, nil, fmt.Errorf("restore retained native runtime claims: %w", err)
 	}
 	return manager, closeStore, nil
+}
+
+func prepareRuntimeLifecycleHAFence(tlsDirectory, ledgerFile string, ownerUID int) (*haFenceController, error) {
+	// Runtime restoration precedes HA server startup. Its fence shares the HA
+	// directory, so initialize TLS first without rotating any retained identity.
+	if _, err := loadOrCreateHATLSCertificate(tlsDirectory); err != nil {
+		return nil, fmt.Errorf("prepare native runtime HA TLS identity: %w", err)
+	}
+	fence, err := newHAFenceController(filepath.Join(filepath.Dir(ledgerFile), "fence"), ownerUID)
+	if err != nil {
+		return nil, err
+	}
+	if err := fence.prepareForServer(); err != nil {
+		return nil, err
+	}
+	return fence, nil
 }
 
 func prepareRuntimeLifecycleAt(ctx context.Context, underlying firewall.Manager, directory string, ownerUID int) (*runtimeLifecycleManager, func(), error) {

--- a/src/core/syswarden-core/network/uds.go
+++ b/src/core/syswarden-core/network/uds.go
@@ -20,6 +20,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+type udsProducerIdentity struct {
+	group int
+	uids  []uint32
+}
+
 type UDSServer struct {
 	socketPath              string
 	conn                    *net.UnixConn
@@ -33,6 +38,7 @@ type UDSServer struct {
 	isWhitelisted           func(string) (bool, error)
 	enforcementMode         func() string
 	isInternalLogLine       func(string) bool
+	producerUIDs            []uint32
 	wg                      sync.WaitGroup
 }
 
@@ -71,10 +77,13 @@ func (s *UDSServer) Start() error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on uds socket: %w", err)
 	}
+	identity, err := configureUDSProducerAccess(conn, s.socketPath)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("attest UDS producer access: %w", err)
+	}
 	s.conn = conn
-
-	// Ensure the socket is writable by authorized groups (0660)
-	_ = os.Chmod(s.socketPath, 0660) // #nosec
+	s.producerUIDs = identity.uids
 
 	log.Printf("[UDS] Listening for unixgram zero-disk streams on %s (0660)", s.socketPath)
 
@@ -98,9 +107,10 @@ func (s *UDSServer) readLoop() {
 	// terminator. ReadMsgUnix exposes MSG_TRUNC so an incomplete record is never
 	// scanned or correlated as though it were authoritative.
 	buf := make([]byte, maxWAAPLogLineBytes+2)
+	control := newUDSCredentialsBuffer()
 
 	for {
-		n, _, flags, _, err := s.conn.ReadMsgUnix(buf, nil)
+		n, controlBytes, flags, _, err := s.conn.ReadMsgUnix(buf, control)
 		if err != nil {
 			select {
 			case <-s.ctx.Done():
@@ -112,6 +122,10 @@ func (s *UDSServer) readLoop() {
 		}
 		if !completeUDSDatagram(n, flags) {
 			log.Printf("[UDS] Refusing truncated or oversized datagram")
+			continue
+		}
+		if !authorizedUDSCredentials(control[:controlBytes], flags, s.producerUIDs) {
+			log.Printf("[UDS] Refusing missing or unauthorized kernel sender credentials")
 			continue
 		}
 

--- a/src/core/syswarden-core/network/uds_permissions_linux.go
+++ b/src/core/syswarden-core/network/uds_permissions_linux.go
@@ -1,0 +1,99 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+func resolveUDSProducerIdentity(ownerUID, ownerGID int, lookupUser func(string) (*user.User, error), lookupGroup func(string) (*user.Group, error)) (udsProducerIdentity, error) {
+	if ownerUID < 0 || uint64(ownerUID) >= 1<<32-1 || ownerGID < 0 || uint64(ownerGID) >= 1<<32-1 {
+		return udsProducerIdentity{}, fmt.Errorf("invalid socket owner identity")
+	}
+	identity := udsProducerIdentity{group: ownerGID, uids: []uint32{uint32(ownerUID)}} // #nosec G115 -- UID is bounded to the Linux uint32 range above
+	if ownerUID != 0 {
+		return identity, nil
+	}
+	account, err := lookupUser("syslog")
+	if err != nil {
+		var absent user.UnknownUserError
+		if errors.As(err, &absent) {
+			return identity, nil
+		}
+		return identity, fmt.Errorf("resolve rsyslog producer account: %w", err)
+	}
+	group, err := lookupGroup("syslog")
+	if err != nil {
+		return identity, fmt.Errorf("resolve rsyslog producer group: %w", err)
+	}
+	if account == nil || group == nil || account.Username != "syslog" || group.Name != "syslog" || account.Gid != group.Gid {
+		return identity, fmt.Errorf("rsyslog producer identity does not match its private group")
+	}
+	uid, uidErr := strconv.ParseUint(account.Uid, 10, 32)
+	gid, gidErr := strconv.ParseUint(group.Gid, 10, 32)
+	if uidErr != nil || gidErr != nil || uid == 0 || gid == 0 || uid == 1<<32-1 || gid == 1<<32-1 ||
+		strconv.FormatUint(uid, 10) != account.Uid || strconv.FormatUint(gid, 10) != group.Gid {
+		return identity, fmt.Errorf("invalid rsyslog producer UID or GID")
+	}
+	identity.group = int(gid)                          // #nosec G115 -- supported Linux builds use 64-bit int and ParseUint bounds GID to 32 bits
+	identity.uids = append(identity.uids, uint32(uid)) // #nosec G115 -- ParseUint above bounds UID to 32 bits
+	return identity, nil
+}
+
+func configureUDSProducerAccess(conn *net.UnixConn, path string) (udsProducerIdentity, error) {
+	identity, err := resolveUDSProducerIdentity(os.Geteuid(), os.Getegid(), user.Lookup, user.LookupGroup)
+	if err != nil {
+		return identity, err
+	}
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return identity, err
+	}
+	var credentialErr error
+	if err := raw.Control(func(fd uintptr) {
+		credentialErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PASSCRED, 1)
+	}); err != nil {
+		return identity, err
+	}
+	if credentialErr != nil {
+		return identity, fmt.Errorf("require kernel UDS sender credentials: %w", credentialErr)
+	}
+	if os.Geteuid() == 0 {
+		if err := os.Chown(path, 0, identity.group); err != nil {
+			return identity, fmt.Errorf("set private UDS producer group: %w", err)
+		}
+	}
+	if err := os.Chmod(path, 0660); err != nil { // #nosec G302 -- only the logging group can write; every datagram additionally requires an authorized kernel UID
+		return identity, fmt.Errorf("set private UDS permissions: %w", err)
+	}
+	return identity, nil
+}
+
+func newUDSCredentialsBuffer() []byte {
+	return make([]byte, unix.CmsgSpace(unix.SizeofUcred))
+}
+
+func authorizedUDSCredentials(control []byte, flags int, allowed []uint32) bool {
+	if flags&unix.MSG_CTRUNC != 0 {
+		return false
+	}
+	messages, err := unix.ParseSocketControlMessage(control)
+	if err != nil || len(messages) != 1 {
+		return false
+	}
+	credentials, err := unix.ParseUnixCredentials(&messages[0])
+	if err != nil || credentials.Pid <= 0 {
+		return false
+	}
+	for _, uid := range allowed {
+		if credentials.Uid == uid {
+			return true
+		}
+	}
+	return false
+}

--- a/src/core/syswarden-core/network/uds_permissions_linux_test.go
+++ b/src/core/syswarden-core/network/uds_permissions_linux_test.go
@@ -1,0 +1,76 @@
+package network
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestUDSProducerIdentityAuthorizesOnlyRootAndSyslogUID(t *testing.T) {
+	lookupUser := func(string) (*user.User, error) { return &user.User{Username: "syslog", Uid: "100", Gid: "101"}, nil }
+	lookupGroup := func(string) (*user.Group, error) { return &user.Group{Name: "syslog", Gid: "101"}, nil }
+	identity, err := resolveUDSProducerIdentity(0, 0, lookupUser, lookupGroup)
+	if err != nil || identity.group != 101 || len(identity.uids) != 2 {
+		t.Fatalf("configured logging producer cannot access its socket: %+v %v", identity, err)
+	}
+	for _, uid := range []uint32{0, 100, 1000} {
+		control := unix.UnixCredentials(&unix.Ucred{Pid: 123, Uid: uid, Gid: 101})
+		if authorizedUDSCredentials(control, 0, identity.uids) != (uid == 0 || uid == 100) {
+			t.Fatalf("sender UID %d was authorized by group membership instead of identity", uid)
+		}
+		if authorizedUDSCredentials(control, unix.MSG_CTRUNC, identity.uids) {
+			t.Fatal("truncated sender credentials were accepted")
+		}
+	}
+	if authorizedUDSCredentials(nil, 0, identity.uids) || authorizedUDSCredentials([]byte("invalid"), 0, identity.uids) {
+		t.Fatal("missing or invalid sender credentials were accepted")
+	}
+	if _, err := resolveUDSProducerIdentity(0, 0, lookupUser, func(string) (*user.Group, error) {
+		return &user.Group{Name: "syslog", Gid: "102"}, nil
+	}); err == nil {
+		t.Fatal("unrelated producer group was accepted")
+	}
+	root, err := resolveUDSProducerIdentity(0, 0, func(string) (*user.User, error) {
+		return nil, user.UnknownUserError("syslog")
+	}, lookupGroup)
+	if err != nil || root.group != 0 || len(root.uids) != 1 || root.uids[0] != 0 {
+		t.Fatalf("root-only native logging changed: %+v %v", root, err)
+	}
+}
+
+func TestUDSKernelCredentialsCarryTheActualNativeSender(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "core.sock")
+	server, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	identity, err := configureUDSProducerAccess(server, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if _, err := client.Write([]byte("native credential witness")); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	data, control := make([]byte, 128), make([]byte, unix.CmsgSpace(unix.SizeofUcred))
+	n, oobn, flags, _, err := server.ReadMsgUnix(data, control)
+	if err != nil || string(data[:n]) != "native credential witness" || !authorizedUDSCredentials(control[:oobn], flags, identity.uids) {
+		t.Fatalf("actual kernel credentials were not accepted: %v", err)
+	}
+	if authorizedUDSCredentials(control[:oobn], flags, []uint32{uint32(os.Geteuid()) + 1}) { // #nosec G115 -- test uses the kernel's current UID and a deliberately different identity
+		t.Fatal("actual sender was accepted as another UID")
+	}
+}

--- a/src/core/syswarden-core/network/uds_permissions_unsupported.go
+++ b/src/core/syswarden-core/network/uds_permissions_unsupported.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package network
+
+import (
+	"fmt"
+	"net"
+)
+
+func configureUDSProducerAccess(*net.UnixConn, string) (udsProducerIdentity, error) {
+	return udsProducerIdentity{}, fmt.Errorf("authenticated UDS producers require Linux kernel credentials")
+}
+
+func newUDSCredentialsBuffer() []byte { return nil }
+
+func authorizedUDSCredentials([]byte, int, []uint32) bool { return false }


### PR DESCRIPTION
Native Ubuntu installs lose SSH detection because hardening changes authentication logs to root ownership while rsyslog runs as syslog, and the root-owned datagram socket denies that producer. Enabling legacy HA on a fresh install also stops the core because the runtime fence creates the TLS directory before certificate publication.

Preserve the supported rsyslog writer when hardening authentication logs and logrotate rules, retain its existing adm membership, and permit socket access through its verified private group. Require kernel sender credentials for root or the exact syslog UID before rule evaluation; another user in the same group remains unauthorized. Refuse ambiguous writer configuration, unsafe source ownership and incomplete credentials. The local audit now checks file ownership and avoids claiming that configuration inspection proves delivery.

Initialize the existing HA TLS identity before creating the runtime fence. Keep certificate paths, persistent identity, atomic publication, incomplete-identity refusal and explicit HA v2 identity handling. Preserve v4.10.0 and all frozen qualification contracts.

Validation: the HA shared-directory regression failed on the original source and passes with the correction; restart persistence and both missing-file cases pass. Real Linux datagrams verify kernel sender credentials. Writer selection, rotation at secure modes, wrong-owner and unsafe-file refusals pass. Complete CLI and core race tests, go vet, golangci-lint, gosec including tests (570 files, zero findings or Go loading errors), documentation and suppression-policy checks passed. One removed legacy suppression was removed from its baseline. Native diagnostics retained the four real failed SSH attempts and both permission failures; the eventual merged and signed candidate still requires native release qualification.
