### PR TITLE
Fix : restore hardened core startup with private syslog sockets

### DIFF
--- a/extensions/rhel-package-owned/inventory.json
+++ b/extensions/rhel-package-owned/inventory.json
@@ -114,7 +114,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd",
+      "sha256": "cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7",
       "rpm_ownership": "payload",
       "rpm_package": "syswarden",
       "role": "systemd-unit"
@@ -205,7 +205,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "0eaaf275afec8a24a8c93bcd1419c31b608be1259ede53a12c29ba16e75b89dd",
+      "sha256": "76f713ff11676693e7faac93c8b7a2cfac6f6155a97d5727d8033b1124300c9b",
       "rpm_ownership": "scriptlet",
       "rpm_package": "syswarden",
       "role": "rpm-pre-install"
@@ -218,7 +218,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "79355b498a8c616541ca2ab40cd67f89aee7acaf623014fcb7648e786bb4b039",
+      "sha256": "71fee0eb80f300dd0e95ee7c540ac3a93e1cac3f24fa8928760f59afe118970e",
       "rpm_ownership": "scriptlet",
       "rpm_package": "syswarden",
       "role": "rpm-post-install"
@@ -231,7 +231,7 @@
       "uid": 0,
       "gid": 0,
       "link_target": null,
-      "sha256": "86de9336a54543d4d9547624e1074170b70df55312656ad202da6674f9cbe2fe",
+      "sha256": "61cf5ae7cf6beb24d7f0c3202be5617bd881fac648c9ac939a6dfdea437ae1fe",
       "rpm_ownership": "scriptlet",
       "rpm_package": "syswarden",
       "role": "rpm-pre-uninstall"

--- a/extensions/rhel-package-owned/scriptlets/post-install.sh
+++ b/extensions/rhel-package-owned/scriptlets/post-install.sh
@@ -57,7 +57,7 @@ exact_file() {
 
 exact_legacy_source_unit() {
     path="$1"
-    digest="$2"
+    shift
     if [ ! -f "$path" ] || [ -L "$path" ]; then
         fail "Refusing unsafe legacy SysWarden unit: $path"
     fi
@@ -66,8 +66,11 @@ exact_legacy_source_unit() {
         0:0:600:1|0:0:644:1) ;;
         *) fail "Refusing modified legacy SysWarden unit metadata: $path" ;;
     esac
-    [ "$(/usr/bin/sha256sum -- "$path" | /usr/bin/awk '{print $1}')" = "$digest" ] || \
-        fail "Refusing modified legacy SysWarden unit content: $path"
+    actual_digest="$(/usr/bin/sha256sum -- "$path" | /usr/bin/awk '{print $1}')"
+    for digest in "$@"; do
+        [ "$actual_digest" = "$digest" ] && return 0
+    done
+    fail "Refusing modified legacy SysWarden unit content: $path"
 }
 
 exact_directory() {
@@ -221,7 +224,7 @@ migrate_enablement() {
 }
 
 exact_file /usr/lib/systemd/system/syswarden-core.service 644 \
-    8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+    cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
 exact_file /usr/lib/systemd/system/syswarden-firewall.service 644 \
     989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1
 exact_file /usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf 644 \
@@ -250,7 +253,8 @@ if [ "$1" -gt 1 ]; then
     fi
     if [ "$core_present" -eq 1 ]; then
         exact_legacy_source_unit /etc/systemd/system/syswarden-core.service \
-            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd \
+            cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
     fi
     if [ "$firewall_present" -eq 1 ]; then
         exact_legacy_source_unit /etc/systemd/system/syswarden-firewall.service \
@@ -258,7 +262,8 @@ if [ "$1" -gt 1 ]; then
     fi
     if [ "$core_present" -eq 1 ]; then
         exact_legacy_source_unit /etc/systemd/system/syswarden-core.service \
-            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd \
+            cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
         /usr/bin/rm -f -- /etc/systemd/system/syswarden-core.service
         [ ! -e /etc/systemd/system/syswarden-core.service ] && \
             [ ! -L /etc/systemd/system/syswarden-core.service ] || \

--- a/extensions/rhel-package-owned/scriptlets/pre-install.sh
+++ b/extensions/rhel-package-owned/scriptlets/pre-install.sh
@@ -21,7 +21,7 @@ fail() {
 
 exact_legacy_source_unit() {
     path="$1"
-    digest="$2"
+    shift
     if [ ! -f "$path" ] || [ -L "$path" ]; then
         fail "Refusing unsafe legacy SysWarden unit: $path"
     fi
@@ -30,8 +30,11 @@ exact_legacy_source_unit() {
         0:0:600:1|0:0:644:1) ;;
         *) fail "Refusing modified legacy SysWarden unit metadata: $path" ;;
     esac
-    [ "$(/usr/bin/sha256sum -- "$path" | /usr/bin/awk '{print $1}')" = "$digest" ] || \
-        fail "Refusing modified legacy SysWarden unit content: $path"
+    actual_digest="$(/usr/bin/sha256sum -- "$path" | /usr/bin/awk '{print $1}')"
+    for digest in "$@"; do
+        [ "$actual_digest" = "$digest" ] && return 0
+    done
+    fail "Refusing modified legacy SysWarden unit content: $path"
 }
 
 exact_enablement() {
@@ -362,7 +365,8 @@ if [ "$1" -gt 1 ]; then
             28 c3dd1e8df980ad039e7ba1c3c7a82625048df88a5636bdb039da6cc1c06de7c9 \
             35 a62c66b7e1f03e6da14b42a39fe6cc4c4af3cf518ed78efa025d958dd85d1247
         exact_legacy_source_unit /etc/systemd/system/syswarden-core.service \
-            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+            8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd \
+            cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
         exact_legacy_source_unit /etc/systemd/system/syswarden-firewall.service \
             989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1
     elif [ "$core_present" -eq 0 ] && [ "$firewall_present" -eq 0 ]; then
@@ -371,7 +375,8 @@ if [ "$1" -gt 1 ]; then
         attest_installed_identity 35 a62c66b7e1f03e6da14b42a39fe6cc4c4af3cf518ed78efa025d958dd85d1247
         if [ "$core_present" -eq 1 ]; then
             exact_legacy_source_unit /etc/systemd/system/syswarden-core.service \
-                8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+                8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd \
+                cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
         fi
         if [ "$firewall_present" -eq 1 ]; then
             exact_legacy_source_unit /etc/systemd/system/syswarden-firewall.service \

--- a/extensions/rhel-package-owned/scriptlets/pre-uninstall.sh
+++ b/extensions/rhel-package-owned/scriptlets/pre-uninstall.sh
@@ -313,7 +313,7 @@ if [ "$1" -eq 0 ]; then
     done
     [ "$dropin_children" -eq 1 ] || fail 'Required SysWarden systemd drop-in is absent.'
     exact_payload_file /usr/lib/systemd/system/syswarden-core.service \
-        8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd
+        cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7
     exact_payload_file /usr/lib/systemd/system/syswarden-firewall.service \
         989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1
     exact_payload_file "$dropin_directory/10-syswarden-wireguard-ordering.conf" \

--- a/extensions/rhel-package-owned/tests/fixtures/syswarden-core-v4043.service
+++ b/extensions/rhel-package-owned/tests/fixtures/syswarden-core-v4043.service
@@ -23,8 +23,7 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 NoNewPrivileges=true
 PrivateTmp=true
 ReadWritePaths=/var/lib/syswarden /var/log/syswarden /run /opt/syswarden /etc/syswarden/lists
-# CAP_CHOWN assigns the socket to the verified private rsyslog producer group.
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_DAC_OVERRIDE CAP_FOWNER
 
 [Install]
 WantedBy=multi-user.target

--- a/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
+++ b/extensions/rhel-package-owned/tests/test-rpm-assembly.sh
@@ -234,8 +234,11 @@ install -d -m 0755 \
     "${STANDARD_STAGE}/opt/syswarden/bin" \
     "${STANDARD_STAGE}/usr/local/bin"
 install -m 0644 \
-    "${PROFILE_STAGE}/payload/usr/lib/systemd/system/syswarden-core.service" \
+    "${TEST_DIRECTORY}/fixtures/syswarden-core-v4043.service" \
     "${STANDARD_STAGE}/usr/share/syswarden-standard-fixture/syswarden-core.service"
+[[ "$(sha256sum "${TEST_DIRECTORY}/fixtures/syswarden-core-v4043.service" |
+    awk 'NF == 2 { print $1 }')" == \
+    8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd ]]
 install -m 0644 \
     "${PROFILE_STAGE}/payload/usr/lib/systemd/system/syswarden-firewall.service" \
     "${STANDARD_STAGE}/usr/share/syswarden-standard-fixture/syswarden-firewall.service"
@@ -683,6 +686,9 @@ assert_standard_authority() {
     local root="$1"
     chroot_path_is_regular "${root}" /etc/systemd/system/syswarden-core.service
     chroot_path_is_regular "${root}" /etc/systemd/system/syswarden-firewall.service
+    [[ "$(run_in_chroot "${root}" /usr/bin/sha256sum /etc/systemd/system/syswarden-core.service |
+        awk 'NF == 2 { print $1 }')" == \
+        8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd ]]
     [[ "$(chroot_admin stat -c '%a' "${root}/etc/systemd/system/syswarden-core.service")" == \
         600 ]]
     [[ "$(chroot_admin stat -c '%a' "${root}/etc/systemd/system/syswarden-firewall.service")" == \

--- a/scripts/ci/package_webtui_retirement.sh
+++ b/scripts/ci/package_webtui_retirement.sh
@@ -268,7 +268,7 @@ syswarden_remove_exact_product_services() {
                 /etc/systemd/system/syswarden-firewall.service || return 1
             syswarden_remove_exact_service_file \
                 /etc/systemd/system/syswarden-core.service \
-                8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd 600 || return 1
+                cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7 600 || return 1
             syswarden_remove_exact_service_file \
                 /etc/systemd/system/syswarden-firewall.service \
                 989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1 600 || return 1

--- a/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/rhel_package_owned_linux_test.go
@@ -36,7 +36,7 @@ func testRHELPackageOwnedOwner(t *testing.T, root string) (uint32, uint32) {
 func TestCompiledRHELPackageOwnedProfileMatchesReviewedPayload(t *testing.T) {
 	t.Parallel()
 	want := map[string]string{
-		rhelPackageOwnedCoreUnitPath:               "8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd",
+		rhelPackageOwnedCoreUnitPath:               "cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7",
 		rhelPackageOwnedFirewallUnitPath:           "989be4b60c43bba830333ef30949376e57658222a48947194395393794e328c1",
 		systemdFirewallWireGuardOrderingDropInPath: "8c4b31f25436882197beec8c8bff5a7599389e564593bd7c353aa99ef3854483",
 		rhelPackageOwnedPresetPath:                 "0f6e058dc43d09ed101799ee444015918d28127186c9f0cbc78231906b955354",

--- a/src/core/syswarden-cli/pkg/system/service_linux.go
+++ b/src/core/syswarden-cli/pkg/system/service_linux.go
@@ -119,11 +119,46 @@ RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
 NoNewPrivileges=true
 PrivateTmp=true
 ReadWritePaths=/var/lib/syswarden /var/log/syswarden /run /opt/syswarden /etc/syswarden/lists
+# CAP_CHOWN assigns the socket to the verified private rsyslog producer group.
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN
+
+[Install]
+WantedBy=multi-user.target
+`
+
+	historicalV4043SystemdCoreService = `[Unit]
+Description=SYSWARDEN WAF and Core Engine
+Requires=syswarden-firewall.service
+After=network.target rsyslog.service syswarden-firewall.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/opt/syswarden/bin/syswarden-core
+Restart=on-failure
+RestartSec=5s
+
+# Security Hardening
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+NoNewPrivileges=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/syswarden /var/log/syswarden /run /opt/syswarden /etc/syswarden/lists
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_DAC_OVERRIDE CAP_FOWNER
 
 [Install]
 WantedBy=multi-user.target
 `
+
+	historicalV4043SystemdCoreServiceLength = 775
+	historicalV4043SystemdCoreServiceSHA256 = "8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd"
 
 	historicalV4028SystemdCoreService = `[Unit]
 Description=SYSWARDEN WAF and Core Engine
@@ -2034,7 +2069,12 @@ func publishSystemdServices() error {
 			historicalContent:       historicalV4028SystemdCoreService,
 			historicalContentLength: historicalV4028SystemdCoreServiceLength,
 			historicalContentSHA256: historicalV4028SystemdCoreServiceSHA256,
-			historicalModes:         []os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode},
+			historicalAlternates: []historicalServiceContent{{
+				content:       historicalV4043SystemdCoreService,
+				contentLength: historicalV4043SystemdCoreServiceLength,
+				contentSHA256: historicalV4043SystemdCoreServiceSHA256,
+			}},
+			historicalModes: []os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode},
 		},
 		{
 			path: firewallUnitPath, content: systemdFirewallService, mode: sourceSystemdUnitMode,

--- a/src/core/syswarden-cli/pkg/system/service_socket_capability_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/service_socket_capability_linux_test.go
@@ -1,0 +1,80 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCoreSystemdUnitsPermitPrivateSyslogSocketOwnership(t *testing.T) {
+	packaged := mustReadTestFile(t, filepath.Join("..", "..", "..", "..", "init", "systemd", "syswarden-core.service"))
+	// The socket is created by root and then assigned to the verified syslog
+	// group. CAP_FOWNER and CAP_DAC_OVERRIDE do not authorize that chown.
+	want := map[string]bool{
+		"CAP_CHOWN": true, "CAP_NET_ADMIN": true, "CAP_NET_RAW": true,
+		"CAP_DAC_OVERRIDE": true, "CAP_FOWNER": true,
+	}
+	for name, unit := range map[string]string{"generated": systemdCoreService, "packaged": string(packaged)} {
+		t.Run(name, func(t *testing.T) {
+			capabilities := make(map[string]bool)
+			count := 0
+			for _, line := range strings.Split(unit, "\n") {
+				if value, ok := strings.CutPrefix(line, "CapabilityBoundingSet="); ok {
+					count++
+					for _, capability := range strings.Fields(value) {
+						capabilities[capability] = true
+					}
+				}
+			}
+			if count != 1 || !reflect.DeepEqual(capabilities, want) {
+				t.Fatalf("core capability boundary cannot support private socket ownership: %v (%d directives)", capabilities, count)
+			}
+			for _, boundary := range []string{"User=root\n", "ProtectSystem=strict\n", "NoNewPrivileges=true\n"} {
+				if !strings.Contains(unit, boundary) {
+					t.Fatalf("core unit lost security boundary %q", boundary)
+				}
+			}
+		})
+	}
+}
+
+func TestCoreSocketCapabilityUpgradePreservesServiceAttestation(t *testing.T) {
+	for _, mode := range []os.FileMode{0600, 0644} {
+		for _, modified := range []bool{false, true} {
+			t.Run(fmt.Sprintf("mode-%04o-modified-%t", mode, modified), func(t *testing.T) {
+				directory, wants := withSystemdPublicationTestPaths(t)
+				core := filepath.Join(directory, "syswarden-core.service")
+				old := historicalV4043SystemdCoreService
+				if modified {
+					old += "# Operator customization\n"
+				}
+				mustWriteFile(t, core, old)
+				mustChmodTestPath(t, core, mode)
+				firewall := filepath.Join(directory, "syswarden-firewall.service")
+				mustWriteFile(t, firewall, systemdFirewallService)
+				mustMkdirAll(t, wants)
+				err := publishSystemdServices()
+				if modified {
+					if err == nil || string(mustReadTestFile(t, core)) != old {
+						t.Fatalf("modified historical unit was not preserved and refused: %v", err)
+					}
+				} else {
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got := string(mustReadTestFile(t, core)); got != systemdCoreService {
+						t.Fatal("exact v4.04.3 unit did not migrate to the socket-capable unit")
+					}
+					assertServiceEnablementTarget(t, filepath.Join(wants, "syswarden-core.service"), "../syswarden-core.service")
+				}
+				if string(mustReadTestFile(t, firewall)) != systemdFirewallService {
+					t.Fatal("socket capability migration changed the firewall unit")
+				}
+				assertNoServiceMigrationArtifacts(t, directory)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Ubuntu hosts with rsyslog running as `syslog` cannot start the hardened core: assigning its Unix socket to the verified private logging group fails with `operation not permitted`. Add `CAP_CHOWN` to both current systemd units so the core can create the required root-owned, private-group socket with mode 0660. Kernel credential checks and the other service restrictions remain in force.

Preserve exact historical v4.04.3 service migration, reject customized units, and update package-owned payload and cleanup digests. The RPM fixture retains the actual historical unit so migration and rollback continue to exercise distinct versions. Version targets and changelog remain unchanged at v4.10.0.

Validation: the original capability boundary reproduced the failure on native Ubuntu; adding only CAP_CHOWN started the unchanged signed core and preserved configuration and operator firewall state. Normal/race/vet checks for all modules, 1,109 Python contracts, security scans, five bounded fuzz campaigns, the isolated nftables test, CLI process compatibility, package builds, and the complete RPM assembly/migration/rollback/purge harness pass. Final native release qualification remains required on the merged commit.
