### PR TITLE
Fix : clean up verified private logging sockets during package removal

### DIFF
--- a/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
+++ b/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
@@ -37,6 +37,12 @@ On Linux the datagram socket grants write access to root and the private
 also carry kernel-generated sender credentials for root or that exact syslog
 UID. Membership in the group alone does not authorize injection; missing,
 truncated, or unauthorized credentials are refused before rule evaluation.
+Package removal accepts that exact root-owned logging socket with mode 0660
+after resolving the same canonical syslog account and private group. The parent
+directory and command socket retain their root:root ownership requirements.
+Legacy root:root sockets and already-absent sockets need no syslog lookup;
+unexpected identities and changes during removal are refused.
+
 When the syslog account is absent, only root is authorized. A service running
 as a non-root user accepts only its own UID. Platforms without the Linux
 credential mechanism cannot start this receiver.

--- a/src/core/syswarden-cli/pkg/system/removal_artifacts_linux.go
+++ b/src/core/syswarden-cli/pkg/system/removal_artifacts_linux.go
@@ -552,6 +552,10 @@ func removeExactProductSymlinkAt(
 }
 
 func removeExactRuntimeSocketAt(path string, expectedUID, expectedGID uint32) error {
+	return removeExactRuntimeSocketWithPrivateGroupAt(path, expectedUID, expectedGID, nil)
+}
+
+func removeExactRuntimeSocketWithPrivateGroupAt(path string, expectedUID, expectedGID uint32, privateGroup func() (uint32, error)) error {
 	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return fmt.Errorf("runtime socket removal path is not clean and absolute")
 	}
@@ -568,14 +572,14 @@ func removeExactRuntimeSocketAt(path string, expectedUID, expectedGID uint32) er
 	if err != nil {
 		return fmt.Errorf("inspect runtime socket %s: %w", path, err)
 	}
-	stat, ok := before.Sys().(*syscall.Stat_t)
-	if !ok || before.Mode()&os.ModeSymlink != 0 || before.Mode()&os.ModeSocket == 0 ||
-		stat.Uid != expectedUID || stat.Gid != expectedGID || stat.Nlink != 1 {
-		return fmt.Errorf("refusing non-attributable runtime socket %s", path)
+	identity, err := attestRuntimeSocketIdentity(before, expectedUID, expectedGID, privateGroup)
+	if err != nil {
+		return fmt.Errorf("refusing non-attributable runtime socket %s: %w", path, err)
 	}
 	confirmed, err := parent.root.Lstat(name)
-	if err != nil || !os.SameFile(before, confirmed) || before.Mode() != confirmed.Mode() {
-		return errors.Join(fmt.Errorf("runtime socket %s changed during attestation", path), err)
+	confirmedIdentity, identityErr := exactRemovalArtifactIdentity(confirmed)
+	if err != nil || identityErr != nil || identity != confirmedIdentity {
+		return errors.Join(fmt.Errorf("runtime socket %s changed during attestation", path), err, identityErr)
 	}
 	if err := parent.root.Remove(name); err != nil {
 		return fmt.Errorf("remove exact runtime socket %s: %w", path, err)
@@ -593,7 +597,7 @@ func removeExactRuntimeSocketAt(path string, expectedUID, expectedGID uint32) er
 // calls this only after every rsyslog producer has been restarted without the
 // SysWarden bridge and before the matching SELinux policy is removed.
 func RemoveExactRuntimeSocketForPackageRemoval() error {
-	return removeExactRuntimeSocketForPackageRemovalUsing(removeExactRuntimeSocketAt)
+	return removeExactRuntimeSocketForPackageRemovalUsing(removePackageRuntimeSocketAt)
 }
 
 func removeExactRuntimeSocketForPackageRemovalUsing(

--- a/src/core/syswarden-cli/pkg/system/removal_socket_identity_linux.go
+++ b/src/core/syswarden-cli/pkg/system/removal_socket_identity_linux.go
@@ -1,0 +1,65 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+)
+
+// The core grants its logging socket to the canonical syslog private group.
+// Keep the parent directory and the separate control socket root:root. Legacy
+// root:root sockets and absent sockets need no logging-account lookup.
+func removePackageRuntimeSocketAt(path string, uid, gid uint32) error {
+	if path != "/run/syswarden.sock" {
+		return removeExactRuntimeSocketAt(path, uid, gid)
+	}
+	return removeExactRuntimeSocketWithPrivateGroupAt(path, uid, gid, func() (uint32, error) {
+		return resolveRemovalSyslogGroup(user.Lookup, user.LookupGroup)
+	})
+}
+
+func resolveRemovalSyslogGroup(lookupUser func(string) (*user.User, error), lookupGroup func(string) (*user.Group, error)) (uint32, error) {
+	account, err := lookupUser("syslog")
+	if err != nil {
+		return 0, fmt.Errorf("resolve runtime socket producer account: %w", err)
+	}
+	group, err := lookupGroup("syslog")
+	if err != nil {
+		return 0, fmt.Errorf("resolve runtime socket producer group: %w", err)
+	}
+	if account == nil || group == nil || account.Username != "syslog" || group.Name != "syslog" || account.Gid != group.Gid {
+		return 0, fmt.Errorf("runtime socket producer does not match its private group")
+	}
+	uid, uidErr := strconv.ParseUint(account.Uid, 10, 32)
+	gid, gidErr := strconv.ParseUint(group.Gid, 10, 32)
+	if uidErr != nil || gidErr != nil || uid == 0 || gid == 0 || uid == 1<<32-1 || gid == 1<<32-1 ||
+		strconv.FormatUint(uid, 10) != account.Uid || strconv.FormatUint(gid, 10) != group.Gid {
+		return 0, fmt.Errorf("invalid runtime socket producer UID or GID")
+	}
+	return uint32(gid), nil // #nosec G115 -- ParseUint above bounds the canonical nonzero GID to 32 bits
+}
+
+func attestRuntimeSocketIdentity(info os.FileInfo, uid, gid uint32, privateGroup func() (uint32, error)) (removalArtifactIdentity, error) {
+	identity, err := exactRemovalArtifactIdentity(info)
+	if err != nil {
+		return identity, err
+	}
+	if info.Mode()&os.ModeType != os.ModeSocket || identity.uid != uid || identity.nlink != 1 {
+		return identity, fmt.Errorf("runtime target is not an owned single-link Unix socket")
+	}
+	if identity.gid == gid {
+		return identity, nil
+	}
+	if privateGroup == nil || info.Mode() != os.ModeSocket|0660 {
+		return identity, fmt.Errorf("runtime socket has an unexpected group or mode")
+	}
+	producerGID, err := privateGroup()
+	if err != nil {
+		return identity, fmt.Errorf("verify private runtime socket producer group: %w", err)
+	}
+	if producerGID == 0 || identity.gid != producerGID {
+		return identity, fmt.Errorf("runtime socket does not match the verified private producer group")
+	}
+	return identity, nil
+}

--- a/src/core/syswarden-cli/pkg/system/removal_socket_identity_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/removal_socket_identity_linux_test.go
@@ -1,0 +1,192 @@
+package system
+
+import (
+	"errors"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestRuntimeSocketRemovalResolvesCanonicalPrivateGroup(t *testing.T) {
+	account := &user.User{Username: "syslog", Uid: "100", Gid: "101"}
+	group := &user.Group{Name: "syslog", Gid: "101"}
+	lookupUser := func(name string) (*user.User, error) {
+		if name != "syslog" {
+			t.Fatalf("unexpected account %q", name)
+		}
+		return account, nil
+	}
+	lookupGroup := func(name string) (*user.Group, error) {
+		if name != "syslog" {
+			t.Fatalf("unexpected group %q", name)
+		}
+		return group, nil
+	}
+	if gid, err := resolveRemovalSyslogGroup(lookupUser, lookupGroup); err != nil || gid != 101 {
+		t.Fatalf("canonical native producer group refused: %d %v", gid, err)
+	}
+	for _, invalid := range []string{"", "0", "-1", "+100", "0100", "4294967295", "4294967296", "invalid"} {
+		account.Uid = invalid
+		if _, err := resolveRemovalSyslogGroup(lookupUser, lookupGroup); err == nil {
+			t.Fatalf("unsafe UID accepted: %q", invalid)
+		}
+		account.Uid = "100"
+		account.Gid, group.Gid = invalid, invalid
+		if _, err := resolveRemovalSyslogGroup(lookupUser, lookupGroup); err == nil {
+			t.Fatalf("unsafe GID accepted: %q", invalid)
+		}
+		account.Gid, group.Gid = "101", "101"
+	}
+	for _, mutate := range []func(){
+		func() { account.Username = "operator" },
+		func() { group.Name = "operator" },
+		func() { account.Gid = "102" },
+		func() { account = nil },
+		func() { group = nil },
+	} {
+		mutate()
+		if _, err := resolveRemovalSyslogGroup(lookupUser, lookupGroup); err == nil {
+			t.Fatal("mismatched or missing producer identity accepted")
+		}
+		account = &user.User{Username: "syslog", Uid: "100", Gid: "101"}
+		group = &user.Group{Name: "syslog", Gid: "101"}
+	}
+	for _, failure := range []error{user.UnknownUserError("syslog"), errors.New("NSS unavailable")} {
+		if _, err := resolveRemovalSyslogGroup(func(string) (*user.User, error) { return nil, failure }, lookupGroup); !errors.Is(err, failure) {
+			t.Fatalf("account lookup failure lost: %v", err)
+		}
+		if _, err := resolveRemovalSyslogGroup(lookupUser, func(string) (*user.Group, error) { return nil, failure }); !errors.Is(err, failure) {
+			t.Fatalf("group lookup failure lost: %v", err)
+		}
+	}
+}
+
+type runtimeSocketMetadataFixture struct {
+	os.FileInfo
+	metadata syscall.Stat_t
+	mode     os.FileMode
+}
+
+func (info runtimeSocketMetadataFixture) Sys() any          { return &info.metadata }
+func (info runtimeSocketMetadataFixture) Mode() os.FileMode { return info.mode }
+
+func TestRuntimeSocketRemovalPrivateGroupBoundaries(t *testing.T) {
+	baseline := runtimeSocketMetadataFixture{metadata: syscall.Stat_t{Uid: 0, Gid: 101, Nlink: 1, Mode: syscall.S_IFSOCK | 0660}, mode: os.ModeSocket | 0660}
+	resolve := func() (uint32, error) { return 101, nil }
+	if _, err := attestRuntimeSocketIdentity(baseline, 0, 0, resolve); err != nil {
+		t.Fatalf("native root:syslog socket refused: %v", err)
+	}
+	for _, mutate := range []func(*runtimeSocketMetadataFixture){
+		func(info *runtimeSocketMetadataFixture) { info.metadata.Uid = 100 },
+		func(info *runtimeSocketMetadataFixture) { info.metadata.Gid = 102 },
+		func(info *runtimeSocketMetadataFixture) { info.metadata.Nlink = 2 },
+		func(info *runtimeSocketMetadataFixture) { info.mode = 0660 },
+		func(info *runtimeSocketMetadataFixture) { info.mode = os.ModeSymlink | 0660 },
+		func(info *runtimeSocketMetadataFixture) { info.mode = os.ModeNamedPipe | 0660 },
+		func(info *runtimeSocketMetadataFixture) { info.mode = os.ModeSocket | 0666 },
+		func(info *runtimeSocketMetadataFixture) { info.mode = os.ModeSocket | 0600 },
+		func(info *runtimeSocketMetadataFixture) { info.mode |= os.ModeSticky },
+	} {
+		info := baseline
+		mutate(&info)
+		if _, err := attestRuntimeSocketIdentity(info, 0, 0, resolve); err == nil {
+			t.Fatalf("non-attributable socket accepted: %+v", info)
+		}
+	}
+	for _, resolver := range []func() (uint32, error){nil, func() (uint32, error) { return 0, nil }, func() (uint32, error) { return 101, errors.New("NSS failure") }} {
+		if _, err := attestRuntimeSocketIdentity(baseline, 0, 0, resolver); err == nil {
+			t.Fatal("socket accepted without a verified private group")
+		}
+	}
+	baseline.metadata.Gid = 0
+	if _, err := attestRuntimeSocketIdentity(baseline, 0, 0, func() (uint32, error) {
+		t.Fatal("legacy root socket unexpectedly required syslog")
+		return 0, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRuntimeSocketNativePrivateGroupRemoval(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires isolated root to create the native root:syslog socket fixture")
+	}
+	for _, scenario := range []string{"remove", "group-writable-parent", "changed-owner", "changed-group", "changed-mode", "replaced-inode"} {
+		t.Run(scenario, func(t *testing.T) {
+			parent := t.TempDir()
+			path := filepath.Join(parent, "syswarden.sock")
+			conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+			if err := os.Chown(path, 0, 101); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(path, 0660); err != nil {
+				t.Fatal(err)
+			} // #nosec G302 -- private root-owned test socket reproduces the exact native producer mode
+			if err := removeExactRuntimeSocketAt(path, 0, 0); err == nil {
+				t.Fatal("strict root socket policy accepted the private group")
+			}
+			if scenario == "group-writable-parent" {
+				if err := os.Chmod(parent, 0770); err != nil {
+					t.Fatal(err)
+				} // #nosec G302 -- deliberately unsafe private fixture must be refused
+			}
+			resolve := func() (uint32, error) {
+				switch scenario {
+				case "changed-owner":
+					if err := os.Chown(path, 100, 101); err != nil {
+						t.Fatal(err)
+					}
+				case "changed-group":
+					if err := os.Chown(path, 0, 102); err != nil {
+						t.Fatal(err)
+					}
+				case "changed-mode":
+					if err := os.Chmod(path, 0600); err != nil {
+						t.Fatal(err)
+					}
+				case "replaced-inode":
+					if err := os.Rename(path, path+".retained"); err != nil {
+						t.Fatal(err)
+					}
+					replacement, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() { _ = replacement.Close() })
+					if err := os.Chown(path, 0, 101); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Chmod(path, 0660); err != nil {
+						t.Fatal(err)
+					} // #nosec G302 -- private replacement fixture matches the native mode to test inode attestation
+				}
+				return 101, nil
+			}
+			err = removeExactRuntimeSocketWithPrivateGroupAt(path, 0, 0, resolve)
+			_, statErr := os.Lstat(path)
+			if scenario == "remove" {
+				if err != nil || !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("private socket removal failed: %v %v", err, statErr)
+				}
+				if err := removeExactRuntimeSocketWithPrivateGroupAt(path, 0, 0, func() (uint32, error) {
+					t.Fatal("absent socket required an account lookup")
+					return 0, nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || statErr != nil {
+				t.Fatalf("unsafe socket or parent was removed: %v %v", err, statErr)
+			} else if scenario != "group-writable-parent" && !strings.Contains(err.Error(), "changed during attestation") {
+				t.Fatalf("identity change was not detected: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Package removal rejects the Linux logging socket after the core assigns its private syslog group, leaving cleanup incomplete. Accept the exact root-owned 0660 logging socket only after verifying the canonical syslog account and primary group, retain strict root ownership of the parent directory and control socket, and recheck the full socket identity before unlinking.

Validation: Go 1.26.6 and Go 1.27.1 functional, race and vet checks; both Go 1.27 JSON modes; 1,109 Python contracts with three expected skips; canonical identity and adversarial socket tests, including real socket removal and ownership or inode changes in an isolated container; security scans, five bounded fuzzers, documentation, package builds and the RPM adversarial harness.

The release version remains v4.10.0. Changelog, workflows and frozen qualification requirements are unchanged. Qualification on signed packages from the eventual merged commit remains required.
