### PR TITLE
Fix : preserve native HA expiry lifecycle for v4.10.0

### DIFF
--- a/src/core/syswarden-core/network/ha_api.go
+++ b/src/core/syswarden-core/network/ha_api.go
@@ -1938,6 +1938,10 @@ func boundedHARemainingTTL(latest, now time.Time) time.Duration {
 }
 
 func (api *haAPI) reconcileDesiredHABanAfterRemoval(ip string, now time.Time) (bool, error) {
+	return api.reconcileDesiredHABanAfterTransition(ip, now, false)
+}
+
+func (api *haAPI) reconcileDesiredHABanAfterTransition(ip string, now time.Time, allowNativeExpiry bool) (bool, error) {
 	canonical, err := canonicalHAStoredEntry(ip)
 	if err != nil {
 		return false, err
@@ -1949,6 +1953,20 @@ func (api *haAPI) reconcileDesiredHABanAfterRemoval(ip string, now time.Time) (b
 	if !desired {
 		if api.fwManager == nil {
 			return false, fmt.Errorf("firewall unavailable")
+		}
+		if allowNativeExpiry {
+			mode, err := api.temporaryBanMode()
+			if err != nil {
+				return false, err
+			}
+			if mode == firewall.BanExpiryNative {
+				// The ledger deadline is rounded to seconds. Let the witnessed
+				// kernel timeout complete instead of recording an operator delete,
+				// or removing a stronger native ban retained during HA admission.
+				if _, targetErr := api.canonicalHAFirewallTarget(canonical); targetErr == nil {
+					return false, nil
+				}
+			}
 		}
 		return false, api.fwManager.Unban(canonical)
 	}
@@ -2402,6 +2420,7 @@ func (api *haAPI) reconcileHABansLocked(now time.Time, limit int) error {
 	allIPs := make([]string, 0)
 	seen := make(map[string]struct{})
 	needsTransition := make(map[string]bool)
+	pendingDeletion := make(map[string]bool)
 	for _, record := range ledger.Bans {
 		expires, err := parseCanonicalHATime(record.ExpiresAt)
 		if err != nil {
@@ -2409,6 +2428,9 @@ func (api *haAPI) reconcileHABansLocked(now time.Time, limit int) error {
 		}
 		if record.State != haBanActive || !expires.After(now) {
 			needsTransition[record.IP] = true
+		}
+		if record.State == haBanPendingDelete {
+			pendingDeletion[record.IP] = true
 		}
 		if _, duplicate := seen[record.IP]; duplicate {
 			continue
@@ -2432,28 +2454,9 @@ func (api *haAPI) reconcileHABansLocked(now time.Time, limit int) error {
 	for _, ip := range candidates {
 		transition := needsTransition[ip]
 		if transition {
-			if err := api.mutateHALedger(func(current *haBanLedger) error {
-				for index := range current.Bans {
-					record := &current.Bans[index]
-					if record.IP != ip {
-						continue
-					}
-					expires, err := parseCanonicalHATime(record.ExpiresAt)
-					if err != nil {
-						return err
-					}
-					if !expires.After(now) {
-						record.State = haBanPendingDelete
-						record.UpdatedAt = now.Format(time.RFC3339)
-					}
-				}
-				return nil
-			}); err != nil {
-				return err
-			}
-		}
-		if transition {
-			_, err = api.reconcileDesiredHABanAfterRemoval(ip, now)
+			// Keep elapsed records distinguishable from explicit pending deletes
+			// until reconciliation succeeds, including after a process restart.
+			_, err = api.reconcileDesiredHABanAfterTransition(ip, now, !pendingDeletion[ip])
 		} else {
 			_, err = api.applyDesiredHABan(ip, now)
 		}
@@ -2466,7 +2469,11 @@ func (api *haAPI) reconcileHABansLocked(now time.Time, limit int) error {
 		if err := api.mutateHALedger(func(current *haBanLedger) error {
 			remaining := current.Bans[:0]
 			for _, record := range current.Bans {
-				if record.IP == ip && record.State == haBanPendingDelete {
+				expires, err := parseCanonicalHATime(record.ExpiresAt)
+				if err != nil {
+					return err
+				}
+				if record.IP == ip && (record.State == haBanPendingDelete || !expires.After(now)) {
 					continue
 				}
 				if record.IP == ip && record.State == haBanPendingApply {

--- a/src/core/syswarden-core/network/ha_native_expiry_lifecycle_test.go
+++ b/src/core/syswarden-core/network/ha_native_expiry_lifecycle_test.go
@@ -1,0 +1,127 @@
+package network
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestHANativeLedgerExpiryPreservesPhysicalExpiryCause(t *testing.T) {
+	manager, native := lifecycleManagerFixture(t)
+	native.now = native.now.Add(900 * time.Millisecond)
+	base := native.now
+	fixture := newHAAPITestFixture(t, manager, []string{"9.9.9.10"})
+	fixture.api.now = func() time.Time { return native.now }
+	response := requestDirectHAHandler(t, fixture.handler, http.MethodPost, "Bearer shared-secret",
+		`{"ip":"8.8.4.90","ttl":60,"reason":"native expiry regression","source":"bunkerweb"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("temporary POST = %d, %q", response.Code, response.Body.String())
+	}
+	for second := 1; second < 60; second++ {
+		native.now = base.Add(time.Duration(second) * time.Second)
+		if err := fixture.api.reconcileHABans(native.now, maxHALedgerRecords); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The ledger uses whole seconds. The witnessed kernel deadline is later.
+	native.now = base.Truncate(time.Second).Add(60*time.Second + 100*time.Millisecond)
+	if err := fixture.api.reconcileHABans(native.now, maxHALedgerRecords); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := manager.RuntimeLifecycleStateSnapshot(10)
+	if err != nil || len(snapshot.Claims) != 1 || snapshot.Claims[0].State != "active" {
+		t.Fatalf("ledger expiry deleted a still-live native ban: %+v, %v", snapshot, err)
+	}
+	ledger, err := fixture.api.readHALedger()
+	if err != nil || len(ledger.Bans) != 0 {
+		t.Fatalf("expired ledger was not finalized: %+v, %v", ledger, err)
+	}
+	native.now = base.Add(61 * time.Second)
+	snapshot, err = manager.RuntimeLifecycleStateSnapshot(10)
+	if err != nil || snapshot.Expired != 1 || snapshot.Claims[0].Cause != "native-expiry" {
+		t.Fatalf("physical expiry lost its cause: %+v, %v", snapshot, err)
+	}
+	native.now = native.now.Add(30 * time.Second)
+	snapshot, err = manager.RuntimeLifecycleStateSnapshot(10)
+	if err != nil || snapshot.Tombstoned != 1 || snapshot.Claims[0].Cause != "native-expiry" {
+		t.Fatalf("confirmed native expiry lost its cause: %+v, %v", snapshot, err)
+	}
+}
+
+func TestHANativeLedgerExpiryPreservesStrongerNativeBan(t *testing.T) {
+	manager, native := lifecycleManagerFixture(t)
+	base := native.now
+	if err := manager.BanWithTTL("8.8.4.90", 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	fixture := newHAAPITestFixture(t, manager, []string{"9.9.9.10"})
+	fixture.api.now = func() time.Time { return native.now }
+	response := requestDirectHAHandler(t, fixture.handler, http.MethodPost, "Bearer shared-secret",
+		`{"ip":"8.8.4.90","ttl":60,"reason":"shorter HA claim","source":"bunkerweb"}`)
+	if response.Code != http.StatusOK {
+		t.Fatalf("temporary POST = %d, %q", response.Code, response.Body.String())
+	}
+	native.now = base.Add(61 * time.Second)
+	if err := fixture.api.reconcileHABans(native.now, maxHALedgerRecords); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := manager.RuntimeLifecycleStateSnapshot(10)
+	if err != nil || snapshot.Active != 1 || snapshot.Claims[0].ExpiresAt != base.Add(10*time.Minute).Format(time.RFC3339Nano) {
+		t.Fatalf("expired HA claim removed a stronger native ban: %+v, %v", snapshot, err)
+	}
+}
+
+func TestHANativeExpiryRecoveryKeepsExplicitDeletionDistinct(t *testing.T) {
+	for _, state := range []string{haBanActive, haBanPendingApply, haBanPendingDelete} {
+		t.Run(state, func(t *testing.T) {
+			manager, native := lifecycleManagerFixture(t)
+			base := native.now
+			if err := manager.BanWithTTL("8.8.4.90", 10*time.Minute); err != nil {
+				t.Fatal(err)
+			}
+			fixture := newHAAPITestFixture(t, manager, []string{"9.9.9.10"})
+			addHAActiveTemporaryRecord(t, fixture, "8.8.4.90", "bunkerweb", base, time.Minute)
+			if err := fixture.api.mutateHALedger(func(ledger *haBanLedger) error {
+				ledger.Bans[0].State = state
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			native.now = base.Add(61 * time.Second)
+			if err := fixture.api.reconcileHABans(native.now, maxHALedgerRecords); err != nil {
+				t.Fatal(err)
+			}
+			snapshot, err := manager.RuntimeLifecycleStateSnapshot(10)
+			expected := "active"
+			if state == haBanPendingDelete {
+				expected = "deleted"
+			}
+			if err != nil || len(snapshot.Claims) != 1 || snapshot.Claims[0].State != expected {
+				t.Fatalf("recovered %s ledger changed native intent: %+v, %v", state, snapshot, err)
+			}
+			ledger, err := fixture.api.readHALedger()
+			if err != nil || len(ledger.Bans) != 0 {
+				t.Fatalf("recovery did not finalize elapsed ledger: %+v, %v", ledger, err)
+			}
+		})
+	}
+}
+
+func TestHANativeExpiryReleasesNewlyWhitelistedTarget(t *testing.T) {
+	manager, native := lifecycleManagerFixture(t)
+	base := native.now
+	if err := manager.BanWithTTL("8.8.4.90", 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	fixture := newHAAPITestFixture(t, manager, []string{"9.9.9.10"})
+	addHAActiveTemporaryRecord(t, fixture, "8.8.4.90", "bunkerweb", base, time.Minute)
+	fixture.api.isWhitelisted = func(string) (bool, error) { return true, nil }
+	native.now = base.Add(61 * time.Second)
+	if err := fixture.api.reconcileHABans(native.now, maxHALedgerRecords); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := manager.RuntimeLifecycleStateSnapshot(10)
+	if err != nil || snapshot.Deleted != 1 {
+		t.Fatalf("expiry retained a newly whitelisted ban: %+v, %v", snapshot, err)
+	}
+}


### PR DESCRIPTION
The legacy HA expiry sweep called Unban when its ledger deadline elapsed, which recorded a manual deletion even when the native kernel timeout was responsible for ending the ban. A real 60-second native qualification reproduced active, deleted and tombstoned states while the required expired state was missing.

Keep elapsed HA records distinct from explicit pending deletions until reconciliation succeeds. Native expiry now follows the kernel timeout, including when it outlives the whole-second ledger deadline or preserves a stronger existing ban. Explicit deletion, invalid target removal and externally managed expiry retain their removal behavior.

Regression tests cover the fractional-second deadline, stronger native bans, restart recovery for active and pending records, and newly whitelisted targets. The full local pre-push checks and pinned RPM harness pass for signed commit 23edfe159523d44e0c12f5ab55e6bb439b597053. Initial local load-related timeouts and successful identical retries are retained in private evidence. GitHub checks and native release qualification remain required.

This non-versioning fix preserves v4.10.0 and leaves the changelog unchanged.
