### PR TITLE
Fix : preserve canonical empty firewall lists

### DIFF
--- a/src/core/syswarden-cli/pkg/firewall/lists.go
+++ b/src/core/syswarden-cli/pkg/firewall/lists.go
@@ -847,6 +847,14 @@ func failWithTransactionalListRollback(cause error, mutations []transactionalLis
 	return errors.Join(cause, fmt.Errorf("restore persistent firewall lists after failure: %w", rollbackErr))
 }
 
+// Empty persistent lists must have zero bytes so strict readers can attest absence.
+func serializeListLines(lines []string) []byte {
+	if len(lines) == 0 {
+		return nil
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
+}
+
 func removeFromListFileAt(target approvedListFile, line string) error {
 	requested, err := parseCanonicalRecoveryListEntry(line, true)
 	if err != nil {
@@ -899,7 +907,7 @@ func removeFromListFileAt(target approvedListFile, line string) error {
 	if !changed {
 		return nil
 	}
-	return writeListFileInDirectoryFromSnapshot(directory, target, []byte(strings.Join(newLines, "\n")+"\n"), content)
+	return writeListFileInDirectoryFromSnapshot(directory, target, serializeListLines(newLines), content)
 }
 
 func sanitizeLegacyListFileAt(target approvedListFile) (bool, error) {
@@ -944,7 +952,7 @@ func sanitizeLegacyListFileAt(target approvedListFile) (bool, error) {
 	if !changed {
 		return false, nil
 	}
-	updated := []byte(strings.Join(newLines, "\n") + "\n")
+	updated := serializeListLines(newLines)
 	if err := writeListFileInDirectoryFromSnapshot(directory, target, updated, content); err != nil {
 		return false, err
 	}
@@ -1141,7 +1149,7 @@ func removeFromListFileTransactionally(target approvedListFile, line string) (tr
 		if !changed {
 			return content, false, nil
 		}
-		return []byte(strings.Join(newLines, "\n") + "\n"), true, nil
+		return serializeListLines(newLines), true, nil
 	})
 }
 
@@ -1171,7 +1179,7 @@ func sanitizeLegacyListFileTransactionally(target approvedListFile) (transaction
 		if !changed {
 			return content, false, nil
 		}
-		return []byte(strings.Join(newLines, "\n") + "\n"), true, nil
+		return serializeListLines(newLines), true, nil
 	})
 }
 
@@ -1608,7 +1616,7 @@ func removeListEntriesForIP(content []byte, ip string) ([]byte, bool, bool) {
 		}
 		newLines = append(newLines, cleanLine)
 	}
-	return []byte(strings.Join(newLines, "\n") + "\n"), found, changed
+	return serializeListLines(newLines), found, changed
 }
 
 func WhitelistInfra() error {

--- a/src/core/syswarden-cli/pkg/firewall/lists_empty_test.go
+++ b/src/core/syswarden-cli/pkg/firewall/lists_empty_test.go
@@ -1,0 +1,103 @@
+package firewall
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFinalListRemovalPersistsCanonicalEmptyFile_SW_GRC_017(t *testing.T) {
+	for _, address := range []string{"192.0.2.10", "2001:db8::10"} {
+		for _, operation := range []struct {
+			name string
+			run  func(approvedListFile, string) error
+		}{
+			{name: "exact removal", run: removeFromListFileAt},
+			{name: "IP removal", run: func(target approvedListFile, address string) error {
+				found, changed, err := removeIPFromListFileAt(target, address)
+				if err == nil && (!found || !changed) {
+					return fmt.Errorf("final address removal did not report the committed change")
+				}
+				return err
+			}},
+		} {
+			t.Run(operation.name+"/"+address, func(t *testing.T) {
+				target := approvedListFile{directory: t.TempDir(), name: "list"}
+				if err := writeListFileAt(target, []byte(address+"\n")); err != nil {
+					t.Fatal(err)
+				}
+				if err := operation.run(target, address); err != nil {
+					t.Fatal(err)
+				}
+				assertCanonicalEmptyListFile(t, target)
+				if err := addToListFileAt(target, address); err != nil {
+					t.Fatal(err)
+				}
+				content, err := readListFileAt(target)
+				if err != nil || string(content) != address+"\n" {
+					t.Fatalf("readding an address after emptying the list = %q, error=%v", content, err)
+				}
+			})
+		}
+	}
+}
+
+func TestEmptyListTransactionsPreserveRollback_SW_GRC_017(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		seed string
+		run  func(approvedListFile) (transactionalListMutation, error)
+	}{
+		{name: "remove final address", seed: "192.0.2.10\n", run: func(target approvedListFile) (transactionalListMutation, error) {
+			return removeFromListFileTransactionally(target, "192.0.2.10")
+		}},
+		{name: "sanitize final unsafe entry", seed: "0.0.0.0/0\n", run: sanitizeLegacyListFileTransactionally},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := approvedListFile{directory: t.TempDir(), name: "list"}
+			if err := writeListFileAt(target, []byte(test.seed)); err != nil {
+				t.Fatal(err)
+			}
+			mutation, err := test.run(target)
+			if err != nil || !mutation.changed {
+				t.Fatalf("list transaction = %#v, error=%v", mutation, err)
+			}
+			assertCanonicalEmptyListFile(t, target)
+			if err := rollbackTransactionalListMutation(mutation); err != nil {
+				t.Fatal(err)
+			}
+			content, err := readListFileAt(target)
+			if err != nil || string(content) != test.seed {
+				t.Fatalf("rollback did not restore the exact preimage: %q, error=%v", content, err)
+			}
+		})
+	}
+}
+
+func TestSanitizingFinalUnsafeEntryPersistsEmptyFile_SW_GRC_017(t *testing.T) {
+	target := approvedListFile{directory: t.TempDir(), name: "list"}
+	if err := writeListFileAt(target, []byte("0.0.0.0/0\n")); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := sanitizeLegacyListFileAt(target)
+	if err != nil || !changed {
+		t.Fatalf("sanitize final entry changed=%t, error=%v", changed, err)
+	}
+	assertCanonicalEmptyListFile(t, target)
+}
+
+func assertCanonicalEmptyListFile(t *testing.T, target approvedListFile) {
+	t.Helper()
+	content, err := readListFileAt(target)
+	if err != nil || len(content) != 0 {
+		t.Fatalf("last-entry removal must leave an existing zero-byte list for strict GRC reads: content=%q, error=%v", content, err)
+	}
+	info, err := os.Stat(filepath.Join(target.directory, target.name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0600 {
+		t.Fatalf("empty list metadata is not protected: mode=%v", info.Mode())
+	}
+}

--- a/src/core/syswarden-core/telemetry/persistent_enforcement_linux_test.go
+++ b/src/core/syswarden-core/telemetry/persistent_enforcement_linux_test.go
@@ -139,6 +139,9 @@ func TestPersistentEnforcementSnapshotRejectsUnsafeFilesAndContent_SW_GRC_018(t 
 		"empty line": func(t *testing.T, directory string) {
 			writePersistentEnforcementTestFile(t, directory, persistentEnforcementIPv4File, "192.0.2.1\n\n198.51.100.1\n")
 		},
+		"newline instead of an empty list": func(t *testing.T, directory string) {
+			writePersistentEnforcementTestFile(t, directory, persistentEnforcementIPv4File, "\n")
+		},
 		"surrounding whitespace": func(t *testing.T, directory string) {
 			writePersistentEnforcementTestFile(t, directory, persistentEnforcementIPv4File, " 192.0.2.1\n")
 		},


### PR DESCRIPTION
Removing the final blocked address wrote a newline-only persistent list. During native qualification, the strict GRC reader rejected that file and reported degraded evidence after the kernel block had been deleted and tombstoned.

Serialize an empty list as an existing zero-byte file in all five removal and sanitization paths. Keep the existing atomic writes, protected file metadata, exact transaction rollback and strict GRC reader. Nonempty lists retain their current serialization.

Validation:
- New IPv4 and IPv6 removal, re-addition, sanitization and rollback regressions fail before the correction and pass afterward.
- The full CLI test suite, firewall and telemetry race tests, and CLI vet pass.
- The strict reader accepts present zero-byte lists and still rejects a newline-only file.
- The version contract confirms that this non-versioning correction preserves v4.10.0.

The first full CLI test attempt hit the sandbox restriction on a local httptest TLS listener. The complete suite passed with loopback sockets enabled. Native requalification on newly signed candidate packages remains required before release.
