### PR TITLE
Fix : preserve native runtime deadlines across reloads

### DIFF
--- a/docs/technical/NATIVE_RUNTIME_LIFECYCLE.md
+++ b/docs/technical/NATIVE_RUNTIME_LIFECYCLE.md
@@ -84,6 +84,14 @@ witnessed candidate can finish publication after an interrupted process. An
 intent whose native result was never witnessed remains fenced and requires
 explicit recovery; it is not promoted to a successful ban or deletion.
 
+Policy reloads and scheduled feed updates retain compatible current runtime
+sets in the kernel while atomically replacing their surrounding rules and
+persistent sets. Validation and commit latency do not restart a ban's remaining
+lifetime. Policy rollback retains those same runtime sets and omits historical
+elements from its recovery snapshot, so an entry that expires during the
+transaction cannot be replayed. Legacy layouts that require reconstruction
+continue through the existing migration and verification path.
+
 On a normal restart, still-live verified desired claims are restored before
 workers start. Timed claims use the remaining lifetime rounded upward to the
 native backend's whole-second precision. Expired claims require a fresh absence

--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_integration_linux_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_integration_linux_test.go
@@ -1,0 +1,172 @@
+//go:build linux && integration
+
+package firewall
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type runtimePreservationNativeRunner struct {
+	delayValidation  time.Duration
+	failVerification bool
+	failRollback     bool
+	applied          bool
+	rollbackApplies  int
+}
+
+func (runner *runtimePreservationNativeRunner) Run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	if runner.applied && runner.failVerification && strings.Join(args, " ") == "-j list ruleset" {
+		runner.failVerification = false
+		return nil, errors.New("injected post-apply observation failure")
+	}
+	if runner.failRollback && len(args) == 2 && args[0] == "-f" && filepath.Base(args[1]) == "rollback.nft" {
+		runner.failRollback = false
+		return nil, errors.New("injected interrupted rollback")
+	}
+	command := exec.CommandContext(ctx, "/usr/bin/nft", args...)
+	command.Stdin = bytes.NewReader(stdin)
+	wire, err := command.CombinedOutput()
+	if err == nil && len(args) == 3 && args[0] == "-c" {
+		select {
+		case <-time.After(runner.delayValidation):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err == nil && len(args) == 2 && args[0] == "-f" && filepath.Base(args[1]) == "candidate.nft" {
+		runner.applied = true
+	}
+	if err == nil && len(args) == 2 && args[0] == "-f" && filepath.Base(args[1]) == "rollback.nft" {
+		runner.rollbackApplies++
+	}
+	return wire, err
+}
+
+func TestNativeReloadPreservesRuntimeExpiryThroughValidationAndRollback(t *testing.T) {
+	parentNamespace := os.Getenv("SYSWARDEN_TEST_PARENT_NETNS")
+	if parentNamespace == "" {
+		t.Skip("requires an explicitly isolated network namespace")
+	}
+	currentNamespace, err := os.Readlink("/proc/self/ns/net")
+	if err != nil || currentNamespace == parentNamespace || os.Geteuid() != 0 {
+		t.Fatal("native firewall test requires root inside a distinct network namespace")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	runner := &runtimePreservationNativeRunner{}
+	const policy = `table inet syswarden {
+ set fixture_set { type ipv4_addr; }
+ set banned_ips { type ipv4_addr; flags interval,timeout; }
+ set banned_ips6 { type ipv6_addr; flags interval,timeout; }
+ chain input { type filter hook input priority 0; policy accept; ip saddr @banned_ips drop; ip6 saddr @banned_ips6 drop; }
+}
+table netdev syswarden_hw_drop {
+ set banned_ips { type ipv4_addr; flags interval,timeout; }
+ set banned_ips6 { type ipv6_addr; flags interval,timeout; }
+ chain runtime_probe { ip saddr @banned_ips drop; ip6 saddr @banned_ips6 drop; }
+}
+`
+	setup := policy + "table inet operator_keep {\n set sample { type ipv4_addr; elements = { 203.0.113.44 }; }\n}\n"
+	for _, key := range nftDynamicBanSets {
+		long, short := "192.0.2.44", "192.0.2.45"
+		if strings.HasSuffix(key.name, "6") {
+			long, short = "2001:db8::44", "2001:db8::45"
+		}
+		setup += fmt.Sprintf("add element %s %s %s { %s timeout 60s, %s timeout 1s }\n", key.family, key.table, key.name, long, short)
+	}
+	if output, err := runner.Run(ctx, []byte(setup), "-f", "-"); err != nil {
+		t.Fatalf("native setup: %s, %v", output, err)
+	}
+	readHandles := func() map[string]uint64 {
+		t.Helper()
+		wire, err := runner.Run(ctx, nil, "-j", "list", "ruleset")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document struct {
+			NFTables []struct {
+				Set *struct {
+					Family string `json:"family"`
+					Table  string `json:"table"`
+					Name   string `json:"name"`
+					Handle uint64 `json:"handle"`
+				} `json:"set"`
+			} `json:"nftables"`
+		}
+		if err := json.Unmarshal(wire, &document); err != nil {
+			t.Fatal(err)
+		}
+		result := make(map[string]uint64)
+		for _, item := range document.NFTables {
+			if item.Set != nil && strings.HasPrefix(item.Set.Name, "banned_ips") {
+				result[item.Set.Family+" "+item.Set.Table+" "+item.Set.Name] = item.Set.Handle
+			}
+		}
+		if len(result) != 4 {
+			t.Fatalf("native runtime inventory is incomplete: %v", result)
+		}
+		return result
+	}
+	before, err := snapshotNFTDynamicBans(ctx, runner, time.Now())
+	if err != nil {
+		t.Fatalf("native preservation preflight: %v", err)
+	}
+	handles := readHandles()
+	operator, err := runner.Run(ctx, nil, "list", "table", "inet", "operator_keep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateDirectory := t.TempDir()
+	runner.delayValidation = 3 * time.Second
+	for cycle := 0; cycle < 4; cycle++ {
+		runner.applied = false
+		runner.failVerification = cycle == 1 || cycle == 2
+		runner.failRollback = cycle == 2
+		_, err := applyNftablesTransactionLocked(ctx, runner, stateDirectory, policy, nil, recoveryPlanWithDynamicSets(), fmt.Sprintf("%016x", cycle+1), nil)
+		if cycle == 1 {
+			if err == nil || !strings.Contains(err.Error(), "post-apply verification failed") || runner.rollbackApplies != 1 {
+				t.Fatalf("native fault did not restore policy: %v", err)
+			}
+		} else if cycle == 2 {
+			if err == nil || !strings.Contains(err.Error(), "rollback failed") {
+				t.Fatalf("native interruption did not retain recovery evidence: %v", err)
+			}
+			if _, err := readNFTTransactionJournal(stateDirectory); err != nil {
+				t.Fatalf("native interrupted transaction lost its journal: %v", err)
+			}
+			if err := recoverPendingNftablesTransaction(ctx, runner, stateDirectory); err != nil {
+				t.Fatalf("native durable recovery: %v", err)
+			}
+			if _, err := readNFTTransactionJournal(stateDirectory); !errors.Is(err, os.ErrNotExist) || runner.rollbackApplies != 2 {
+				t.Fatalf("native recovery did not finish its rollback: %v", err)
+			}
+		} else if err != nil {
+			t.Fatalf("native policy cycle %d: %v", cycle, err)
+		}
+		if !reflect.DeepEqual(handles, readHandles()) {
+			t.Fatal("runtime sets were recreated during policy replacement or rollback")
+		}
+		after, err := snapshotNFTDynamicBans(ctx, runner, time.Now())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := compareNFTDynamicSnapshots(before, after, time.Now()); err != nil {
+			t.Fatalf("native expiry changed across delayed policy cycle %d: %v", cycle, err)
+		}
+		currentOperator, err := runner.Run(ctx, nil, "list", "table", "inet", "operator_keep")
+		if err != nil || !bytes.Equal(operator, currentOperator) {
+			t.Fatal("unrelated operator policy changed")
+		}
+	}
+}

--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux.go
@@ -1,0 +1,153 @@
+//go:build linux
+
+package firewall
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func isNFTRuntimeTable(target nftTableTarget) bool {
+	return target == (nftTableTarget{family: "inet", name: "syswarden"}) ||
+		target == (nftTableTarget{family: "netdev", name: "syswarden_hw_drop"})
+}
+
+// Reloading a live runtime set would restart its relative expiration clock.
+// Keep compatible sets in the kernel while replacing the surrounding policy.
+// Their lifetime then continues through validation, commit and rollback.
+func nftRuntimePreservationRules(wire []byte, snapshot nftDynamicSnapshot) (string, error) {
+	for _, key := range nftDynamicBanSets {
+		if !snapshot.present[key] || len(snapshot.discarded[key]) != 0 {
+			return "", nil
+		}
+	}
+	var document struct {
+		NFTables []map[string]json.RawMessage `json:"nftables"`
+	}
+	if err := json.Unmarshal(wire, &document); err != nil {
+		return "", err
+	}
+	chains := make(map[nftTableTarget][]string)
+	objects := make(map[nftTableTarget][]string)
+	compatible := make(map[nftObjectKey]bool)
+	for _, entry := range document.NFTables {
+		for kind, raw := range entry {
+			var object struct {
+				Family  string          `json:"family"`
+				Table   string          `json:"table"`
+				Name    string          `json:"name"`
+				Type    json.RawMessage `json:"type"`
+				Flags   []string        `json:"flags"`
+				Timeout json.RawMessage `json:"timeout"`
+			}
+			if err := json.Unmarshal(raw, &object); err != nil {
+				return "", fmt.Errorf("inspect runtime preservation object: %w", err)
+			}
+			target := nftTableTarget{family: object.Family, name: object.Table}
+			if !isNFTRuntimeTable(target) {
+				continue
+			}
+			if kind == "rule" || kind == "element" {
+				continue
+			}
+			if !nftSetNameRE.MatchString(object.Name) {
+				return "", fmt.Errorf("runtime preservation object has an unsupported name")
+			}
+			key := nftObjectKey{family: target.family, table: target.name, name: object.Name}
+			if kind == "set" && snapshot.present[key] {
+				var dataType string
+				if err := json.Unmarshal(object.Type, &dataType); err != nil {
+					return "", nil
+				}
+				wantedType := "ipv4_addr"
+				if strings.HasSuffix(key.name, "6") {
+					wantedType = "ipv6_addr"
+				}
+				sort.Strings(object.Flags)
+				if dataType != wantedType || strings.Join(object.Flags, ",") != "interval,timeout" ||
+					nftDurationSpecified(object.Timeout) || compatible[key] {
+					return "", nil
+				}
+				compatible[key] = true
+				continue
+			}
+			command := fmt.Sprintf("delete %s %s %s %s\n", kind, target.family, target.name, object.Name)
+			switch kind {
+			case "chain":
+				chains[target] = append(chains[target], command)
+			case "set", "map", "counter", "quota", "limit", "flowtable", "ct helper", "ct timeout", "ct expectation", "synproxy", "secmark":
+				objects[target] = append(objects[target], command)
+			default:
+				return "", fmt.Errorf("runtime preservation refuses unsupported owned object %q", kind)
+			}
+		}
+	}
+	if len(compatible) != len(nftDynamicBanSets) {
+		return "", nil
+	}
+	var result strings.Builder
+	for _, target := range syswardenNFTTables {
+		if !isNFTRuntimeTable(target) {
+			continue
+		}
+		_, _ = fmt.Fprintf(&result, "flush table %s %s\n", target.family, target.name)
+		sort.Strings(chains[target])
+		sort.Strings(objects[target])
+		for _, command := range append(chains[target], objects[target]...) {
+			result.WriteString(command)
+		}
+	}
+	return result.String(), nil
+}
+
+// Only canonical output from the pinned nft executable reaches this parser.
+// Dynamic values were independently parsed from its JSON snapshot. Removing
+// their declarations prevents a rollback from resurrecting an entry that
+// naturally expired while the policy transaction was in progress.
+func nftRollbackWithoutRuntimeElements(snapshot string) (string, error) {
+	lines := strings.SplitAfter(snapshot, "\n")
+	var result strings.Builder
+	ownedTable, runtimeSet, elements := false, false, false
+	seen := 0
+	for _, line := range lines {
+		switch strings.TrimSpace(line) {
+		case "table inet syswarden {", "table netdev syswarden_hw_drop {":
+			ownedTable = true
+		}
+		if ownedTable && (line == "\tset banned_ips {\n" || line == "\tset banned_ips6 {\n") {
+			runtimeSet = true
+			seen++
+		}
+		if runtimeSet && strings.HasPrefix(line, "\t\telements = { ") {
+			if elements {
+				return "", fmt.Errorf("ambiguous runtime elements in rollback snapshot")
+			}
+			elements = true
+		}
+		if runtimeSet && !elements && strings.Contains(line, "elements") {
+			return "", fmt.Errorf("noncanonical runtime elements in rollback snapshot")
+		}
+		if elements {
+			if strings.ContainsAny(strings.TrimPrefix(line, "\t\telements = { "), "{\"#") {
+				return "", fmt.Errorf("unsupported runtime element syntax in rollback snapshot")
+			}
+			if strings.HasSuffix(strings.TrimSpace(line), "}") {
+				elements = false
+			}
+			continue
+		}
+		if line == "\t}\n" {
+			runtimeSet = false
+		}
+		if line == "}\n" {
+			ownedTable = false
+		}
+		result.WriteString(line)
+	}
+	if elements || runtimeSet || seen != len(nftDynamicBanSets) {
+		return "", fmt.Errorf("rollback snapshot lacks four complete canonical runtime set definitions")
+	}
+	return result.String(), nil
+}

--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux_test.go
@@ -1,0 +1,169 @@
+//go:build linux
+
+package firewall
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func runtimePreservationFixture(t *testing.T) ([]byte, nftDynamicSnapshot) {
+	t.Helper()
+	var entries []any
+	for _, key := range nftDynamicBanSets {
+		dataType := "ipv4_addr"
+		if strings.HasSuffix(key.name, "6") {
+			dataType = "ipv6_addr"
+		}
+		entries = append(entries, map[string]any{"set": map[string]any{
+			"family": key.family, "table": key.table, "name": key.name,
+			"type": dataType, "flags": []string{"timeout", "interval"},
+		}})
+	}
+	for _, family := range []string{"inet", "netdev"} {
+		table := "syswarden"
+		if family == "netdev" {
+			table = "syswarden_hw_drop"
+		}
+		for kind, name := range map[string]string{"chain": "old_policy", "set": "old_feed", "counter": "old_counter"} {
+			entries = append(entries, map[string]any{kind: map[string]any{"family": family, "table": table, "name": name}})
+		}
+	}
+	entries = append(entries, map[string]any{"chain": map[string]any{"family": "inet", "table": "operator", "name": "untouched"}})
+	wire, err := json.Marshal(map[string]any{"nftables": entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeNFTJSON(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := extractNFTDynamicSnapshot(document, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wire, snapshot
+}
+
+func TestNFTReloadKeepsLiveRuntimeSetsInTheKernel(t *testing.T) {
+	wire, snapshot := runtimePreservationFixture(t)
+	rules, err := nftRuntimePreservationRules(wire, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"flush table inet syswarden\n", "flush table netdev syswarden_hw_drop\n",
+		"delete chain inet syswarden old_policy\n", "delete set inet syswarden old_feed\n",
+		"delete counter netdev syswarden_hw_drop old_counter\n",
+	} {
+		if !strings.Contains(rules, required) {
+			t.Fatalf("policy replacement is incomplete: missing %q in %s", required, rules)
+		}
+	}
+	for _, forbidden := range []string{"banned_ips", "delete table", "add element", "operator", "untouched", "syswarden_table"} {
+		if strings.Contains(rules, forbidden) {
+			t.Fatalf("runtime or unrelated policy would be changed: %s", rules)
+		}
+	}
+	if strings.Index(rules, "delete chain inet") > strings.Index(rules, "delete set inet") {
+		t.Fatal("referenced sets are deleted before their chains")
+	}
+}
+
+func TestNFTRuntimePreservationRequiresCompatibleCompleteSets(t *testing.T) {
+	wire, snapshot := runtimePreservationFixture(t)
+	for _, replacement := range [][2]string{
+		{`"ipv4_addr"`, `"ipv6_addr"`},
+		{`["timeout","interval"]`, `["timeout"]`},
+		{`"type":"ipv4_addr"`, `"type":"ipv4_addr","timeout":60`},
+		{`"name":"banned_ips"`, `"name":"old_runtime"`},
+	} {
+		changed := strings.Replace(string(wire), replacement[0], replacement[1], 1)
+		if changed == string(wire) {
+			t.Fatal("fixture replacement did not change the input")
+		}
+		rules, err := nftRuntimePreservationRules([]byte(changed), snapshot)
+		if err != nil || rules != "" {
+			t.Fatalf("incompatible runtime definitions were retained: %q, %v", rules, err)
+		}
+	}
+	key := nftDynamicBanSets[0]
+	snapshot.present[key] = false
+	if rules, err := nftRuntimePreservationRules(wire, snapshot); err != nil || rules != "" {
+		t.Fatalf("partial runtime was retained: %q, %v", rules, err)
+	}
+}
+
+func TestNFTRuntimePreservationRefusesUnsupportedOwnedObjects(t *testing.T) {
+	wire, snapshot := runtimePreservationFixture(t)
+	for _, replacement := range [][2]string{
+		{`"counter":`, `"unknown_object":`},
+		{`"old_policy"`, `"bad; flush ruleset"`},
+	} {
+		changed := strings.Replace(string(wire), replacement[0], replacement[1], 1)
+		if rules, err := nftRuntimePreservationRules([]byte(changed), snapshot); err == nil || rules != "" {
+			t.Fatalf("unsafe reset plan was produced: %q, %v", rules, err)
+		}
+	}
+}
+
+func canonicalRuntimeRollbackFixture() string {
+	var result strings.Builder
+	for _, table := range []string{"inet syswarden", "netdev syswarden_hw_drop"} {
+		result.WriteString("table " + table + " {\n")
+		result.WriteString("\tset banned_ips {\n\t\ttype ipv4_addr\n\t\tflags interval,timeout\n\t\telements = { 192.0.2.44 timeout 1m expires 40s,\n\t\t\t     192.0.2.45 timeout 1m expires 1ms }\n\t}\n")
+		result.WriteString("\tset banned_ips6 {\n\t\ttype ipv6_addr\n\t\tflags interval,timeout\n\t\telements = { 2001:db8::44 timeout 1m expires 40s }\n\t}\n")
+		result.WriteString("\tset persistent {\n\t\ttype ipv4_addr\n\t\telements = { 198.51.100.1 }\n\t}\n}\n")
+	}
+	return result.String()
+}
+
+func TestNFTRollbackCannotResurrectRetainedRuntimeElements(t *testing.T) {
+	snapshot := canonicalRuntimeRollbackFixture()
+	cleaned, err := nftRollbackWithoutRuntimeElements(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, address := range []string{"192.0.2.44", "192.0.2.45", "2001:db8::44", "expires"} {
+		if strings.Contains(cleaned, address) {
+			t.Fatalf("historical runtime could be replayed: %s", cleaned)
+		}
+	}
+	if strings.Count(cleaned, "198.51.100.1") != 2 || strings.Count(cleaned, "flags interval,timeout") != 4 {
+		t.Fatalf("persistent policy or runtime definitions were lost: %s", cleaned)
+	}
+	if again, err := nftRollbackWithoutRuntimeElements(cleaned); err != nil || again != cleaned {
+		t.Fatalf("recovery cannot safely reuse the journal: %q, %v", again, err)
+	}
+	for _, malformed := range []string{
+		strings.Replace(snapshot, "\tset banned_ips {", "\tset renamed {", 1),
+		strings.Replace(snapshot, "\t\telements = { 192.0.2.44", "\t\telements={ 192.0.2.44", 1),
+		strings.Replace(snapshot, "192.0.2.44 timeout", "{ 192.0.2.44 timeout", 1),
+	} {
+		if _, err := nftRollbackWithoutRuntimeElements(malformed); err == nil {
+			t.Fatal("ambiguous rollback snapshot was accepted")
+		}
+	}
+}
+
+func TestNFTRetainedFinalSecondMayExpireWithoutBecomingPermanent(t *testing.T) {
+	now := time.Now()
+	expected := newNFTDynamicSnapshot(now)
+	key := nftDynamicBanSets[0]
+	ban, err := parseNFTDynamicBan(json.RawMessage(`{"elem":{"val":"192.0.2.44","timeout":60,"expires":0}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected.sets[key][dynamicBanIdentity(ban)] = ban
+	observed := newNFTDynamicSnapshot(now.Add(time.Millisecond))
+	if err := compareNFTDynamicSnapshots(expected, observed, now.Add(2*time.Millisecond)); err != nil {
+		t.Fatalf("legitimate final-second expiry was rejected: %v", err)
+	}
+	ban.timeout, ban.expires = 0, 0
+	observed.sets[key][dynamicBanIdentity(ban)] = ban
+	if err := compareNFTDynamicSnapshots(expected, observed, now.Add(2*time.Millisecond)); err == nil {
+		t.Fatal("timed claim could become permanent during reload")
+	}
+}

--- a/src/core/syswarden-cli/pkg/firewall/nft_transaction_linux.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_transaction_linux.go
@@ -530,10 +530,11 @@ type nftDynamicBan struct {
 }
 
 type nftDynamicSnapshot struct {
-	capturedAt time.Time
-	sets       map[nftObjectKey]map[string]nftDynamicBan
-	discarded  map[nftObjectKey]map[string]nftDynamicBan
-	present    map[nftObjectKey]bool
+	capturedAt   time.Time
+	sets         map[nftObjectKey]map[string]nftDynamicBan
+	discarded    map[nftObjectKey]map[string]nftDynamicBan
+	present      map[nftObjectKey]bool
+	preservation string
 }
 
 type nftDynamicBanRemoval struct {
@@ -917,7 +918,15 @@ func snapshotNFTDynamicBans(ctx context.Context, runner nftCommandRunner, captur
 	if err != nil {
 		return nftDynamicSnapshot{}, fmt.Errorf("decode dynamic nftables bans: %w", err)
 	}
-	return extractNFTDynamicSnapshot(document, capturedAt)
+	snapshot, err := extractNFTDynamicSnapshot(document, capturedAt)
+	if err != nil {
+		return nftDynamicSnapshot{}, err
+	}
+	snapshot.preservation, err = nftRuntimePreservationRules(output, snapshot)
+	if err != nil {
+		return nftDynamicSnapshot{}, err
+	}
+	return snapshot, nil
 }
 
 // QuarantineLegacyDynamicBanIntervals removes only volatile address-family
@@ -1603,12 +1612,30 @@ func applyNftablesTransactionLocked(ctx context.Context, runner nftCommandRunner
 	if err != nil {
 		return fail("prepare preserved dynamic bans: %v", err)
 	}
+	preserveRuntime := dynamicSnapshot.preservation != "" && len(dynamicBanRemovals) == 0
+	if !preserveRuntime {
+		dynamicSnapshot.preservation = ""
+	}
+	if preserveRuntime {
+		rollbackRules, err = nftRollbackWithoutRuntimeElements(rollbackRules)
+		if err != nil {
+			return fail("prepare rollback without resetting runtime expiry: %v", err)
+		}
+		dynamicRules = ""
+		expectedDynamicBans = dynamicSnapshot
+	}
 
 	var transaction strings.Builder
 	for _, target := range syswardenNFTTables {
+		if preserveRuntime && isNFTRuntimeTable(target) {
+			continue
+		}
 		if existing[target] {
 			_, _ = fmt.Fprintf(&transaction, "delete table %s %s\n", target.family, target.name)
 		}
+	}
+	if preserveRuntime {
+		transaction.WriteString(dynamicSnapshot.preservation)
 	}
 	transaction.WriteString(persistentRules)
 	transaction.WriteString(dynamicRules)
@@ -1658,12 +1685,11 @@ func applyNftablesTransactionLocked(ctx context.Context, runner nftCommandRunner
 			fmt.Errorf("%w: %s", applyErr, strings.TrimSpace(string(output))),
 		)
 	}
-	// The expiry values in expectedDynamicBans are the exact relative values
-	// submitted to the successful atomic apply. Start their verification clock
-	// when that apply completes. Anchoring them before the potentially expensive
-	// `nft -c` validation incorrectly treats validation time as elapsed kernel
-	// lifetime and can reject an otherwise exact restored element.
-	expectedDynamicBans.capturedAt = time.Now()
+	// Recreated sets receive relative lifetimes at the atomic apply. Retained
+	// sets keep their original clock, including time spent validating policy.
+	if !preserveRuntime {
+		expectedDynamicBans.capturedAt = time.Now()
+	}
 	if err := updateNFTTransactionJournal(stateDirectory, journal, nftTransactionApplied); err != nil {
 		rollbackErr := rollbackJournaledNftables(runner, stateDirectory, journal, dynamicSnapshot)
 		if rollbackErr != nil {
@@ -2035,18 +2061,39 @@ func rollbackNftables(runner nftCommandRunner, snapshot string, dynamicSnapshot 
 	if err != nil {
 		return fmt.Errorf("inspect tables before rollback: %w", err)
 	}
+	preservation := ""
+	if dynamicSnapshot.preservation != "" && previousSets == (nftDynamicSetPresence{true, true, true, true}) {
+		current, err := snapshotNFTDynamicBans(ctx, runner, time.Now())
+		if err != nil {
+			return fmt.Errorf("inspect retained runtime before rollback: %w", err)
+		}
+		if current.preservation == "" {
+			return fmt.Errorf("runtime set identity changed before policy rollback")
+		}
+		snapshot, err = nftRollbackWithoutRuntimeElements(snapshot)
+		if err != nil {
+			return err
+		}
+		preservation = current.preservation
+	}
 	var rollback strings.Builder
 	for _, target := range syswardenNFTTables {
+		if preservation != "" && isNFTRuntimeTable(target) {
+			continue
+		}
 		if existing[target] {
 			_, _ = fmt.Fprintf(&rollback, "delete table %s %s\n", target.family, target.name)
 		}
 	}
+	rollback.WriteString(preservation)
 	rollback.WriteString(snapshot)
-	dynamicRules, err := buildNFTDynamicBanRollbackRules(dynamicSnapshot, time.Now(), previousSets)
-	if err != nil {
-		return fmt.Errorf("prepare rollback dynamic bans: %w", err)
+	if preservation == "" {
+		dynamicRules, err := buildNFTDynamicBanRollbackRules(dynamicSnapshot, time.Now(), previousSets)
+		if err != nil {
+			return fmt.Errorf("prepare rollback dynamic bans: %w", err)
+		}
+		rollback.WriteString(dynamicRules)
 	}
-	rollback.WriteString(dynamicRules)
 	pathDirectory, err := os.MkdirTemp("", "syswarden-firewall-rollback-")
 	if err != nil {
 		return err
@@ -2624,7 +2671,7 @@ func compareNFTDynamicSnapshots(expected, observed nftDynamicSnapshot, observedA
 	for _, key := range nftDynamicBanSets {
 		activeExpected := make(map[string]nftDynamicBan, len(expected.sets[key]))
 		for identity, ban := range expected.sets[key] {
-			if ban.expires > 0 {
+			if ban.timeout > 0 {
 				// A timed element that was already beyond the libnftables
 				// rounding tolerance before observation began must be absent.
 				if ban.expires <= elapsedAtStart && elapsedAtStart-ban.expires > expiryTolerance {
@@ -2637,7 +2684,7 @@ func compareNFTDynamicSnapshots(expected, observed nftDynamicSnapshot, observedA
 		for identity, wanted := range activeExpected {
 			found, exists := actual[identity]
 			if !exists {
-				if wanted.expires > 0 &&
+				if wanted.timeout > 0 &&
 					(wanted.expires <= elapsedAtFinish || wanted.expires-elapsedAtFinish <= expiryTolerance) {
 					// The element could legitimately have expired while nft was
 					// serializing the ruleset captured by this observation window.

--- a/src/core/syswarden-core/firewall/runtime_snapshot_linux.go
+++ b/src/core/syswarden-core/firewall/runtime_snapshot_linux.go
@@ -116,47 +116,64 @@ func (m *NftablesManager) nativeRuntimeSnapshotsLocked(entries []firewallEntry, 
 	}
 	result := make([]NativeRuntimeEntrySnapshot, 0, len(entries))
 	for _, entry := range entries {
-		var snapshot NativeRuntimeEntrySnapshot
-		var earliestExpiry time.Time
-		for index, layer := range m.layersForKeyLocked(entry.key) {
-			observation := observations[layer.name]
-			if !requireTrackedInventory && nativeTargetInsideDifferentInterval(observation.elements, entry.key) {
-				return nil, fmt.Errorf("native %s target %s is inside another retained interval", layer.name, entry.text)
-			}
-			element, present, open, err := indexedNativeElementState(observation.elements, entry)
-			if err != nil || open {
-				return nil, fmt.Errorf("native %s entry %s is ambiguous: %v", layer.name, entry.text, err)
-			}
-			permanent := present && element.Timeout == 0 && element.Expires == 0
-			var expiry time.Time
-			if present && !permanent {
-				if element.Timeout <= 0 || element.Expires <= 0 || element.Expires > element.Timeout+time.Second {
-					return nil, fmt.Errorf("native %s lifetime evidence is invalid", layer.name)
-				}
-				expiry = observation.endedAt.Add(element.Expires)
-				lowerBound := observation.startedAt.Add(element.Expires)
-				if earliestExpiry.IsZero() || lowerBound.Before(earliestExpiry) {
-					earliestExpiry = lowerBound
-				}
-			}
-			if index == 0 {
-				snapshot = NativeRuntimeEntrySnapshot{Entry: entry.text, Present: present, Permanent: permanent, ExpiresAt: expiry}
-			} else if snapshot.Present != present || snapshot.Permanent != permanent {
-				return nil, fmt.Errorf("native runtime layers disagree for %s", entry.text)
-			}
-			if expiry.After(snapshot.ExpiresAt) {
-				snapshot.ExpiresAt = expiry
-			}
-			if observation.endedAt.After(snapshot.CapturedAt) {
-				snapshot.CapturedAt = observation.endedAt
-			}
-		}
-		if !snapshot.ExpiresAt.IsZero() && (snapshot.ExpiresAt.Sub(earliestExpiry) > 2*time.Second || !earliestExpiry.After(snapshot.CapturedAt)) {
-			return nil, fmt.Errorf("native runtime expiry is divergent or elapsed during capture for %s", entry.text)
+		snapshot, err := nativeRuntimeEntrySnapshot(entry, m.layersForKeyLocked(entry.key), observations, requireTrackedInventory)
+		if err != nil {
+			return nil, err
 		}
 		result = append(result, snapshot)
 	}
 	return result, nil
+}
+
+func nativeRuntimeEntrySnapshot(entry firewallEntry, layers []nftablesLayer, observations map[string]nativeLayerObservation, requireTrackedInventory bool) (NativeRuntimeEntrySnapshot, error) {
+	var snapshot NativeRuntimeEntrySnapshot
+	var earliestExpiry, earliestUpperBound, latestLowerBound time.Time
+	for index, layer := range layers {
+		observation := observations[layer.name]
+		if !requireTrackedInventory && nativeTargetInsideDifferentInterval(observation.elements, entry.key) {
+			return NativeRuntimeEntrySnapshot{}, fmt.Errorf("native %s target %s is inside another retained interval", layer.name, entry.text)
+		}
+		element, present, open, err := indexedNativeElementState(observation.elements, entry)
+		if err != nil || open {
+			return NativeRuntimeEntrySnapshot{}, fmt.Errorf("native %s entry %s is ambiguous: %v", layer.name, entry.text, err)
+		}
+		permanent := present && element.Timeout == 0 && element.Expires == 0
+		var expiry time.Time
+		if present && !permanent {
+			if element.Timeout <= 0 || element.Expires <= 0 || element.Expires > element.Timeout+time.Second {
+				return NativeRuntimeEntrySnapshot{}, fmt.Errorf("native %s lifetime evidence is invalid", layer.name)
+			}
+			// Netlink encodes the remaining lifetime in whole milliseconds.
+			// Keep the read window and that wire precision separate from
+			// a real difference between the two enforcement deadlines.
+			expiry = observation.endedAt.Add(element.Expires + time.Millisecond)
+			lowerBound := observation.startedAt.Add(element.Expires)
+			if earliestExpiry.IsZero() || lowerBound.Before(earliestExpiry) {
+				earliestExpiry = lowerBound
+			}
+			if earliestUpperBound.IsZero() || expiry.Before(earliestUpperBound) {
+				earliestUpperBound = expiry
+			}
+			if lowerBound.After(latestLowerBound) {
+				latestLowerBound = lowerBound
+			}
+		}
+		if index == 0 {
+			snapshot = NativeRuntimeEntrySnapshot{Entry: entry.text, Present: present, Permanent: permanent, ExpiresAt: expiry}
+		} else if snapshot.Present != present || snapshot.Permanent != permanent {
+			return NativeRuntimeEntrySnapshot{}, fmt.Errorf("native runtime layers disagree for %s", entry.text)
+		}
+		if expiry.After(snapshot.ExpiresAt) {
+			snapshot.ExpiresAt = expiry
+		}
+		if observation.endedAt.After(snapshot.CapturedAt) {
+			snapshot.CapturedAt = observation.endedAt
+		}
+	}
+	if !snapshot.ExpiresAt.IsZero() && (latestLowerBound.Sub(earliestUpperBound) > 2*time.Second || !earliestExpiry.After(snapshot.CapturedAt)) {
+		return NativeRuntimeEntrySnapshot{}, fmt.Errorf("native runtime expiry is divergent or elapsed during capture for %s", entry.text)
+	}
+	return snapshot, nil
 }
 
 func nativeTargetInsideDifferentInterval(elements []nftables.SetElement, key []byte) bool {

--- a/src/core/syswarden-core/firewall/runtime_snapshot_linux_test.go
+++ b/src/core/syswarden-core/firewall/runtime_snapshot_linux_test.go
@@ -193,3 +193,99 @@ func TestNativeMutationRefusesPointInsideUntrackedPrefixBeforePreparation(t *tes
 		t.Fatal("covered native point received an absence witness or prepared a deletion")
 	}
 }
+
+func TestNativeRuntimeExpiryUsesCaptureIntervals(t *testing.T) {
+	base := time.Date(2026, 9, 12, 5, 22, 56, 0, time.UTC)
+	for _, test := range []struct {
+		name          string
+		inetStart     time.Duration
+		inetEnd       time.Duration
+		netdevStart   time.Duration
+		netdevEnd     time.Duration
+		inetExpires   time.Duration
+		netdevExpires time.Duration
+		wantError     bool
+	}{
+		{
+			name:      "native boundary with millisecond wire precision",
+			inetStart: 920378592, inetEnd: 920461872,
+			netdevStart: 920629481, netdevEnd: 920694681,
+			inetExpires: 2565377506 * time.Millisecond, netdevExpires: 2565379506 * time.Millisecond,
+		},
+		{
+			name:        "equal deadlines observed across a slow read",
+			inetEnd:     900 * time.Millisecond,
+			netdevStart: time.Second, netdevEnd: 1900 * time.Millisecond,
+			inetExpires: time.Minute, netdevExpires: 59 * time.Second,
+		},
+		{
+			name:        "boundary plus bounded read latency",
+			inetEnd:     400 * time.Millisecond,
+			netdevStart: 500 * time.Millisecond, netdevEnd: 900 * time.Millisecond,
+			inetExpires: time.Minute, netdevExpires: 61900 * time.Millisecond,
+		},
+		{
+			name:        "divergence beyond both capture intervals",
+			inetEnd:     100 * time.Microsecond,
+			netdevStart: 200 * time.Microsecond, netdevEnd: 300 * time.Microsecond,
+			inetExpires: time.Minute, netdevExpires: 62002 * time.Millisecond,
+			wantError: true,
+		},
+		{
+			name:        "reverse divergence beyond both capture intervals",
+			inetEnd:     100 * time.Microsecond,
+			netdevStart: 200 * time.Microsecond, netdevEnd: 300 * time.Microsecond,
+			inetExpires: 62002 * time.Millisecond, netdevExpires: time.Minute,
+			wantError: true,
+		},
+		{
+			name:        "first layer expires during second capture",
+			inetEnd:     100 * time.Microsecond,
+			netdevStart: 500 * time.Microsecond, netdevEnd: 2 * time.Millisecond,
+			inetExpires: time.Millisecond, netdevExpires: time.Millisecond,
+			wantError: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, value := range []string{"192.0.2.44", "2001:db8::44"} {
+				entry, err := parseFirewallEntry(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				observations := make(map[string]nativeLayerObservation)
+				for _, layer := range []struct {
+					name       string
+					start, end time.Duration
+					expires    time.Duration
+				}{
+					{"inet", test.inetStart, test.inetEnd, test.inetExpires},
+					{"netdev", test.netdevStart, test.netdevEnd, test.netdevExpires},
+				} {
+					elements := nftablesIntervalElements(entry, MaximumBanTTL)
+					elements[0].Expires = layer.expires
+					observations[layer.name] = nativeLayerObservation{
+						elements: elements, startedAt: base.Add(layer.start), endedAt: base.Add(layer.end),
+					}
+				}
+				got, err := nativeRuntimeEntrySnapshot(entry, []nftablesLayer{{name: "inet"}, {name: "netdev"}}, observations, true)
+				if (err != nil) != test.wantError {
+					t.Fatalf("%s: snapshot %+v, error %v, want error %t", value, got, err, test.wantError)
+				}
+				if test.wantError {
+					continue
+				}
+				if got.Entry != value || !got.Present || got.Permanent || !got.CapturedAt.Equal(base.Add(test.netdevEnd)) {
+					t.Fatalf("invalid native identity or observation: %+v", got)
+				}
+				// The exposed deadline must cover each layer's upper bound.
+				// A shorter witness could expire a still-enforced claim early.
+				for _, observation := range observations {
+					upper := observation.endedAt.Add(observation.elements[0].Expires + time.Millisecond)
+					if got.ExpiresAt.Before(upper) {
+						t.Fatalf("native witness shortened enforcement: %+v, layer %+v", got, observation)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scheduled feed and policy reloads recreated timed native sets, restarting their relative expiry clocks. Repeated reloads could move the two enforcement deadlines apart and prevent the core from restoring retained GRC claims.

This change keeps compatible IPv4 and IPv6 runtime sets in the kernel while replacing the surrounding policy. Rollback and durable recovery omit historical runtime elements so an expired entry cannot be resurrected. Snapshot comparison accounts for the netlink observation window while continuing to reject real expiry divergence. Legacy layout conversion retains its existing path.

Validation:
- Full CLI and core tests, targeted race tests and vet passed.
- Lint, gosec, nosec baseline, documentation contract and secret scan passed.
- A real nftables regression in an isolated network namespace covers delayed validation, repeated reloads, rollback and recovery after an interrupted rollback. The baseline fails and the corrected implementation passes.
- Version validation preserves v4.10.0 and the changelog byte-for-byte.

This fixes a qualification blocker. Full native release qualification remains incomplete; this PR does not authorize publication or relax any release gate.
