### PR TITLE
Fix : align native provenance and active block registry

### DIFF
--- a/scripts/ci/native_capability_evidence.py
+++ b/scripts/ci/native_capability_evidence.py
@@ -725,6 +725,7 @@ def _load_package_bindings(
         standard_provenance,
         {
             "apk_signature",
+            "bootstrap_qualification",
             "deb_signature",
             "packages",
             "policy_sha256",
@@ -744,6 +745,7 @@ def _load_package_bindings(
     rhel = _exact_mapping(
         rhel_provenance,
         {
+            "bootstrap_qualification",
             "package_role",
             "packages",
             "policy_sha256",
@@ -780,6 +782,22 @@ def _load_package_bindings(
     ):
         raise NativeCapabilityEvidenceError(
             "native capability evidence requires the qualified signing provenance"
+        )
+    try:
+        for provenance in (standard, rhel):
+            signing_bundle.validate_bootstrap_reference(
+                provenance["bootstrap_qualification"],
+                contract["target_release"],
+                candidate_commit,
+                provenance["repository"],
+            )
+    except signing_bundle.SigningBundleError as exc:
+        raise NativeCapabilityEvidenceError(
+            f"native signing bootstrap qualification is invalid: {exc}"
+        ) from exc
+    if rhel["bootstrap_qualification"] != standard["bootstrap_qualification"]:
+        raise NativeCapabilityEvidenceError(
+            "native signing bootstrap qualification references differ"
         )
     standard_source = _exact_mapping(
         standard["source"],

--- a/scripts/ci/native_capability_evidence_test.py
+++ b/scripts/ci/native_capability_evidence_test.py
@@ -167,7 +167,28 @@ class NativeCapabilityEvidenceTests(unittest.TestCase):
             "unsigned_artifact_name": "syswarden-packages-4.10.0",
             "unsigned_package_run_id": 100,
         }
+        signing = evidence.signing_bundle
+        bootstrap = {
+            "schema_version": 1,
+            "profile": signing.BOOTSTRAP_REFERENCE_PROFILE,
+            "repository": signing.BOOTSTRAP_REPOSITORY,
+            "release_sha": signing.BOOTSTRAP_RELEASE_SHA,
+            "policy_sha256": signing.FOUNDATION_POLICY_SHA256,
+            "signing_run": {
+                "attempt": 1,
+                "id": signing.BOOTSTRAP_SIGNING_RUN_ID,
+                "workflow": ".github/workflows/native-package-signing.yml",
+                "workflow_sha": signing.BOOTSTRAP_RELEASE_SHA,
+            },
+            "artifact": {
+                "digest": signing.BOOTSTRAP_SIGNED_ARTIFACT_DIGEST,
+                "id": signing.BOOTSTRAP_SIGNED_ARTIFACT_ID,
+                "name": signing.BOOTSTRAP_SIGNED_ARTIFACT_NAME,
+                "size": signing.BOOTSTRAP_SIGNED_ARTIFACT_SIZE,
+            },
+        }
         standard = {
+            "bootstrap_qualification": bootstrap,
             "apk_signature": {
                 "exact_unsigned_suffix": True,
                 "key": apk_key,
@@ -210,6 +231,7 @@ class NativeCapabilityEvidenceTests(unittest.TestCase):
             "size": len(rhel_data),
         }
         rhel = {
+            "bootstrap_qualification": copy.deepcopy(bootstrap),
             "package_role": "rhel-package-owned",
             "packages": {"signed": rhel_record, "unsigned": rhel_record},
             "policy_sha256": standard["policy_sha256"],
@@ -777,6 +799,45 @@ class NativeCapabilityEvidenceTests(unittest.TestCase):
             evidence._load_package_bindings(
                 self.signing_bundle, self.candidate, contract
             )
+
+    def test_bootstrap_reference_is_required_and_validated_for_each_package_role(self) -> None:
+        contract, _ = evidence.load_contract()
+        paths = (
+            self.signing_bundle / "evidence/NATIVE_SIGNING_PROVENANCE.json",
+            self.signing_bundle / "rhel-package-owned/evidence/SIGNING_PROVENANCE.json",
+        )
+        for path in paths:
+            original = json.loads(path.read_text(encoding="utf-8"))
+            mutations = []
+            missing = copy.deepcopy(original)
+            del missing["bootstrap_qualification"]
+            mutations.append(missing)
+            for key_path, value in (
+                (("schema_version",), True),
+                (("release_sha",), self.candidate),
+                (("repository",), "other/repository"),
+                (("policy_sha256",), "0" * 64),
+                (("unexpected",), True),
+                (("signing_run", "id"), 1),
+                (("artifact", "digest"), "sha256:" + "0" * 64),
+            ):
+                changed = copy.deepcopy(original)
+                target = changed["bootstrap_qualification"]
+                for component in key_path[:-1]:
+                    target = target[component]
+                target[key_path[-1]] = value
+                mutations.append(changed)
+            for changed in mutations:
+                with self.subTest(path=path, reference=changed.get("bootstrap_qualification")):
+                    self.write_json(path, changed)
+                    with self.assertRaisesRegex(
+                        evidence.NativeCapabilityEvidenceError,
+                        "keys are not exact|bootstrap qualification is invalid",
+                    ):
+                        evidence._load_package_bindings(
+                            self.signing_bundle, self.candidate, contract
+                        )
+            self.write_json(path, original)
 
     def test_bootstrap_signing_provenance_is_not_capability_qualification(self) -> None:
         contract, _ = evidence.load_contract()

--- a/scripts/ci/native_lifecycle_bundle_verify.py
+++ b/scripts/ci/native_lifecycle_bundle_verify.py
@@ -246,6 +246,7 @@ def _validated_signing_inputs(
         provenance,
         {
             "apk_signature",
+            "bootstrap_qualification",
             "deb_signature",
             "packages",
             "policy_sha256",
@@ -291,6 +292,12 @@ def _validated_signing_inputs(
         native_package_signing_bundle.fail(
             "native signing provenance trust binding is malformed"
         )
+    native_package_signing_bundle.validate_bootstrap_reference(
+        provenance["bootstrap_qualification"],
+        native_lifecycle_evidence.TARGET_RELEASE,
+        candidate,
+        provenance["repository"],
+    )
     source = native_package_signing_bundle.exact_keys(
         provenance["source"],
         {
@@ -479,6 +486,7 @@ def _validated_rhel_signing_input(
     native_package_signing_bundle.exact_keys(
         provenance,
         {
+            "bootstrap_qualification",
             "package_role",
             "packages",
             "policy_sha256",
@@ -512,6 +520,19 @@ def _validated_rhel_signing_input(
     ):
         native_package_signing_bundle.fail(
             "RHEL package-owned signing provenance identity is invalid"
+        )
+    native_package_signing_bundle.validate_bootstrap_reference(
+        provenance["bootstrap_qualification"],
+        native_lifecycle_evidence.TARGET_RELEASE,
+        candidate,
+        provenance["repository"],
+    )
+    if (
+        provenance["bootstrap_qualification"]
+        != standard_provenance["bootstrap_qualification"]
+    ):
+        native_package_signing_bundle.fail(
+            "RHEL package-owned bootstrap qualification reference differs"
         )
     expected_name = native_package_signing_bundle.rhel_package_owned_name(
         native_lifecycle_evidence.TARGET_RELEASE

--- a/scripts/ci/native_lifecycle_evidence_test.py
+++ b/scripts/ci/native_lifecycle_evidence_test.py
@@ -536,7 +536,28 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
             "size": 512,
         }
         policy_sha256 = "4" * 64
+        signing = bundle_verify.native_package_signing_bundle
+        bootstrap = {
+            "schema_version": 1,
+            "profile": signing.BOOTSTRAP_REFERENCE_PROFILE,
+            "repository": signing.BOOTSTRAP_REPOSITORY,
+            "release_sha": signing.BOOTSTRAP_RELEASE_SHA,
+            "policy_sha256": signing.FOUNDATION_POLICY_SHA256,
+            "signing_run": {
+                "attempt": 1,
+                "id": signing.BOOTSTRAP_SIGNING_RUN_ID,
+                "workflow": ".github/workflows/native-package-signing.yml",
+                "workflow_sha": signing.BOOTSTRAP_RELEASE_SHA,
+            },
+            "artifact": {
+                "digest": signing.BOOTSTRAP_SIGNED_ARTIFACT_DIGEST,
+                "id": signing.BOOTSTRAP_SIGNED_ARTIFACT_ID,
+                "name": signing.BOOTSTRAP_SIGNED_ARTIFACT_NAME,
+                "size": signing.BOOTSTRAP_SIGNED_ARTIFACT_SIZE,
+            },
+        }
         provenance: dict[str, object] = {
+            "bootstrap_qualification": bootstrap,
             "apk_signature": {
                 "exact_unsigned_suffix": True,
                 "key": apk_key,
@@ -656,6 +677,7 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
             "status": "verified",
         }
         rhel_provenance = {
+            "bootstrap_qualification": copy.deepcopy(bootstrap),
             "package_role": "rhel-package-owned",
             "packages": {
                 "signed": copy.deepcopy(rhel_package),
@@ -1185,6 +1207,44 @@ class NativeLifecycleEvidenceTests(unittest.TestCase):
             rhel_package["name"],
             evidence.PACKAGE_NAMES[("RPM-A9-RHELPO", evidence.TARGET_RELEASE)],
         )
+
+    def test_bundle_revalidator_requires_reviewed_bootstrap_for_each_package_role(self) -> None:
+        signing_root, _, _ = self.signing_evidence()
+        paths = (
+            signing_root / "NATIVE_SIGNING_PROVENANCE.json",
+            signing_root.parent / "rhel-package-owned/evidence/SIGNING_PROVENANCE.json",
+        )
+        for path in paths:
+            original = json.loads(path.read_text(encoding="utf-8"))
+            mutations = []
+            missing = copy.deepcopy(original)
+            del missing["bootstrap_qualification"]
+            mutations.append(missing)
+            for key_path, value in (
+                (("schema_version",), True),
+                (("release_sha",), self.candidate),
+                (("repository",), "other/repository"),
+                (("policy_sha256",), "0" * 64),
+                (("unexpected",), True),
+                (("signing_run", "id"), 1),
+                (("artifact", "digest"), "sha256:" + "0" * 64),
+            ):
+                changed = copy.deepcopy(original)
+                target = changed["bootstrap_qualification"]
+                for component in key_path[:-1]:
+                    target = target[component]
+                target[key_path[-1]] = value
+                mutations.append(changed)
+            for changed in mutations:
+                with self.subTest(path=path, reference=changed.get("bootstrap_qualification")):
+                    self.write_json(path, changed)
+                    with self.assertRaises(
+                        bundle_verify.native_package_signing_bundle.SigningBundleError
+                    ):
+                        bundle_verify._validated_signing_inputs(
+                            signing_root, self.candidate
+                        )
+            self.write_json(path, original)
 
     def test_bundle_revalidator_rejects_unqualified_provenance_status(self) -> None:
         signing_root, provenance, _ = self.signing_evidence()

--- a/src/core/syswarden-core/telemetry/runtime_registry.go
+++ b/src/core/syswarden-core/telemetry/runtime_registry.go
@@ -1,0 +1,35 @@
+package telemetry
+
+import "sort"
+
+// Administrative runtime claims need no attack record to appear in the active
+// registry. This projection never contributes to physical-hit or risk metrics.
+func appendActiveRuntimeRegistryEntries(entries []BannedIP, view runtimeEnforcementView) []BannedIP {
+	if !view.linked || !view.complete || view.truncated || len(entries) >= 50 {
+		return entries
+	}
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		if entry.Action == "BANNED" && entry.EnforcementState == "active" {
+			seen[entry.IP] = true
+		}
+	}
+	addresses := make([]string, 0, len(view.byIP))
+	for address, state := range view.byIP {
+		if state == "active" && !seen[address] {
+			addresses = append(addresses, address)
+		}
+	}
+	sort.Strings(addresses)
+	for _, address := range addresses {
+		if len(entries) >= 50 {
+			break
+		}
+		entries = append(entries, BannedIP{
+			Timestamp: view.capturedAt, IP: address, Jail: "native-runtime", Mitre: "-",
+			Payload: "Active firewall block reported by native runtime.",
+			Action:  "BANNED", EnforcementState: "active",
+		})
+	}
+	return entries
+}

--- a/src/core/syswarden-core/telemetry/runtime_registry_test.go
+++ b/src/core/syswarden-core/telemetry/runtime_registry_test.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestActiveRuntimeClaimAppearsWithoutAnAttackRecord(t *testing.T) {
+	view, err := collectRuntimeEnforcementView(localRuntimeReporterFixture{snapshot: localRuntimeSnapshotFixture()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := appendActiveRuntimeRegistryEntries(nil, view)
+	if len(entries) != 1 || entries[0].IP != "192.0.2.10" || entries[0].EnforcementState != "active" ||
+		entries[0].Action != "BANNED" || entries[0].Jail != "native-runtime" || entries[0].Mitre != "-" ||
+		entries[0].Timestamp != view.capturedAt {
+		t.Fatalf("active native claim missing or misattributed: %+v", entries)
+	}
+	if !reflect.DeepEqual(*view.localSnapshot, localRuntimeSnapshotFixture()) {
+		t.Fatal("registry projection modified native lifecycle history")
+	}
+}
+
+func TestRuntimeRegistryPreservesAttackEvidenceAndBound(t *testing.T) {
+	view := runtimeEnforcementView{linked: true, complete: true, capturedAt: "2026-09-11T19:00:00Z", byIP: map[string]string{
+		"192.0.2.10": "active", "192.0.2.11": "deleted", "192.0.2.12": "expired", "192.0.2.13": "tombstoned",
+		"192.0.2.14": "active", "2001:db8::/64": "active",
+	}}
+	original := []BannedIP{{IP: "192.0.2.10", Jail: "ssh-auth", Action: "BANNED", EnforcementState: "active", Payload: "original evidence"}}
+	entries := appendActiveRuntimeRegistryEntries(append([]BannedIP{}, original...), view)
+	if len(entries) != 3 || entries[0] != original[0] || entries[1].IP != "192.0.2.14" || entries[2].IP != "2001:db8::/64" {
+		t.Fatalf("registry duplicated or altered attack evidence: %+v", entries)
+	}
+	for _, fault := range []string{"unlinked", "incomplete", "truncated"} {
+		t.Run(fault, func(t *testing.T) {
+			unsafe := view
+			switch fault {
+			case "unlinked":
+				unsafe.linked = false
+			case "incomplete":
+				unsafe.complete = false
+			case "truncated":
+				unsafe.truncated = true
+			}
+			if got := appendActiveRuntimeRegistryEntries(nil, unsafe); len(got) != 0 {
+				t.Fatalf("unverified runtime claims entered the registry: %+v", got)
+			}
+		})
+	}
+	view.byIP = make(map[string]string)
+	for index := 1; index <= 60; index++ {
+		view.byIP[fmt.Sprintf("192.0.2.%d", index)] = "active"
+	}
+	first := appendActiveRuntimeRegistryEntries(nil, view)
+	second := appendActiveRuntimeRegistryEntries(nil, view)
+	if len(first) != 50 || !reflect.DeepEqual(first, second) {
+		t.Fatal("registry bound or deterministic ordering was lost")
+	}
+}

--- a/src/core/syswarden-core/telemetry/worker.go
+++ b/src/core/syswarden-core/telemetry/worker.go
@@ -2224,6 +2224,7 @@ func getWAFStats(fwManager FirewallManager) WAF {
 		seenIPs[allBans[i].IP] = true
 		waf.BannedIPs = append(waf.BannedIPs, allBans[i])
 	}
+	waf.BannedIPs = appendActiveRuntimeRegistryEntries(waf.BannedIPs, runtimeView)
 
 	metrics, categoryCounts, jailCounts, rejectedMetrics := buildAttackerMetrics(metricEvents, catalog)
 	if !journalScopeComplete {

--- a/src/core/syswarden-tui/main.go
+++ b/src/core/syswarden-tui/main.go
@@ -2848,6 +2848,7 @@ func printDashboardText() {
 				a.IP, a.Hits, a.Severity, a.PrimaryJail, a.EnforcementJail, a.EnforcementAction, a.EnforcementState, a.SelectedPolicyQuality, a.MetricQuality, a.HitQuality, a.HitEvidence, a.Country, a.ASN, a.Org)
 		}
 	}
+	printActiveBlockRegistry(os.Stdout, d.WAF.BannedIPs)
 	fmt.Println("[RUNTIME LIFECYCLE HISTORY]")
 	if lines, err := runtimeLifecycleHistoryLines(d.WAF.GRCKPI); err != nil {
 		fmt.Printf(" - Unavailable: %v\n", err)

--- a/src/core/syswarden-tui/runtime_registry.go
+++ b/src/core/syswarden-tui/runtime_registry.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+func printActiveBlockRegistry(output io.Writer, entries []BannedIP) {
+	fmt.Fprintln(output, "[ACTIVE BLOCK REGISTRY]")
+	count := 0
+	for _, entry := range entries {
+		if entry.Action != "BANNED" || entry.EnforcementState != "active" {
+			continue
+		}
+		fmt.Fprintf(output, " - %s | state=active | source=%s\n", entry.IP, entry.Jail)
+		count++
+	}
+	if count == 0 {
+		fmt.Fprintln(output, " - No active entries in the current registry snapshot.")
+	}
+}

--- a/src/core/syswarden-tui/runtime_registry_test.go
+++ b/src/core/syswarden-tui/runtime_registry_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestActiveBlockRegistryDistinguishesRuntimeAndAttackEvidence(t *testing.T) {
+	entries := []BannedIP{
+		{IP: "192.0.2.10", Action: "BANNED", EnforcementState: "active", Jail: "native-runtime"},
+		{IP: "192.0.2.11", Action: "BANNED", EnforcementState: "active", Jail: "ssh-auth"},
+		{IP: "192.0.2.12", Action: "BANNED", EnforcementState: "deleted"},
+		{IP: "192.0.2.13", Action: "BANNED", EnforcementState: "expired"},
+		{IP: "192.0.2.14", Action: "BANNED", EnforcementState: "tombstoned"},
+		{IP: "192.0.2.15", Action: "SHADOW-ALERT"},
+		{IP: "192.0.2.16", Action: "BANNED", EnforcementState: "unknown"},
+	}
+	var output bytes.Buffer
+	printActiveBlockRegistry(&output, entries)
+	expected := "[ACTIVE BLOCK REGISTRY]\n - 192.0.2.10 | state=active | source=native-runtime\n - 192.0.2.11 | state=active | source=ssh-auth\n"
+	if output.String() != expected {
+		t.Fatalf("current registry includes a historical or unverified block: %s", output.String())
+	}
+	output.Reset()
+	printActiveBlockRegistry(&output, entries[2:])
+	if !strings.Contains(output.String(), "No active entries in the current registry snapshot.") {
+		t.Fatal("empty current registry was not identified")
+	}
+}


### PR DESCRIPTION
Native qualification found two gaps: an active administrative firewall claim had no row in the TUI block registry when no attack record existed, and valid signing provenance was rejected because the consumers did not accept its required bootstrap qualification reference.

Add verified active native claims to the bounded registry and show the active block registry in text mode alongside lifecycle history. Preserve existing attack rows, exclude terminal or unverified claims, and keep administrative state separate from physical-hit and enrichment metrics. Both signing consumers now require and validate the reviewed bootstrap reference for standard and RHEL package-owned provenance.

Validation: native captures document the missing registry row; regression tests cover active administrative claims, terminal states, incomplete snapshots, duplicate prevention, stable bounds and text rendering. Core and TUI tests, race, vet and security scans pass, as do repository lint and all 1126 Python CI contract tests with three expected skips. The unchanged signed candidate bundle passes both corrected provenance consumers in a local preflight. GitHub checks and fresh native qualification remain required for the merged candidate.

Both commits use the non-versioning Fix convention. Version inspection and commit validation preserve v4.10.0; the changelog is unchanged.
