### PR TITLE
Fix : recognize ISO timestamps in SSH authentication logs

### DIFF
--- a/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
+++ b/docs/technical/CUSTOM_LOG_SOURCE_TRUST.md
@@ -32,6 +32,12 @@ writer. Unknown or ambiguous privilege-drop declarations stop hardening before
 authentication log ownership changes. Other privilege-drop configuration
 formats must be reviewed and expressed in this supported form first.
 
+The SSH authentication rule accepts records from `sshd` and `sshd-session`
+without a syslog envelope, with the traditional month/day timestamp, or with an
+ISO timestamp using `Z` or a numeric timezone offset and optional fractional
+seconds. The process identity remains anchored after the timestamp and host.
+Successful logins and connection-close records do not count as failed attempts.
+
 On Linux the datagram socket grants write access to root and the private
 `syslog` group when its account and primary group agree. Every datagram must
 also carry kernel-generated sender credentials for root or that exact syslog

--- a/src/core/syswarden-core/engine/ssh_session_catalog_test.go
+++ b/src/core/syswarden-core/engine/ssh_session_catalog_test.go
@@ -10,7 +10,13 @@ func TestProductionSSHSessionAuthentication(t *testing.T) {
 	detector := newProductionTestEngine(t)
 	for _, process := range []string{"sshd", "sshd-session"} {
 		for _, address := range []string{"192.0.2.44", "2001:db8::44"} {
-			for _, prefix := range []string{"", "Sep 10 11:53:27 gateway "} {
+			for _, prefix := range []string{
+				"", "Sep 10 11:53:27 gateway ",
+				"2030-01-02T03:04:05.123456+00:00 gateway ",
+				"2030-01-02T03:04:05Z gateway ",
+				"2030-01-02T05:04:05+02:00 gateway ",
+				"2030-01-01T22:04:05.123456789-05:00 gateway ",
+			} {
 				for _, event := range []string{
 					"Invalid user native-probe",
 					"Failed password for invalid user native-probe",
@@ -53,5 +59,49 @@ func TestProductionSSHSessionRejectsNonAuthenticationAndForgedIdentity(t *testin
 	match := detector.Scan(line)
 	if match == nil || match.RuleID != "ssh-auth" || match.Host != netip.MustParseAddr("192.0.2.44") {
 		t.Fatalf("username redirected the SSH enforcement address: %#v", match)
+	}
+}
+
+func TestProductionSSHRejectsMalformedISOEnvelope(t *testing.T) {
+	detector := newProductionTestEngine(t)
+	for _, line := range []string{
+		"2030-01-02T03:04:05 gateway sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05.1234567890Z gateway sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05+0000 gateway sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05Z gateway nginx[7393]: sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05Z gateway not-sshd-session[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05Z gateway sshd-session-extra[7393]: Invalid user native-probe from 192.0.2.44 port 33071",
+		"2030-01-02T03:04:05Z gateway sshd-session[7393]: Accepted publickey for root from 192.0.2.44 port 33071 ssh2",
+		"2030-01-02T03:04:05Z gateway sshd-session[7393]: Connection closed by invalid user native-probe 192.0.2.44 port 33071 [preauth]",
+	} {
+		t.Run(line, func(t *testing.T) {
+			if match := detector.Scan(line); match != nil {
+				t.Fatalf("malformed or non-authentication record was admitted: %#v", match)
+			}
+		})
+	}
+}
+
+func TestProductionSSHISOIngressThreshold(t *testing.T) {
+	detector, err := NewEngine("../signatures.json", 4, 61)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decisions := 0
+	for index := range 4 {
+		line := fmt.Sprintf("2030-01-02T03:04:05.%06d+00:00 gateway sshd-session[%d]: Invalid user native-probe from 192.0.2.44 port %d", index, 7393+index, 33071+index)
+		match := detector.ScanIngress(IngressSourceUDS, line)
+		if match == nil || match.RuleID != "ssh-auth" || match.Action != "track" || match.Host != netip.MustParseAddr("192.0.2.44") {
+			t.Fatalf("native ISO record was not attributed: %#v", match)
+		}
+		if detector.EvaluateThreshold(match.Host.String(), match.RuleID, match.Threshold, match.Window) {
+			decisions++
+		}
+		if duplicate := detector.ScanIngress(IngressSourceDirect, line); duplicate != nil {
+			t.Fatalf("second collector duplicated a physical SSH event: %#v", duplicate)
+		}
+	}
+	if decisions != 1 {
+		t.Fatalf("four physical events produced %d threshold decisions, want one", decisions)
 	}
 }

--- a/src/core/syswarden-core/signatures.json
+++ b/src/core/syswarden-core/signatures.json
@@ -98,7 +98,7 @@
     {
       "id": "ssh-auth",
       "type": "regex",
-      "pattern": "^(?:[A-Z][a-z]{2}[[:space:]]+[0-9]{1,2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]]+[^[:space:]]+[[:space:]]+)?sshd(?:-session)?(?:\\[[0-9]+\\])?:[[:space:]]+(?:Failed password for|Invalid user|POSSIBLE BREAK-IN).*?from <HOST>(?: port [0-9]+(?: ssh[0-9]+)?)?(?: \\[preauth\\])?[[:space:]]*$",
+      "pattern": "^(?:(?:[A-Z][a-z]{2}[[:space:]]+[0-9]{1,2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}|[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2}))[[:space:]]+[^[:space:]]+[[:space:]]+)?sshd(?:-session)?(?:\\[[0-9]+\\])?:[[:space:]]+(?:Failed password for|Invalid user|POSSIBLE BREAK-IN).*?from <HOST>(?: port [0-9]+(?: ssh[0-9]+)?)?(?: \\[preauth\\])?[[:space:]]*$",
       "service": "sshd",
       "action": "track",
       "trusted_host_capture": true


### PR DESCRIPTION
SSH authentication records with an ISO timestamp were ignored by the production catalog, preventing repeated failed logins from reaching the blocking threshold. The SSH rule now accepts ISO timestamps with a timezone and optional fractional seconds, while preserving the anchored `sshd` or `sshd-session` process identity and existing bare and traditional syslog formats.

Regression coverage exercises IPv4 and IPv6, both process names, supported timestamp formats, malformed envelopes, unrelated processes, successful logins, and duplicate physical events received through separate collectors. Four distinct failed logins produce one threshold decision. The source trust documentation describes the accepted envelopes. Version v4.10.0 and the changelog are unchanged.

Validation: all four Go modules passed tests, race tests and vet; the full 1,109-test Python suite passed with three expected skips; security scans, lint, five fuzz campaigns, the isolated nftables golden test, documentation, 50 CLI process contracts, package builds, RHEL staging and the RPM assembly harness passed. Go 1.27 functional, race, vet and both JSON modes passed. The Python suite was rerun unchanged after two readiness timeouts during concurrent compilation. The RPM harness was rerun unchanged after correcting source archive permissions. ShellCheck retains 39 unchanged informational diagnostics.

Fresh signed packages and native qualification on the eventual merged commit are still required before release.
