### PR TITLE
Fix : preserve native rollback service compatibility

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -429,6 +429,7 @@ jobs:
           set -euo pipefail
           install -d -m 0755 \
             "${STAGING_AMD64}/opt/syswarden/bin" \
+            "${STAGING_AMD64}/usr/lib/systemd/system/syswarden-core.service.d" \
             "${STAGING_AMD64}/usr/lib/systemd/system/syswarden-firewall.service.d" \
             "${STAGING_AMD64}/usr/local/bin" \
             "${STAGING_AMD64}/usr/share/bash-completion/completions" \
@@ -462,12 +463,21 @@ jobs:
           install -m 0644 \
             "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf" \
             "${STAGING_AMD64}/usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf"
+          install -m 0644 \
+            "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+            "${STAGING_AMD64}/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf"
 
       - name: Stage Opt-in RHEL Package-owned RPM Payload
         shell: bash
         run: |
           set -euo pipefail
           cp -a "${STAGING_AMD64}/." "${RHEL_PROFILE_STAGING}/"
+          # RHEL vendor units already carry the socket ownership capability.
+          cmp -s \
+            "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+            "${RHEL_PROFILE_STAGING}/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf"
+          rm -- "${RHEL_PROFILE_STAGING}/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf"
+          rmdir -- "${RHEL_PROFILE_STAGING}/usr/lib/systemd/system/syswarden-core.service.d"
           PYTHONDONTWRITEBYTECODE=1 python3 \
             "${EXACT_SOURCE_ROOT}/extensions/rhel-package-owned/stage.py" \
             --enable-rhel-package-owned-profile \
@@ -690,6 +700,10 @@ jobs:
           PYTHONDONTWRITEBYTECODE=1 python3 scripts/ci/package_stage_gate.py \
             linux --root "${STAGING_AMD64}" \
             --service-manager systemd \
+            --systemd-socket-contract \
+            scripts/ci/package_systemd_socket_capability_contract.json \
+            --systemd-socket-source \
+            "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
             --systemd-ordering-contract \
             scripts/ci/package_systemd_wireguard_ordering_contract.json \
             --systemd-ordering-source \
@@ -748,6 +762,13 @@ jobs:
             "${AMD64_DIGEST_CONTRACT}" >> "${GITHUB_OUTPUT}"
           printf 'apk_amd64_digest_contract=%s\n' \
             "${APK_AMD64_DIGEST_CONTRACT}" >> "${GITHUB_OUTPUT}"
+          PYTHONDONTWRITEBYTECODE=1 python3 \
+            scripts/ci/package_systemd_ordering_artifact_gate.py \
+            --artifact socket --format stage \
+            --root "${STAGING_AMD64}" \
+            --source \
+            "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+            --contract scripts/ci/package_systemd_socket_capability_contract.json
 
       - name: Prepare Linux Maintainer Scripts
         run: |
@@ -762,6 +783,7 @@ jobs:
           syswarden_preflight_alpine_cronie
           syswarden_preflight_install_barriers
           syswarden_preflight_systemd_ordering_dropin
+          syswarden_preflight_systemd_socket_dropin
           if [ "${SYSWARDEN_OFFLINE_QUALIFICATION:-}" = 1 ]; then
               if [ "${syswarden_deferred_present:-0}" -ne 0 ] || \
                  [ "${syswarden_finalizing_present:-0}" -ne 0 ]; then
@@ -1202,6 +1224,8 @@ jobs:
             --after-install "${PACKAGE_RPM_SCRIPTS}/postinst.sh" \
             --before-remove "${PACKAGE_RPM_SCRIPTS}/prerm.sh" \
             --after-remove "${PACKAGE_RPM_SCRIPTS}/postrm.sh" \
+            --directories /usr/lib/systemd/system/syswarden-core.service.d \
+            --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-core.service.d" \
             --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
             --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
             --directories /usr/share/doc/syswarden \
@@ -1528,6 +1552,13 @@ jobs:
               --source \
               "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf" \
               --contract scripts/ci/package_systemd_wireguard_ordering_contract.json
+            PYTHONDONTWRITEBYTECODE=1 python3 \
+              scripts/ci/package_systemd_ordering_artifact_gate.py \
+              --artifact socket --format "${format}" \
+              --package "${package}" \
+              --source \
+              "${EXACT_SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+              --contract scripts/ci/package_systemd_socket_capability_contract.json
           done
 
       - name: Validate Packaged Binary Provenance

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -397,6 +397,7 @@ install -d -m 0755 \
     staging/usr/lib \
     staging/usr/lib/systemd \
     staging/usr/lib/systemd/system \
+    staging/usr/lib/systemd/system/syswarden-core.service.d \
     staging/usr/lib/systemd/system/syswarden-firewall.service.d \
     staging/usr/local \
     staging/usr/local/bin \
@@ -434,6 +435,9 @@ install -m 0644 \
 install -m 0644 \
     "${SOURCE_ROOT}/src/init/systemd/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf" \
     staging/usr/lib/systemd/system/syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf
+install -m 0644 \
+    "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+    staging/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf
 cp "${SOURCE_ROOT}/src/core/syswarden-core/signatures.json" staging-apk/opt/syswarden/
 cp dist/bin-apk/syswarden-cli dist/bin-apk/syswarden-core dist/bin-apk/syswarden-tui staging-apk/opt/syswarden/bin/
 ln -s /opt/syswarden/bin/syswarden-cli staging-apk/usr/local/bin/syswarden
@@ -458,6 +462,10 @@ PYTHONDONTWRITEBYTECODE=1 python3 \
     "${SOURCE_ROOT}/scripts/ci/package_stage_gate.py" \
     linux --root staging \
     --service-manager systemd \
+    --systemd-socket-contract \
+    "${SOURCE_ROOT}/scripts/ci/package_systemd_socket_capability_contract.json" \
+    --systemd-socket-source \
+    "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
     --systemd-ordering-contract \
     "${SOURCE_ROOT}/scripts/ci/package_systemd_wireguard_ordering_contract.json" \
     --systemd-ordering-source \
@@ -571,6 +579,13 @@ fi
 RHEL_PROFILE_STAGE=""
 if [ "${RHEL_PACKAGE_OWNED_PROFILE}" -eq 1 ]; then
     RHEL_PROFILE_STAGE="${PACKAGE_WORKSPACE}/rhel-package-owned-profile"
+    # Vendor-owned units already carry CAP_CHOWN and do not need the standard
+    # package's generated-unit compatibility policy.
+    cmp -s \
+        "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+        staging-rpm/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf
+    rm -- staging-rpm/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf
+    rmdir -- staging-rpm/usr/lib/systemd/system/syswarden-core.service.d
     PYTHONDONTWRITEBYTECODE=1 python3 \
         "${REPOSITORY_ROOT}/extensions/rhel-package-owned/stage.py" \
         --enable-rhel-package-owned-profile \
@@ -605,6 +620,7 @@ export SYSWARDEN_PKG_INSTALL=1
 syswarden_preflight_alpine_cronie
 syswarden_preflight_install_barriers
 syswarden_preflight_systemd_ordering_dropin
+syswarden_preflight_systemd_socket_dropin
 if [ "${SYSWARDEN_OFFLINE_QUALIFICATION:-}" = 1 ]; then
     if [ "${syswarden_deferred_present:-0}" -ne 0 ] || \
        [ "${syswarden_finalizing_present:-0}" -ne 0 ]; then
@@ -997,12 +1013,17 @@ normalize_package_mtimes \
 # 4. Generate Packages
 echo "[*] Generating .deb and .rpm packages via FPM..."
 
+RPM_SOCKET_FPM_OPTIONS=(
+    --directories /usr/lib/systemd/system/syswarden-core.service.d
+    --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-core.service.d"
+)
 RPM_PROFILE_DEPENDENCIES=()
 RPM_PROFILE_FPM_OPTIONS=()
 RPM_BUILD_ID_FPM_OPTIONS=(--directories /usr/lib/.build-id)
 RPM_BUILD_ID_DEFINE_OPTIONS=()
 if [ "${RHEL_PACKAGE_OWNED_PROFILE}" -eq 1 ]; then
     RPM_PROFILE_DEPENDENCIES=(-d "systemd")
+    RPM_SOCKET_FPM_OPTIONS=()
     RPM_BUILD_ID_FPM_OPTIONS=()
     RPM_BUILD_ID_DEFINE_OPTIONS=(--rpm-rpmbuild-define "_build_id_links none")
     RPM_PROFILE_FPM_OPTIONS=(
@@ -1086,6 +1107,7 @@ fi
         --rpm-rpmbuild-define "clamp_mtime_to_source_date_epoch 1" \
         --rpm-rpmbuild-define "_buildhost syswarden-build.invalid" \
         "${RPM_BUILD_ID_FPM_OPTIONS[@]}" \
+        "${RPM_SOCKET_FPM_OPTIONS[@]}" \
         --directories /usr/lib/systemd/system/syswarden-firewall.service.d \
         --rpm-attr "0755,root,root:/usr/lib/systemd/system/syswarden-firewall.service.d" \
         --directories /usr/share/doc/syswarden \
@@ -1140,6 +1162,30 @@ EOF
     --config nfpm_alpine_amd64.yaml \
     --packager apk \
     --target "${PACKAGE_WORKSPACE}/syswarden_${VERSION}_x86_64.apk"
+
+PYTHONDONTWRITEBYTECODE=1 python3 \
+    "${SOURCE_ROOT}/scripts/ci/package_systemd_ordering_artifact_gate.py" \
+    --artifact socket --format stage \
+    --root staging \
+    --source \
+    "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+    --contract "${SOURCE_ROOT}/scripts/ci/package_systemd_socket_capability_contract.json"
+PYTHONDONTWRITEBYTECODE=1 python3 \
+    "${SOURCE_ROOT}/scripts/ci/package_systemd_ordering_artifact_gate.py" \
+    --artifact socket --format deb \
+    --package "${PACKAGE_WORKSPACE}/syswarden_${VERSION}_amd64.deb" \
+    --source \
+    "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+    --contract "${SOURCE_ROOT}/scripts/ci/package_systemd_socket_capability_contract.json"
+if [ "${RHEL_PACKAGE_OWNED_PROFILE}" -eq 0 ]; then
+    PYTHONDONTWRITEBYTECODE=1 python3 \
+        "${SOURCE_ROOT}/scripts/ci/package_systemd_ordering_artifact_gate.py" \
+        --artifact socket --format rpm \
+        --package "${PACKAGE_WORKSPACE}/${RPM_PACKAGE_FILENAME}" \
+        --source \
+        "${SOURCE_ROOT}/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf" \
+        --contract "${SOURCE_ROOT}/scripts/ci/package_systemd_socket_capability_contract.json"
+fi
 
 PYTHONDONTWRITEBYTECODE=1 python3 \
     "${SOURCE_ROOT}/scripts/ci/package_systemd_ordering_artifact_gate.py" \

--- a/docs/technical/NATIVE_RUNTIME_LIFECYCLE.md
+++ b/docs/technical/NATIVE_RUNTIME_LIFECYCLE.md
@@ -56,6 +56,15 @@ are bounded and reject unknown fields, duplicate fields, and trailing messages.
 The rsyslog datagram input at `/run/syswarden.sock` cannot submit these commands.
 Package removal cleans up both exact owned sockets after stopping the core.
 
+Standard DEB and RPM packages keep the generated core service byte-compatible
+with v4.04.3. The package owns a separate systemd policy at
+`/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf`
+that adds `CAP_CHOWN` for the private rsyslog socket. The CLI verifies its exact
+content, metadata and stable package ownership before selecting that layout.
+Native downgrade removes the policy with the newer package. Source installs
+and the RHEL package-owned profile retain their existing self-contained units
+with the same effective capabilities. Modified or unowned policies are refused.
+
 For legacy HA, the CLI and core hold compatible read leases on the existing
 writer fence during the coordinated unblock. Fence transitions require an
 exclusive lease and cannot overtake either participant. The ordinary legacy

--- a/scripts/ci/package_lifecycle_contract_test.py
+++ b/scripts/ci/package_lifecycle_contract_test.py
@@ -6758,7 +6758,7 @@ systemctl() {
             ),
             2,
         )
-        self.assertEqual(workflow_stage.count("install -m 0644"), 5)
+        self.assertEqual(workflow_stage.count("install -m 0644"), 6)
 
         local = LOCAL_BUILD_SCRIPT.read_text(encoding="utf-8")
         self.assertEqual(local.count("GEOIP-DATA-LICENSE.txt"), 2)

--- a/scripts/ci/package_stage_gate.py
+++ b/scripts/ci/package_stage_gate.py
@@ -80,6 +80,10 @@ SYSTEMD_ORDERING_PATH = (
     "usr/lib/systemd/system/syswarden-firewall.service.d/"
     "10-syswarden-wireguard-ordering.conf"
 )
+SYSTEMD_SOCKET_PATH = (
+    "usr/lib/systemd/system/syswarden-core.service.d/"
+    "10-syswarden-socket-ownership.conf"
+)
 SYSTEMD_LINUX_ENTRIES = {
     **LINUX_ENTRIES,
     "usr/lib": DIRECTORY,
@@ -87,6 +91,8 @@ SYSTEMD_LINUX_ENTRIES = {
     "usr/lib/systemd/system": DIRECTORY,
     "usr/lib/systemd/system/syswarden-firewall.service.d": DIRECTORY,
     SYSTEMD_ORDERING_PATH: ExpectedEntry("file", mode=0o644, nonempty=True),
+    "usr/lib/systemd/system/syswarden-core.service.d": DIRECTORY,
+    SYSTEMD_SOCKET_PATH: ExpectedEntry("file", mode=0o644, nonempty=True),
 }
 
 def entry_kind(metadata: os.stat_result) -> str:
@@ -232,6 +238,7 @@ def validate(
     geoip_data_license_contract: ContentContract | None = None,
     project_license_contract: ContentContract | None = None,
     systemd_ordering_contract: ContentContract | None = None,
+    systemd_socket_contract: ContentContract | None = None,
 ) -> None:
     actual = inventory(root)
     actual_paths = set(actual)
@@ -299,6 +306,9 @@ def validate(
             systemd_ordering_contract,
         )
 
+    if systemd_socket_contract is not None:
+        validate_exact_content(root / SYSTEMD_SOCKET_PATH, systemd_socket_contract)
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -314,6 +324,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--systemd-ordering-contract", type=Path)
     parser.add_argument("--systemd-ordering-source", type=Path)
+    parser.add_argument("--systemd-socket-contract", type=Path)
+    parser.add_argument("--systemd-socket-source", type=Path)
     return parser
 
 
@@ -333,6 +345,7 @@ def main() -> int:
         validate_exact_content(args.project_license_source, project_license_contract)
         expected = LINUX_ENTRIES
         systemd_ordering_contract = None
+        systemd_socket_contract = None
         if args.service_manager == "systemd":
             if args.systemd_ordering_contract is None or args.systemd_ordering_source is None:
                 raise PackageStageError(
@@ -344,8 +357,15 @@ def main() -> int:
             validate_exact_content(
                 args.systemd_ordering_source, systemd_ordering_contract
             )
+            if args.systemd_socket_contract is None or args.systemd_socket_source is None:
+                raise PackageStageError("systemd staging requires a socket capability contract and source")
+            systemd_socket_contract = load_content_contract(args.systemd_socket_contract)
+            validate_exact_content(args.systemd_socket_source, systemd_socket_contract)
             expected = SYSTEMD_LINUX_ENTRIES
-        elif args.systemd_ordering_contract is not None or args.systemd_ordering_source is not None:
+        elif any(value is not None for value in (
+            args.systemd_ordering_contract, args.systemd_ordering_source,
+            args.systemd_socket_contract, args.systemd_socket_source,
+        )):
             raise PackageStageError(
                 "OpenRC staging must not carry the systemd ordering contract"
             )
@@ -356,6 +376,7 @@ def main() -> int:
             geoip_data_license_contract,
             project_license_contract,
             systemd_ordering_contract,
+            systemd_socket_contract,
         )
     except PackageStageError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/ci/package_stage_gate_test.py
+++ b/scripts/ci/package_stage_gate_test.py
@@ -74,6 +74,27 @@ class PackageStageGateTests(unittest.TestCase):
                 package_stage_gate.LINUX_ENTRIES,
             )
 
+    def test_systemd_socket_policy_requires_exact_inventory_and_content(self) -> None:
+        self.create_stage(package_stage_gate.SYSTEMD_LINUX_ENTRIES)
+        path = self.root / package_stage_gate.SYSTEMD_SOCKET_PATH
+        content = path.read_bytes()
+        contract = package_stage_gate.ContentContract(
+            sha256=hashlib.sha256(content).hexdigest(), size=len(content)
+        )
+        package_stage_gate.validate(
+            self.root, package_stage_gate.SYSTEMD_LINUX_ENTRIES,
+            systemd_socket_contract=contract,
+        )
+        path.write_bytes(content + b"changed")
+        with self.assertRaises(package_stage_gate.PackageStageError):
+            package_stage_gate.validate(
+                self.root, package_stage_gate.SYSTEMD_LINUX_ENTRIES,
+                systemd_socket_contract=contract,
+            )
+        path.unlink()
+        with self.assertRaises(package_stage_gate.PackageStageError):
+            package_stage_gate.validate(self.root, package_stage_gate.SYSTEMD_LINUX_ENTRIES)
+
     def test_systemd_inventory_rejects_missing_ordering_artifact(self) -> None:
         self.create_stage(package_stage_gate.SYSTEMD_LINUX_ENTRIES)
         (self.root / package_stage_gate.SYSTEMD_ORDERING_PATH).unlink()

--- a/scripts/ci/package_systemd_ordering_artifact_gate.py
+++ b/scripts/ci/package_systemd_ordering_artifact_gate.py
@@ -254,6 +254,7 @@ def validate_rpm(package: Path, expected: bytes, contract: ContentContract) -> N
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", choices=("ordering", "socket"), default="ordering")
     parser.add_argument("--format", choices=("stage", "deb", "rpm"), required=True)
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--contract", type=Path, required=True)
@@ -263,7 +264,21 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
+    global RELATIVE_PATH, ABSOLUTE_PATH, DIRECTORY_PATH
     args = build_parser().parse_args()
+    # Select only a fixed repository-owned policy, never a caller-supplied path.
+    if args.artifact == "socket":
+        RELATIVE_PATH = (
+            "usr/lib/systemd/system/syswarden-core.service.d/"
+            "10-syswarden-socket-ownership.conf"
+        )
+    else:
+        RELATIVE_PATH = (
+            "usr/lib/systemd/system/syswarden-firewall.service.d/"
+            "10-syswarden-wireguard-ordering.conf"
+        )
+    ABSOLUTE_PATH = "/" + RELATIVE_PATH
+    DIRECTORY_PATH = str(Path(ABSOLUTE_PATH).parent)
     try:
         contract = load_contract(args.contract)
         expected = validate_source_and_stage(
@@ -281,7 +296,7 @@ def main() -> int:
     except OrderingArtifactError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
-    print(f"Validated exact systemd ordering artifact for {args.format}.")
+    print(f"Validated exact systemd {args.artifact} artifact for {args.format}.")
     return 0
 
 

--- a/scripts/ci/package_systemd_ordering_artifact_gate_test.py
+++ b/scripts/ci/package_systemd_ordering_artifact_gate_test.py
@@ -265,6 +265,37 @@ class OrderingArtifactGateTests(unittest.TestCase):
         with self.assertRaises(gate.OrderingArtifactError):
             gate.validate_source_and_stage(source, CONTRACT)
 
+    def test_socket_policy_cli_requires_its_own_exact_payload(self) -> None:
+        repository = Path.cwd()
+        while not (repository / "scripts/ci/package_stage_gate.py").is_file():
+            if repository.parent == repository:
+                self.fail("repository root is unavailable")
+            repository = repository.parent
+        source = repository / (
+            "src/init/systemd/syswarden-core.service.d/"
+            "10-syswarden-socket-ownership.conf"
+        )
+        stage = self.root / "stage"
+        staged = stage / (
+            "usr/lib/systemd/system/syswarden-core.service.d/"
+            "10-syswarden-socket-ownership.conf"
+        )
+        staged.parent.mkdir(parents=True)
+        command = [
+            sys.executable,
+            str(repository / "scripts/ci/package_systemd_ordering_artifact_gate.py"),
+            "--artifact", "socket", "--format", "stage", "--root", str(stage),
+            "--source", str(source), "--contract",
+            str(repository / "scripts/ci/package_systemd_socket_capability_contract.json"),
+        ]
+        for payload, expected in ((CONTENT, 1), (source.read_bytes(), 0),
+                                  (source.read_bytes().replace(b"CAP_CHOWN", b"CAP_KILL"), 1)):
+            with self.subTest(expected=expected, payload=payload):
+                staged.write_bytes(payload)
+                staged.chmod(0o644)
+                result = subprocess.run(command, capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, expected, result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/package_systemd_ordering_preflight.sh
+++ b/scripts/ci/package_systemd_ordering_preflight.sh
@@ -92,3 +92,96 @@ syswarden_preflight_systemd_ordering_dropin() {
         return 1
     fi
 }
+
+syswarden_preflight_systemd_socket_dropin() {
+    [ ! -f /etc/alpine-release ] || return 0
+
+    syswarden_socket_path=/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf
+    syswarden_socket_directory=/usr/lib/systemd/system/syswarden-core.service.d
+    syswarden_socket_sha256=b1b4cc3937ea7464f6d86a40024ea7b7e8dc0dd12e4d0aa7a8b58f6dd0254186
+
+    for syswarden_socket_parent in \
+        /usr \
+        /usr/lib \
+        /usr/lib/systemd \
+        /usr/lib/systemd/system; do
+        if [ ! -d "${syswarden_socket_parent}" ] || \
+            [ -L "${syswarden_socket_parent}" ] || \
+            [ "$(stat -c '%u:%g' "${syswarden_socket_parent}" 2>/dev/null)" != 0:0 ] || \
+            [ -n "$(find "${syswarden_socket_parent}" -maxdepth 0 -perm /0022 -print -quit 2>/dev/null)" ]; then
+            printf 'Refusing unsafe systemd package parent: %s\n' \
+                "${syswarden_socket_parent}" >&2
+            return 1
+        fi
+    done
+
+    if [ -e "${syswarden_socket_directory}" ] || [ -L "${syswarden_socket_directory}" ]; then
+        if [ ! -d "${syswarden_socket_directory}" ] || \
+            [ -L "${syswarden_socket_directory}" ] || \
+            [ "$(stat -c '%u:%g' "${syswarden_socket_directory}" 2>/dev/null)" != 0:0 ] || \
+            [ -n "$(find "${syswarden_socket_directory}" -maxdepth 0 -perm /0022 -print -quit 2>/dev/null)" ]; then
+            printf 'Refusing unsafe SysWarden systemd drop-in directory: %s\n' \
+                "${syswarden_socket_directory}" >&2
+            return 1
+        fi
+        syswarden_socket_unexpected="$({
+            find "${syswarden_socket_directory}" -mindepth 1 -maxdepth 1 \
+                ! -path "${syswarden_socket_path}" -print -quit
+        } 2>/dev/null)" || return 1
+        [ -z "${syswarden_socket_unexpected}" ] || {
+            printf 'Refusing an existing unowned systemd drop-in: %s\n' \
+                "${syswarden_socket_unexpected}" >&2
+            return 1
+        }
+    fi
+
+    if [ ! -e "${syswarden_socket_path}" ] && [ ! -L "${syswarden_socket_path}" ]; then
+        return 0
+    fi
+    if [ ! -f "${syswarden_socket_path}" ] || \
+        [ -L "${syswarden_socket_path}" ] || \
+        [ "$(stat -c '%u:%g:%a:%h:%s' "${syswarden_socket_path}" 2>/dev/null)" != 0:0:644:1:110 ]; then
+        printf 'Refusing unsafe existing SysWarden systemd socket capability drop-in.\n' >&2
+        return 1
+    fi
+    syswarden_socket_identity_before="$(
+        stat -c '%d:%i:%f:%u:%g:%h:%s:%Y:%Z' "${syswarden_socket_path}"
+    )" || return 1
+    [ "$(sha256sum "${syswarden_socket_path}" | awk '{ print $1 }')" = \
+        "${syswarden_socket_sha256}" ] || {
+        printf 'Refusing modified existing SysWarden systemd socket capability drop-in.\n' >&2
+        return 1
+    }
+
+    syswarden_socket_authorities=0
+    if command -v dpkg-query >/dev/null 2>&1; then
+        syswarden_socket_dpkg_files="$(dpkg-query --listfiles syswarden 2>/dev/null)" || \
+            syswarden_socket_dpkg_files=
+        if [ -n "${syswarden_socket_dpkg_files}" ] && \
+            [ "$(printf '%s\n' "${syswarden_socket_dpkg_files}" | \
+                awk -v path="${syswarden_socket_path}" '$0 == path { count++ } END { print count + 0 }')" -eq 1 ]; then
+            syswarden_socket_authorities=$((syswarden_socket_authorities + 1))
+        fi
+    fi
+    if command -v rpm >/dev/null 2>&1; then
+        syswarden_socket_rpm_owner="$(
+            rpm --query --file "${syswarden_socket_path}" \
+                --queryformat '%{NAME}\n' 2>/dev/null
+        )" || syswarden_socket_rpm_owner=
+        if [ "${syswarden_socket_rpm_owner}" = syswarden ]; then
+            syswarden_socket_authorities=$((syswarden_socket_authorities + 1))
+        fi
+    fi
+    [ "${syswarden_socket_authorities}" -eq 1 ] || {
+        printf 'Refusing an existing SysWarden systemd socket capability drop-in without one exact package owner.\n' >&2
+        return 1
+    }
+
+    if [ "$(stat -c '%d:%i:%f:%u:%g:%h:%s:%Y:%Z' "${syswarden_socket_path}" 2>/dev/null)" != \
+        "${syswarden_socket_identity_before}" ] || \
+        [ "$(sha256sum "${syswarden_socket_path}" | awk '{ print $1 }')" != \
+            "${syswarden_socket_sha256}" ]; then
+        printf 'SysWarden systemd socket capability drop-in changed during package preflight.\n' >&2
+        return 1
+    fi
+}

--- a/scripts/ci/package_systemd_ordering_preflight_test.py
+++ b/scripts/ci/package_systemd_ordering_preflight_test.py
@@ -18,6 +18,12 @@ CONTENT = b"[Unit]\nAfter=wg-quick@wg-syswarden.service\n"
 
 
 class SystemdOrderingPreflightTests(unittest.TestCase):
+    artifact_content = CONTENT
+    artifact_relative = "syswarden-firewall.service.d/10-syswarden-wireguard-ordering.conf"
+    helper_name = "syswarden_preflight_systemd_ordering_dropin"
+    hash_variable = "syswarden_ordering_sha256"
+    contract_file = "package_systemd_wireguard_ordering_contract.json"
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
@@ -26,26 +32,23 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
         self.root.joinpath("usr/lib/systemd/system").mkdir(parents=True)
         self.root.joinpath("etc").mkdir()
         self.fake_bin.mkdir()
-        self.path = self.root / (
-            "usr/lib/systemd/system/syswarden-firewall.service.d/"
-            "10-syswarden-wireguard-ordering.conf"
-        )
+        self.path = self.root / "usr/lib/systemd/system" / self.artifact_relative
         self.directory = self.path.parent
         self._write_package_query_fixtures()
         self.harness = Path(self.temporary.name) / "preflight-harness.sh"
         self.harness.write_text(
             "#!/bin/sh\nset -eu\n"
             + self._isolated_function()
-            + "\nsyswarden_preflight_systemd_ordering_dropin\n",
+            + "\n" + self.helper_name + "\n",
             encoding="ascii",
         )
         self.harness.chmod(0o700)
 
     def _isolated_function(self) -> str:
         source = SCRIPT.read_text(encoding="ascii")
-        marker = "syswarden_preflight_systemd_ordering_dropin() {"
+        marker = self.helper_name + "() {"
         self.assertEqual(source.count(marker), 1)
-        function = source[source.index(marker) :]
+        function = source[source.index(marker) :].split("\n}\n", 1)[0] + "\n}\n"
         self.assertEqual(function.count("/etc/alpine-release"), 1)
         self.assertEqual(function.count("/usr"), 6)
         self.assertEqual(function.count("= 0:0"), 3)
@@ -85,7 +88,9 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
         )
         rpm.chmod(0o700)
 
-    def _write_exact_artifact(self, content: bytes = CONTENT) -> None:
+    def _write_exact_artifact(self, content: bytes | None = None) -> None:
+        if content is None:
+            content = self.artifact_content
         self.directory.mkdir(mode=0o755)
         self.path.write_bytes(content)
         self.path.chmod(0o644)
@@ -119,27 +124,24 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
 
     def test_helper_contract_matches_repository_source_and_json(self) -> None:
         repository_root = Path(__file__).resolve().parents[2]
-        source = repository_root / (
-            "src/init/systemd/syswarden-firewall.service.d/"
-            "10-syswarden-wireguard-ordering.conf"
-        )
+        source = repository_root / "src/init/systemd" / self.artifact_relative
         contract = json.loads(
             (
                 repository_root
-                / "scripts/ci/package_systemd_wireguard_ordering_contract.json"
+                / "scripts/ci" / self.contract_file
             ).read_bytes()
         )
         helper = SCRIPT.read_text(encoding="ascii")
 
-        self.assertEqual(source.read_bytes(), CONTENT)
+        self.assertEqual(source.read_bytes(), self.artifact_content)
         self.assertEqual(
             contract,
             {
-                "sha256": hashlib.sha256(CONTENT).hexdigest(),
-                "size": len(CONTENT),
+                "sha256": hashlib.sha256(self.artifact_content).hexdigest(),
+                "size": len(self.artifact_content),
             },
         )
-        self.assertIn(f"syswarden_ordering_sha256={contract['sha256']}", helper)
+        self.assertIn(f"{self.hash_variable}={contract['sha256']}", helper)
         self.assertIn(f"0:0:644:1:{contract['size']}", helper)
 
     def test_exact_dpkg_owned_artifact_is_accepted(self) -> None:
@@ -153,7 +155,7 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_tampered_artifact_is_rejected(self) -> None:
-        self._write_exact_artifact(CONTENT.replace(b"After", b"Bfter"))
+        self._write_exact_artifact(self.artifact_content.replace(b"=", b":", 1))
         result = self._run(dpkg_owner=True)
         self.assertNotEqual(result.returncode, 0, result)
         self.assertIn("modified existing", result.stderr)
@@ -170,7 +172,7 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
     def test_symlinked_artifact_is_rejected(self) -> None:
         self.directory.mkdir(mode=0o755)
         target = Path(self.temporary.name) / "outside.conf"
-        target.write_bytes(CONTENT)
+        target.write_bytes(self.artifact_content)
         target.chmod(0o644)
         self.path.symlink_to(target)
         result = self._run(dpkg_owner=True)
@@ -221,6 +223,18 @@ class SystemdOrderingPreflightTests(unittest.TestCase):
         result = self._run(dpkg_owner=True, rpm_owner=True)
         self.assertNotEqual(result.returncode, 0, result)
         self.assertIn("without one exact package owner", result.stderr)
+
+
+class SystemdSocketPreflightTests(SystemdOrderingPreflightTests):
+    artifact_content = (
+        b"[Service]\n"
+        b"# Assign the socket to the verified private rsyslog producer group.\n"
+        b"CapabilityBoundingSet=CAP_CHOWN\n"
+    )
+    artifact_relative = "syswarden-core.service.d/10-syswarden-socket-ownership.conf"
+    helper_name = "syswarden_preflight_systemd_socket_dropin"
+    hash_variable = "syswarden_socket_sha256"
+    contract_file = "package_systemd_socket_capability_contract.json"
 
 
 if __name__ == "__main__":

--- a/scripts/ci/package_systemd_socket_capability_contract.json
+++ b/scripts/ci/package_systemd_socket_capability_contract.json
@@ -1,0 +1,4 @@
+{
+  "sha256": "b1b4cc3937ea7464f6d86a40024ea7b7e8dc0dd12e4d0aa7a8b58f6dd0254186",
+  "size": 110
+}

--- a/src/core/syswarden-cli/pkg/system/removal_service_artifacts_linux.go
+++ b/src/core/syswarden-cli/pkg/system/removal_service_artifacts_linux.go
@@ -45,13 +45,17 @@ type preparedSystemdServiceArtifactHost struct {
 	afterFirstCapture func()
 }
 
-func productionPreparedSystemdServiceArtifactHost() preparedSystemdServiceArtifactHost {
+func productionPreparedSystemdServiceArtifactHost() (preparedSystemdServiceArtifactHost, error) {
+	content, err := selectedSystemdCoreServiceContent(hostFirewallExecutor())
+	if err != nil {
+		return preparedSystemdServiceArtifactHost{}, err
+	}
 	corePath := filepath.Join(serviceSystemdUnitDir, "syswarden-core.service")
 	firewallPath := filepath.Join(serviceSystemdUnitDir, "syswarden-firewall.service")
 	return preparedSystemdServiceArtifactHost{
 		artifacts: []preparedSystemdServiceArtifact{
 			{
-				path: corePath, content: systemdCoreService, mode: sourceSystemdUnitMode,
+				path: corePath, content: content, mode: sourceSystemdUnitMode,
 				allowedModes: []os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode},
 			},
 			{
@@ -76,6 +80,10 @@ func productionPreparedSystemdServiceArtifactHost() preparedSystemdServiceArtifa
 				path: systemdFirewallWireGuardOrderingDropInPath, content: systemdFirewallWireGuardOrderingDropIn,
 				mode: 0644, packageDropIn: true, optionalParent: true,
 			},
+			{
+				path: systemdCoreSocketCapabilityDropInPath, content: systemdCoreSocketCapabilityDropIn,
+				mode: 0644, packageDropIn: true, optionalParent: true,
+			},
 		},
 		trustedRoot:     "/",
 		expectedUID:     0,
@@ -84,9 +92,12 @@ func productionPreparedSystemdServiceArtifactHost() preparedSystemdServiceArtifa
 		executor:        hostFirewallExecutor(),
 		processScan:     scanExactRootSysWardenCLIMutators,
 		attestPackageDrop: func(executor firewallManagerExecutor, path string) (string, error) {
+			if path == systemdCoreSocketCapabilityDropInPath {
+				return attestExactSystemdCoreSocketCapabilityDropIn(executor, path)
+			}
 			return attestExactSystemdFirewallOrderingDropIn(executor, path)
 		},
-	}
+	}, nil
 }
 
 func preparedSystemdServiceArtifactModes(artifact preparedSystemdServiceArtifact) []os.FileMode {
@@ -126,7 +137,7 @@ func inspectSingleLinkExactServiceFileModes(
 }
 
 func (host preparedSystemdServiceArtifactHost) validate() error {
-	if len(host.artifacts) != 5 || host.classifyRuntime == nil || host.processScan == nil ||
+	if len(host.artifacts) != 6 || host.classifyRuntime == nil || host.processScan == nil ||
 		host.attestPackageDrop == nil || host.executor.lookPath == nil || host.executor.validate == nil ||
 		host.executor.output == nil || host.trustedRoot == "" || !filepath.IsAbs(host.trustedRoot) ||
 		filepath.Clean(host.trustedRoot) != host.trustedRoot {
@@ -165,8 +176,8 @@ func (host preparedSystemdServiceArtifactHost) validate() error {
 			return fmt.Errorf("systemd enablement recovery contract is incomplete for %s", artifact.path)
 		}
 	}
-	if packageDropIns != 1 {
-		return fmt.Errorf("systemd service artifact recovery requires one package drop-in")
+	if packageDropIns != 2 {
+		return fmt.Errorf("systemd service artifact recovery requires two package drop-ins")
 	}
 	return nil
 }
@@ -583,7 +594,11 @@ func RemovePreparedServiceArtifactsForRemoval() error {
 			return fmt.Errorf("service artifact removal requires prepared firewall mutators: %w", err)
 		}
 		initialErr := err
-		if recoveryErr := productionPreparedSystemdServiceArtifactHost().recoverInterruptedRemoval(); recoveryErr != nil {
+		host, recoveryErr := productionPreparedSystemdServiceArtifactHost()
+		if recoveryErr == nil {
+			recoveryErr = host.recoverInterruptedRemoval()
+		}
+		if recoveryErr != nil {
 			return errors.Join(
 				fmt.Errorf("service artifact removal requires prepared firewall mutators: %w", initialErr),
 				fmt.Errorf("recover interrupted systemd service artifact removal: %w", recoveryErr),
@@ -625,7 +640,11 @@ func RemovePreparedServiceArtifactsForRemoval() error {
 			)
 		}
 	} else {
-		host := productionPreparedSystemdServiceArtifactHost()
+		host, err := productionPreparedSystemdServiceArtifactHost()
+		if err != nil {
+			return err
+		}
+		coreContent := host.artifacts[0].content
 		managerState, err := host.classifyRuntime(false)
 		if err != nil {
 			return fmt.Errorf("classify systemd runtime before exact service removal: %w", err)
@@ -646,7 +665,7 @@ func RemovePreparedServiceArtifactsForRemoval() error {
 		}
 		if err := removePreparedServiceEnablementModes(
 			"/etc/systemd/system/multi-user.target.wants/syswarden-core.service",
-			"/etc/systemd/system/syswarden-core.service", systemdCoreService,
+			"/etc/systemd/system/syswarden-core.service", coreContent,
 			[]os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode},
 			"../syswarden-core.service", "/etc/systemd/system/syswarden-core.service",
 		); err != nil {
@@ -661,7 +680,7 @@ func RemovePreparedServiceArtifactsForRemoval() error {
 			return err
 		}
 		if err := removePreparedExactServiceFileModes(
-			"/etc/systemd/system/syswarden-core.service", systemdCoreService,
+			"/etc/systemd/system/syswarden-core.service", coreContent,
 			[]os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode},
 		); err != nil {
 			return err
@@ -676,6 +695,11 @@ func RemovePreparedServiceArtifactsForRemoval() error {
 			systemdFirewallWireGuardOrderingDropInPath,
 			systemdFirewallWireGuardOrderingDropIn,
 			0644,
+		); err != nil {
+			return err
+		}
+		if err := removePreparedExactServiceFile(
+			systemdCoreSocketCapabilityDropInPath, systemdCoreSocketCapabilityDropIn, 0644,
 		); err != nil {
 			return err
 		}

--- a/src/core/syswarden-cli/pkg/system/removal_service_artifacts_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/removal_service_artifacts_linux_test.go
@@ -17,6 +17,7 @@ type preparedSystemdServiceArtifactTestPaths struct {
 	coreEnablement string
 	firewallEnable string
 	dropIn         string
+	socketDropIn   string
 }
 
 func containsEveryRemovalTestValue(value string, expected ...string) bool {
@@ -43,7 +44,8 @@ func newPreparedSystemdServiceArtifactTestHostWithUnitMode(
 	unitDirectory := filepath.Join(root, "etc", "systemd", "system")
 	wantsDirectory := filepath.Join(unitDirectory, "multi-user.target.wants")
 	dropInDirectory := filepath.Join(root, "usr", "lib", "systemd", "system", "syswarden-firewall.service.d")
-	for _, directory := range []string{unitDirectory, wantsDirectory, dropInDirectory} {
+	socketDirectory := filepath.Join(root, "usr", "lib", "systemd", "system", "syswarden-core.service.d")
+	for _, directory := range []string{unitDirectory, wantsDirectory, dropInDirectory, socketDirectory} {
 		if err := os.MkdirAll(directory, 0755); err != nil { // #nosec G301 -- private fixture models trusted service directories
 			t.Fatal(err)
 		}
@@ -54,6 +56,7 @@ func newPreparedSystemdServiceArtifactTestHostWithUnitMode(
 		coreEnablement: filepath.Join(wantsDirectory, "syswarden-core.service"),
 		firewallEnable: filepath.Join(wantsDirectory, "syswarden-firewall.service"),
 		dropIn:         filepath.Join(dropInDirectory, "10-syswarden-wireguard-ordering.conf"),
+		socketDropIn:   filepath.Join(socketDirectory, "10-syswarden-socket-ownership.conf"),
 	}
 	for _, fixture := range []struct {
 		path    string
@@ -63,6 +66,7 @@ func newPreparedSystemdServiceArtifactTestHostWithUnitMode(
 		{paths.coreUnit, systemdCoreService, unitMode},
 		{paths.firewallUnit, systemdFirewallService, unitMode},
 		{paths.dropIn, systemdFirewallWireGuardOrderingDropIn, 0644},
+		{paths.socketDropIn, systemdCoreSocketCapabilityDropIn, 0644},
 	} {
 		if err := os.WriteFile(fixture.path, []byte(fixture.content), fixture.mode); err != nil {
 			t.Fatal(err)
@@ -105,6 +109,10 @@ func newPreparedSystemdServiceArtifactTestHostWithUnitMode(
 				path: paths.dropIn, content: systemdFirewallWireGuardOrderingDropIn,
 				mode: 0644, packageDropIn: true, optionalParent: true,
 			},
+			{
+				path: paths.socketDropIn, content: systemdCoreSocketCapabilityDropIn,
+				mode: 0644, packageDropIn: true, optionalParent: true,
+			},
 		},
 		trustedRoot: root,
 		expectedUID: systemTestUID(t),
@@ -135,7 +143,7 @@ func newPreparedSystemdServiceArtifactTestHostWithUnitMode(
 		},
 		processScan: func() error { return nil },
 		attestPackageDrop: func(_ firewallManagerExecutor, path string) (string, error) {
-			if path != paths.dropIn {
+			if path != paths.dropIn && path != paths.socketDropIn {
 				return "", fmt.Errorf("unexpected package drop-in path %s", path)
 			}
 			return "syswarden@4.04.3#test", nil

--- a/src/core/syswarden-cli/pkg/system/service_linux.go
+++ b/src/core/syswarden-cli/pkg/system/service_linux.go
@@ -2061,15 +2061,30 @@ func publishOpenRCServices() error {
 }
 
 func publishSystemdServices() error {
+	content, err := selectedSystemdCoreServiceContent(hostFirewallExecutor())
+	if err != nil {
+		return err
+	}
+	return publishSystemdServicesWithCore(content)
+}
+
+func publishSystemdServicesWithCore(content string) error {
+	if content != systemdCoreService && content != historicalV4043SystemdCoreService {
+		return fmt.Errorf("refusing unknown core service publication content")
+	}
 	coreUnitPath := filepath.Join(serviceSystemdUnitDir, "syswarden-core.service")
 	firewallUnitPath := filepath.Join(serviceSystemdUnitDir, "syswarden-firewall.service")
 	return publishServiceArtifacts([]serviceArtifact{
 		{
-			path: coreUnitPath, content: systemdCoreService, mode: sourceSystemdUnitMode,
+			path: coreUnitPath, content: content, mode: sourceSystemdUnitMode,
 			historicalContent:       historicalV4028SystemdCoreService,
 			historicalContentLength: historicalV4028SystemdCoreServiceLength,
 			historicalContentSHA256: historicalV4028SystemdCoreServiceSHA256,
 			historicalAlternates: []historicalServiceContent{{
+				content:       systemdCoreService,
+				contentLength: len(systemdCoreService),
+				contentSHA256: "cfc30f12ea66548dce4322d2cde38a62cbc257d93be3e82218434a848051dbd7",
+			}, {
 				content:       historicalV4043SystemdCoreService,
 				contentLength: historicalV4043SystemdCoreServiceLength,
 				contentSHA256: historicalV4043SystemdCoreServiceSHA256,
@@ -2086,7 +2101,7 @@ func publishSystemdServices() error {
 		{
 			path: filepath.Join(serviceSystemdWantsDir, "syswarden-core.service"), target: "../syswarden-core.service",
 			legacyTargets:    []string{"/etc/systemd/system/syswarden-core.service"},
-			attestedFilePath: coreUnitPath, attestedFileContent: systemdCoreService,
+			attestedFilePath: coreUnitPath, attestedFileContent: content,
 			attestedFileMode: sourceSystemdUnitMode,
 		},
 		{
@@ -2099,6 +2114,9 @@ func publishSystemdServices() error {
 }
 
 func attestSystemdFirewallOrderingBeforeActivation() error {
+	if err := attestSystemdSocketCapabilityBeforeActivation(); err != nil {
+		return err
+	}
 	_, err := os.Lstat(systemdFirewallWireGuardOrderingDropInPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return attestAbsentSystemdFirewallOrderingDropIn(

--- a/src/core/syswarden-cli/pkg/system/systemd_socket_capability_linux.go
+++ b/src/core/syswarden-cli/pkg/system/systemd_socket_capability_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package system
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+const (
+	systemdCoreSocketCapabilityDropInPath = "/usr/lib/systemd/system/syswarden-core.service.d/10-syswarden-socket-ownership.conf"
+	systemdCoreSocketCapabilityDropIn     = `[Service]
+# Assign the socket to the verified private rsyslog producer group.
+CapabilityBoundingSet=CAP_CHOWN
+`
+)
+
+func attestExactSystemdCoreSocketCapabilityDropIn(executor firewallManagerExecutor, path string) (string, error) {
+	return attestExactSystemdPackageDropInAt(
+		executor, path, systemdCoreSocketCapabilityDropInPath, "/", 0, 0,
+		systemdCoreSocketCapabilityDropIn, "socket capability",
+	)
+}
+
+// Native packages own the capability addition separately so downgrading also
+// removes it. The generated base unit remains byte-compatible with v4.04.3.
+// Source installations retain the self-contained socket-capable unit.
+func selectedSystemdCoreServiceContent(executor firewallManagerExecutor) (string, error) {
+	return selectSystemdCoreServiceContentAt(executor, systemdCoreSocketCapabilityDropInPath, "/", 0, 0)
+}
+
+func selectSystemdCoreServiceContentAt(executor firewallManagerExecutor, path, trustedRoot string, uid, gid uint32) (string, error) {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return systemdCoreService, nil
+	} else if err != nil {
+		return "", fmt.Errorf("inspect systemd socket capability policy: %w", err)
+	}
+	if _, err := attestExactSystemdPackageDropInAt(
+		executor, path, path, trustedRoot, uid, gid,
+		systemdCoreSocketCapabilityDropIn, "socket capability",
+	); err != nil {
+		return "", err
+	}
+	return historicalV4043SystemdCoreService, nil
+}
+
+func attestSystemdSocketCapabilityBeforeActivation() error {
+	content, err := selectedSystemdCoreServiceContent(hostFirewallExecutor())
+	if err != nil {
+		return err
+	}
+	if content == systemdCoreService {
+		// The separately attested RHEL package-owned profile uses its existing
+		// vendor unit, which already includes the socket ownership capability.
+		if present, err := attestInstalledRHELPackageOwnedProfile(); err != nil {
+			return err
+		} else if present {
+			return nil
+		}
+		// Missing policy is acceptable only for an independently attested source
+		// installation. Native packages must not silently change unit layout.
+		if err := attestAbsentSystemdFirewallOrderingDropIn(
+			hostFirewallExecutor(), systemdCoreSocketCapabilityDropInPath,
+			servicePackageEnvironment("SYSWARDEN_PKG_INSTALL") == "1",
+		); err != nil {
+			return fmt.Errorf("socket capability policy is required for native packages: %w", err)
+		}
+	}
+	return nil
+}

--- a/src/core/syswarden-cli/pkg/system/systemd_socket_capability_linux_test.go
+++ b/src/core/syswarden-cli/pkg/system/systemd_socket_capability_linux_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package system
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNativeSocketPolicyPreservesLegacyUnitAndEffectiveCapabilities(t *testing.T) {
+	packaged := mustReadTestFile(t, filepath.Join("..", "..", "..", "..", "init", "systemd", "syswarden-core.service.d", "10-syswarden-socket-ownership.conf"))
+	if string(packaged) != systemdCoreSocketCapabilityDropIn {
+		t.Fatal("compiled socket policy differs from the package payload")
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256([]byte(historicalV4043SystemdCoreService))); got != "8d84f0eeb3bf912055eadee1173b5b354b7e03f9bef34ab43546b06458e980bd" {
+		t.Fatal("native base unit no longer matches the immutable v4.04.3 unit")
+	}
+	capabilities := func(text string) string {
+		var values []string
+		for _, line := range strings.Split(text, "\n") {
+			if value, ok := strings.CutPrefix(line, "CapabilityBoundingSet="); ok {
+				values = append(values, value)
+			}
+		}
+		return strings.Join(values, " ")
+	}
+	// systemd merges these positive directives by union, with no reset or
+	// ambient capability added by the package policy.
+	if capabilities(historicalV4043SystemdCoreService+systemdCoreSocketCapabilityDropIn) != capabilities(systemdCoreService) {
+		t.Fatal("native compatibility layout changes the effective capability set")
+	}
+}
+
+func TestNativeCorePublicationSupportsRollbackWithoutAcceptingModifiedUnits(t *testing.T) {
+	for _, previous := range []string{historicalV4043SystemdCoreService, systemdCoreService} {
+		for _, mode := range []os.FileMode{0600, 0644} {
+			for _, modified := range []bool{false, true} {
+				t.Run(fmt.Sprintf("size-%d-mode-%04o-modified-%t", len(previous), mode, modified), func(t *testing.T) {
+					directory, wants := withSystemdPublicationTestPaths(t)
+					core := filepath.Join(directory, "syswarden-core.service")
+					input := previous
+					if modified {
+						input += "# Operator customization\n"
+					}
+					mustWriteFile(t, core, input)
+					mustChmodTestPath(t, core, mode)
+					mustWriteFile(t, filepath.Join(directory, "syswarden-firewall.service"), systemdFirewallService)
+					mustMkdirAll(t, wants)
+					err := publishSystemdServicesWithCore(historicalV4043SystemdCoreService)
+					if modified {
+						if err == nil || string(mustReadTestFile(t, core)) != input {
+							t.Fatalf("modified unit was not refused and preserved: %v", err)
+						}
+					} else if err != nil {
+						t.Fatal(err)
+					} else if string(mustReadTestFile(t, core)) != historicalV4043SystemdCoreService {
+						t.Fatal("native unit is not byte-compatible with the legacy installer")
+					}
+					assertNoServiceMigrationArtifacts(t, directory)
+				})
+			}
+		}
+	}
+}
+
+func TestCoreSocketPolicySelectionRequiresExactStablePackageOwnership(t *testing.T) {
+	for _, scenario := range []string{"dpkg", "rpm", "absent", "modified", "mode", "symlink", "hardlink", "unowned", "dual-owner", "owner-drift", "file-drift"} {
+		t.Run(scenario, func(t *testing.T) {
+			root, path, uid, gid := testSysWardenSystemdOrderingFixture(t)
+			mustWriteFile(t, path, systemdCoreSocketCapabilityDropIn)
+			mustChmodTestPath(t, path, 0644)
+			calls := 0
+			executor := testSysWardenOrderingPackageExecutor(t, path,
+				scenario != "rpm" && scenario != "unowned",
+				scenario == "rpm" || scenario == "dual-owner",
+				func(manager string) string {
+					calls++
+					if scenario == "owner-drift" && calls > 1 {
+						return "4.04.3"
+					}
+					if scenario == "file-drift" {
+						mustWriteFile(t, path, systemdCoreSocketCapabilityDropIn+"# changed\n")
+					}
+					if manager == "rpm" {
+						return "4.10.0-1"
+					}
+					return "4.10.0"
+				})
+			switch scenario {
+			case "absent", "symlink":
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if scenario == "symlink" {
+					if err := os.Symlink("missing", path); err != nil {
+						t.Fatal(err)
+					}
+				}
+			case "modified":
+				mustWriteFile(t, path, strings.ReplaceAll(systemdCoreSocketCapabilityDropIn, "CAP_CHOWN", "CAP_KILL"))
+			case "mode":
+				mustChmodTestPath(t, path, 0600)
+			case "hardlink":
+				if err := os.Link(path, filepath.Join(root, "alias")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			content, err := selectSystemdCoreServiceContentAt(executor, path, root, uid, gid)
+			switch scenario {
+			case "dpkg", "rpm":
+				if err != nil || content != historicalV4043SystemdCoreService {
+					t.Fatalf("authenticated native policy was not selected: %v", err)
+				}
+			case "absent":
+				if err != nil || content != systemdCoreService || calls != 0 {
+					t.Fatalf("absent policy did not retain the self-contained source unit: %v", err)
+				}
+			default:
+				if err == nil || content != "" {
+					t.Fatal("untrusted native policy selected a legacy base unit")
+				}
+			}
+		})
+	}
+}

--- a/src/core/syswarden-cli/pkg/system/systemd_vendor_dropin_linux.go
+++ b/src/core/syswarden-cli/pkg/system/systemd_vendor_dropin_linux.go
@@ -363,6 +363,12 @@ func attestApprovedSystemdServiceDropIns(
 				return "", err
 			}
 			evidence = append(evidence, item)
+		case systemdCoreSocketCapabilityDropInPath:
+			item, err := attestExactSystemdCoreSocketCapabilityDropIn(executor, path)
+			if err != nil {
+				return "", err
+			}
+			evidence = append(evidence, item)
 		case systemdFirewallWireGuardOrderingDropInPath:
 			item, err := attestExactSystemdFirewallOrderingDropIn(executor, path)
 			if err != nil {
@@ -399,20 +405,32 @@ func attestExactSystemdFirewallOrderingDropInAt(
 	expectedUID uint32,
 	expectedGID uint32,
 ) (string, error) {
+	return attestExactSystemdPackageDropInAt(
+		executor, path, expectedPath, trustedRoot, expectedUID, expectedGID,
+		systemdFirewallWireGuardOrderingDropIn, "ordering",
+	)
+}
+
+func attestExactSystemdPackageDropInAt(
+	executor firewallManagerExecutor,
+	path, expectedPath, trustedRoot string,
+	expectedUID, expectedGID uint32,
+	expectedContent, description string,
+) (string, error) {
 	if path != expectedPath {
-		return "", fmt.Errorf("refusing unexpected SysWarden systemd ordering drop-in %s", path)
+		return "", fmt.Errorf("refusing unexpected SysWarden systemd %s drop-in %s", description, path)
 	}
 	if err := attestApprovedSystemdServiceDropInParents(
 		path, trustedRoot, expectedUID, expectedGID,
 	); err != nil {
-		return "", fmt.Errorf("attest SysWarden systemd ordering drop-in parents: %w", err)
+		return "", fmt.Errorf("attest SysWarden systemd %s drop-in parents: %w", description, err)
 	}
 	first, err := readFirewallRemovalFileWithOwner(path, 0644, expectedUID, expectedGID)
 	if err != nil {
-		return "", fmt.Errorf("attest SysWarden systemd ordering drop-in: %w", err)
+		return "", fmt.Errorf("attest SysWarden systemd %s drop-in: %w", description, err)
 	}
-	if string(first.content) != systemdFirewallWireGuardOrderingDropIn {
-		return "", fmt.Errorf("refusing modified SysWarden systemd ordering drop-in %s", path)
+	if string(first.content) != expectedContent {
+		return "", fmt.Errorf("refusing modified SysWarden systemd %s drop-in %s", description, path)
 	}
 	firstPackageEvidence, err := attestSysWardenSystemdDropInPackageOwnership(executor, path)
 	if err != nil {
@@ -421,16 +439,16 @@ func attestExactSystemdFirewallOrderingDropInAt(
 	second, err := readFirewallRemovalFileWithOwner(path, 0644, expectedUID, expectedGID)
 	if err != nil || !sameFirewallRemovalFileIdentity(first.identity, second.identity) ||
 		!bytes.Equal(first.content, second.content) {
-		return "", fmt.Errorf("SysWarden systemd ordering drop-in changed during attestation")
+		return "", fmt.Errorf("SysWarden systemd %s drop-in changed during attestation", description)
 	}
 	secondPackageEvidence, err := attestSysWardenSystemdDropInPackageOwnership(executor, path)
 	if err != nil || secondPackageEvidence != firstPackageEvidence {
-		return "", fmt.Errorf("SysWarden systemd ordering drop-in package ownership changed during attestation")
+		return "", fmt.Errorf("SysWarden systemd %s drop-in package ownership changed during attestation", description)
 	}
 	if err := attestApprovedSystemdServiceDropInParents(
 		path, trustedRoot, expectedUID, expectedGID,
 	); err != nil {
-		return "", fmt.Errorf("SysWarden systemd ordering drop-in parent chain changed: %w", err)
+		return "", fmt.Errorf("SysWarden systemd %s drop-in parent chain changed: %w", description, err)
 	}
 	digest := sha256.Sum256(first.content)
 	return path + "#" + fmt.Sprintf("%x", digest) + "#" + firstPackageEvidence, nil

--- a/src/core/syswarden-cli/pkg/system/uninstall_linux.go
+++ b/src/core/syswarden-cli/pkg/system/uninstall_linux.go
@@ -936,7 +936,11 @@ func PrepareFirewallStateForRemoval() error {
 		}
 	}
 	if !IsAlpine() && !rhelPackageOwned {
-		if err := productionPreparedSystemdServiceArtifactHost().recoverInterruptedRemoval(); err != nil {
+		host, err := productionPreparedSystemdServiceArtifactHost()
+		if err != nil {
+			return fmt.Errorf("attest systemd socket capability before service recovery: %w", err)
+		}
+		if err := host.recoverInterruptedRemoval(); err != nil {
 			return fmt.Errorf("recover interrupted systemd service artifact removal: %w", err)
 		}
 	}

--- a/src/core/syswarden-cli/pkg/system/uninstall_service_attestation_linux.go
+++ b/src/core/syswarden-cli/pkg/system/uninstall_service_attestation_linux.go
@@ -750,8 +750,12 @@ func attestPackageOwnedSystemdWireGuardUnit(executor firewallManagerExecutor, pa
 func attestSystemdFirewallRemovalUnitFileWith(executor firewallManagerExecutor, path string) error {
 	switch path {
 	case "/etc/systemd/system/syswarden-core.service":
+		content, err := selectedSystemdCoreServiceContent(executor)
+		if err != nil {
+			return err
+		}
 		return readExactFirewallRemovalFileWithOwnerModes(
-			path, systemdCoreService,
+			path, content,
 			[]os.FileMode{sourceSystemdUnitMode, historicalSourceSystemdUnitMode}, 0, 0,
 		)
 	case "/etc/systemd/system/syswarden-firewall.service":

--- a/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf
+++ b/src/init/systemd/syswarden-core.service.d/10-syswarden-socket-ownership.conf
@@ -1,0 +1,3 @@
+[Service]
+# Assign the socket to the verified private rsyslog producer group.
+CapabilityBoundingSet=CAP_CHOWN


### PR DESCRIPTION
Downgrading a standard native v4.10.0 package to v4.04.3 failed because the older installer rejected the changed core systemd unit. Keep the generated base unit byte-compatible with v4.04.3 and ship the private socket ownership capability in an exact package-owned drop-in. Installation, removal and recovery attest its content, metadata and stable package ownership. Native package downgrade removes that policy with the newer payload.

The effective capability set and private socket protections are preserved. Source installations and the RHEL package-owned profile retain their existing self-contained units. The version remains v4.10.0 and the changelog is unchanged.

Validation: 49 local pre-push checks and the pinned RPM lifecycle harness passed. Coverage includes 1,124 Python tests (3 expected skips), Go test/race/vet, Go 1.27 functional checks, security scans, 50 CLI compatibility cases and all four native package builds. ShellCheck retains 39 unchanged informational diagnostics and no new diagnostics. Native qualification with fresh signed packages and public release remain pending.
