### PR TITLE
Fix : preserve the owned operator chain during native reload

### DIFF
--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_integration_linux_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_integration_linux_test.go
@@ -69,7 +69,8 @@ func TestNativeReloadPreservesRuntimeExpiryThroughValidationAndRollback(t *testi
  set fixture_set { type ipv4_addr; }
  set banned_ips { type ipv4_addr; flags interval,timeout; }
  set banned_ips6 { type ipv6_addr; flags interval,timeout; }
- chain input { type filter hook input priority 0; policy accept; ip saddr @banned_ips drop; ip6 saddr @banned_ips6 drop; }
+ chain operator-policy { return; }
+ chain input { type filter hook input priority 0; policy accept; jump operator-policy; ip saddr @banned_ips drop; ip6 saddr @banned_ips6 drop; }
 }
 table netdev syswarden_hw_drop {
  set banned_ips { type ipv4_addr; flags interval,timeout; }

--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux.go
@@ -52,7 +52,9 @@ func nftRuntimePreservationRules(wire []byte, snapshot nftDynamicSnapshot) (stri
 			if kind == "rule" || kind == "element" {
 				continue
 			}
-			if !nftSetNameRE.MatchString(object.Name) {
+			ownedOperatorChain := kind == "chain" && target == (nftTableTarget{family: "inet", name: "syswarden"}) &&
+				object.Name == operatorPolicyChainName
+			if !nftSetNameRE.MatchString(object.Name) && !ownedOperatorChain {
 				return "", fmt.Errorf("runtime preservation object has an unsupported name")
 			}
 			key := nftObjectKey{family: target.family, table: target.name, name: object.Name}

--- a/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/nft_runtime_preservation_linux_test.go
@@ -72,6 +72,52 @@ func TestNFTReloadKeepsLiveRuntimeSetsInTheKernel(t *testing.T) {
 	}
 }
 
+func TestNFTRuntimePreservationAcceptsOwnedOperatorPolicyChain(t *testing.T) {
+	wire, snapshot := runtimePreservationFixture(t)
+	var document map[string][]json.RawMessage
+	if err := json.Unmarshal(wire, &document); err != nil {
+		t.Fatal(err)
+	}
+	chain, err := json.Marshal(map[string]any{"chain": map[string]any{
+		"family": "inet", "table": "syswarden", "name": operatorPolicyChainName,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	document["nftables"] = append(document["nftables"], chain)
+	wire, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules, err := nftRuntimePreservationRules(wire, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "delete chain inet syswarden " + operatorPolicyChainName + "\n"
+	if strings.Count(rules, want) != 1 || strings.Contains(rules, "banned_ips") {
+		t.Fatalf("owned operator chain was not safely replaced: %s", rules)
+	}
+	for _, replacement := range [][2]string{
+		{`"chain":`, `"set":`},
+		{`"inet"`, `"netdev"`},
+		{`"operator-policy"`, `"operator-policy-other"`},
+		{`"operator-policy"`, `"operator-policy; flush ruleset"`},
+	} {
+		changed := strings.Replace(string(chain), replacement[0], replacement[1], 1)
+		if replacement[1] == `"netdev"` {
+			changed = strings.Replace(changed, `"syswarden"`, `"syswarden_hw_drop"`, 1)
+		}
+		document["nftables"][len(document["nftables"])-1] = json.RawMessage(changed)
+		wire, err = json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rules, err := nftRuntimePreservationRules(wire, snapshot); err == nil || rules != "" {
+			t.Fatalf("operator chain exception accepted unsupported object %s: %q, %v", changed, rules, err)
+		}
+	}
+}
+
 func TestNFTRuntimePreservationRequiresCompatibleCompleteSets(t *testing.T) {
 	wire, snapshot := runtimePreservationFixture(t)
 	for _, replacement := range [][2]string{


### PR DESCRIPTION
A clean signed APK installation failed when OpenRC started the firewall service: runtime preservation rejected SysWarden's own `operator-policy` chain because its name contains a hyphen. The same rejection affects policy reloads with this generated chain.

Accept only that exact chain name in `inet syswarden`. Keep rejecting unsupported names, other object kinds and the same name in the netdev table. The regression tests include the referenced operator chain in the real nftables reload, expiry, rollback and interrupted recovery scenario.

Validation: the new unit test and isolated kernel test fail on the previous implementation and pass with this change. Full CLI tests, firewall race tests, vet, regular and integration lint, gosec, secret scanning, documentation checks and version inspection pass. The declared version remains v4.10.0. Signed native package qualification must be repeated after integration; the failed APK installation is retained as a failure.
